### PR TITLE
Add support for adding ClusterRoles and RoleBindings for Kyverno

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -46,6 +46,8 @@ parameters:
       - '[ClusterReportChangeRequest,*,*]'
       - '[PolicyReport,*,*]'
       - '[ClusterPolicyReport,*,*]'
+    additionalClusterRoles: {}
+    additionalRoleBindings: {}
     excludeGroupRole:
       - system:serviceaccounts:kube-system
       - system:nodes

--- a/class/kyverno.yml
+++ b/class/kyverno.yml
@@ -54,5 +54,6 @@ parameters:
       - input_paths:
           - kyverno/component/main.jsonnet
           - kyverno/component/kyverno.jsonnet
+          - kyverno/component/rolebindings.jsonnet
         input_type: jsonnet
         output_path: kyverno/

--- a/component/rolebindings.jsonnet
+++ b/component/rolebindings.jsonnet
@@ -1,0 +1,43 @@
+local kap = import 'lib/kapitan.libjsonnet';
+local kube = import 'lib/kube.libjsonnet';
+local inv = kap.inventory();
+// The hiera parameters for the component
+local params = inv.parameters.kyverno;
+
+local defaultLabels = {
+  'app.kubernetes.io/name': 'kyverno',
+  'app.kubernetes.io/component': 'kyverno',
+  'app.kubernetes.io/managed-by': 'commodore',
+};
+
+local additionalClusterRoles = [
+  kube.ClusterRole('kyverno-user:%s' % [ role ],) {
+    metadata+: {
+      labels+: defaultLabels,
+    },
+    rules: params.additionalClusterRoles[role],
+  }
+  for role in std.prune(std.objectFields(params.additionalClusterRoles))
+];
+
+local additionalRoleBindings = [
+  kube.RoleBinding('user:%s' % [ binding ],) {
+    metadata+: {
+      labels+: defaultLabels,
+    },
+    roleRef+: params.additionalRoleBindings[binding],
+    subjects: [
+      {
+        kind: 'ServiceAccount',
+        name: 'kyverno-service-account',
+        namespace: params.namespace,
+      },
+    ],
+  }
+  for binding in std.prune(std.objectFields(params.additionalRoleBindings))
+];
+
+{
+  '03_additional-clusterroles': additionalClusterRoles,
+  '04_additional-rolebindings': additionalRoleBindings,
+}

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -66,3 +66,56 @@ extraArgs:
 ----
 
 Allows passing extra arguments to Kyverno.
+
+== `additionalClusterRoles`
+
+[horizontal]
+type:: object
+default:: `{}`
+example::
++
+[source,yaml]
+----
+my-name:
+  - <1>
+    apiGroups:
+      - rbac.authorization.k8s.io
+    verbs:
+      - '*'
+    resources:
+      - rolebindings
+----
+<1> The spec of the `rules` property within `ClusterRole` is taken verbatim.
+
+Generates additional `ClusterRole`.
+This is useful if you want to deploy Kyverno policies that generate resources, but the Kyverno ServiceAccount might have insufficient RBAC permissions to do so.
+
+See also `additionalRoleBindings` to bind the Kyverno ServiceAccount to the new roles.
+
+NOTE: The `metadata.name` is prefixed with `kyverno-user:` to avoid name clashes with existing resources.
+
+
+== `additionalRoleBindings`
+
+[horizontal]
+type:: object
+default:: `{}`
+example::
++
+[source,yaml]
+----
+allowManageRoleBindings: <1>
+  kind: ClusterRole
+  name: kyverno-user:my-name <2>
+----
+<1> This is the `metadata.name` of the RoleBinding.
+<2> The name of the Role or ClusterRole to bind to.
+
+Generates additional `RoleBinding` s in the Kyverno namespace for the Kyverno SystemAccount.
+This is useful if you want to deploy Kyverno policies that generate resources, but the Kyverno ServiceAccount might have insufficient RBAC permissions to do so.
+
+See also `additionalClusterRoles` if the necessary `ClusterRole` doesn't exist.
+
+NOTE: The `metadata.name` is prefixed with `user:` to avoid name clashes with existing resources.
+
+TIP: If you need to reference a `ClusterRole` defined in `additionalClusterRoles`, you need to prefix the role name with `kyverno-user:` as shown in the example.

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -1,3 +1,19 @@
 # Overwrite parameters here
 
-# parameters: {...}
+parameters:
+  kyverno:
+    additionalClusterRoles:
+      my-name:
+        - apiGroups:
+            - rbac.authorization.k8s.io
+          verbs:
+            - '*'
+          resources:
+            - rolebindings
+    additionalRoleBindings:
+      allowManageRoleBindings:
+        kind: ClusterRole
+        name: kyverno-user-my-name
+      cluster-admin:
+        kind: ClusterRole
+        name: cluster-admin

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -13,7 +13,7 @@ parameters:
     additionalRoleBindings:
       allowManageRoleBindings:
         kind: ClusterRole
-        name: kyverno-user-my-name
-      cluster-admin:
+        name: kyverno-user:my-name
+      admin:
         kind: ClusterRole
-        name: cluster-admin
+        name: admin

--- a/tests/golden/defaults/kyverno/kyverno/03_additional-clusterroles.yaml
+++ b/tests/golden/defaults/kyverno/kyverno/03_additional-clusterroles.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: kyverno
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: kyverno
+    name: kyverno-user-my-name
+  name: kyverno-user:my-name
+rules:
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - rolebindings
+    verbs:
+      - '*'

--- a/tests/golden/defaults/kyverno/kyverno/04_additional-rolebindings.yaml
+++ b/tests/golden/defaults/kyverno/kyverno/04_additional-rolebindings.yaml
@@ -6,12 +6,12 @@ metadata:
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    name: user-allowManageRoleBindings
-  name: user:allowManageRoleBindings
+    name: user-admin
+  name: user:admin
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kyverno-user-my-name
+  name: admin
 subjects:
   - kind: ServiceAccount
     name: kyverno-service-account
@@ -25,12 +25,12 @@ metadata:
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    name: user-cluster-admin
-  name: user:cluster-admin
+    name: user-allowManageRoleBindings
+  name: user:allowManageRoleBindings
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cluster-admin
+  name: kyverno-user:my-name
 subjects:
   - kind: ServiceAccount
     name: kyverno-service-account

--- a/tests/golden/defaults/kyverno/kyverno/04_additional-rolebindings.yaml
+++ b/tests/golden/defaults/kyverno/kyverno/04_additional-rolebindings.yaml
@@ -1,0 +1,37 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: kyverno
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: kyverno
+    name: user-allowManageRoleBindings
+  name: user:allowManageRoleBindings
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kyverno-user-my-name
+subjects:
+  - kind: ServiceAccount
+    name: kyverno-service-account
+    namespace: syn-kyverno
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: kyverno
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: kyverno
+    name: user-cluster-admin
+  name: user:cluster-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: kyverno-service-account
+    namespace: syn-kyverno


### PR DESCRIPTION
* Adds `additionalClusterRoles` key that result in ClusterRole resources
* Adds `additionalRoleBindings` key that bind the Kyverno ServiceAccount to additional Roles

When deploying Kyverno policy rules that generate resources, Kyverno might not have enough RBAC permissions to actually create them, resulting in errors in the logs.
With these 2 keys we can
* Bind Kyverno to existing ClusterRoles (e.g. admin)
* Create (and bind to) new ClusterRoles if there is not an appropriate Role for the policy.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
