### PR TITLE
Fix RoleBinding to be ClusterRolebindings

### DIFF
--- a/component/rolebindings.jsonnet
+++ b/component/rolebindings.jsonnet
@@ -11,7 +11,7 @@ local defaultLabels = {
 };
 
 local additionalClusterRoles = [
-  kube.ClusterRole('kyverno-user:%s' % [ role ],) {
+  kube.ClusterRole('kyverno:user:%s' % [ role ],) {
     metadata+: {
       labels+: defaultLabels,
     },

--- a/component/rolebindings.jsonnet
+++ b/component/rolebindings.jsonnet
@@ -21,7 +21,7 @@ local additionalClusterRoles = [
 ];
 
 local additionalRoleBindings = [
-  kube.RoleBinding('user:%s' % [ binding ],) {
+  kube.ClusterRoleBinding('kyverno:user:%s' % [ binding ],) {
     metadata+: {
       labels+: defaultLabels,
     },

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -111,11 +111,11 @@ allowManageRoleBindings: <1>
 <1> This is the `metadata.name` of the RoleBinding.
 <2> The name of the Role or ClusterRole to bind to.
 
-Generates additional `RoleBinding` s in the Kyverno namespace for the Kyverno SystemAccount.
-This is useful if you want to deploy Kyverno policies that generate resources, but the Kyverno ServiceAccount might have insufficient RBAC permissions to do so.
+Generates additional `ClusterRoleBinding` s in the Kyverno namespace for the Kyverno SystemAccount.
+This is useful if you want to deploy Kyverno policies that generate resources in other namespaces, but the Kyverno ServiceAccount might have insufficient RBAC permissions to do so.
 
 See also `additionalClusterRoles` if the necessary `ClusterRole` doesn't exist.
 
-NOTE: The `metadata.name` is prefixed with `user:` to avoid name clashes with existing resources.
+NOTE: The `metadata.name` is prefixed with `kyverno:user:` to avoid name clashes with existing resources.
 
 TIP: If you need to reference a `ClusterRole` defined in `additionalClusterRoles`, you need to prefix the role name with `kyverno:user:` as shown in the example.

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -92,7 +92,7 @@ This is useful if you want to deploy Kyverno policies that generate resources, b
 
 See also `additionalRoleBindings` to bind the Kyverno ServiceAccount to the new roles.
 
-NOTE: The `metadata.name` is prefixed with `kyverno-user:` to avoid name clashes with existing resources.
+NOTE: The `metadata.name` is prefixed with `kyverno:user:` to avoid name clashes with existing resources.
 
 
 == `additionalRoleBindings`
@@ -106,7 +106,7 @@ example::
 ----
 allowManageRoleBindings: <1>
   kind: ClusterRole
-  name: kyverno-user:my-name <2>
+  name: kyverno:user:my-name <2>
 ----
 <1> This is the `metadata.name` of the RoleBinding.
 <2> The name of the Role or ClusterRole to bind to.
@@ -118,4 +118,4 @@ See also `additionalClusterRoles` if the necessary `ClusterRole` doesn't exist.
 
 NOTE: The `metadata.name` is prefixed with `user:` to avoid name clashes with existing resources.
 
-TIP: If you need to reference a `ClusterRole` defined in `additionalClusterRoles`, you need to prefix the role name with `kyverno-user:` as shown in the example.
+TIP: If you need to reference a `ClusterRole` defined in `additionalClusterRoles`, you need to prefix the role name with `kyverno:user:` as shown in the example.

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -13,7 +13,7 @@ parameters:
     additionalRoleBindings:
       allowManageRoleBindings:
         kind: ClusterRole
-        name: kyverno-user:my-name
+        name: kyverno:user:my-name
       admin:
         kind: ClusterRole
         name: admin

--- a/tests/golden/defaults/kyverno/kyverno/03_additional-clusterroles.yaml
+++ b/tests/golden/defaults/kyverno/kyverno/03_additional-clusterroles.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
     name: kyverno-user-my-name
-  name: kyverno-user:my-name
+  name: kyverno:user:my-name
 rules:
   - apiGroups:
       - rbac.authorization.k8s.io

--- a/tests/golden/defaults/kyverno/kyverno/04_additional-rolebindings.yaml
+++ b/tests/golden/defaults/kyverno/kyverno/04_additional-rolebindings.yaml
@@ -1,13 +1,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   annotations: {}
   labels:
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    name: user-admin
-  name: user:admin
+    name: kyverno-user-admin
+  name: kyverno:user:admin
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -18,19 +18,19 @@ subjects:
     namespace: syn-kyverno
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   annotations: {}
   labels:
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    name: user-allowManageRoleBindings
-  name: user:allowManageRoleBindings
+    name: kyverno-user-allowManageRoleBindings
+  name: kyverno:user:allowManageRoleBindings
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kyverno-user:my-name
+  name: kyverno:user:my-name
 subjects:
   - kind: ServiceAccount
     name: kyverno-service-account


### PR DESCRIPTION
Design oversight from #18 : A RoleBinding in the Kyverno namespace does not grant the permissions to generate resources in other namespaces...


Labelled `bug` since the last release of v1.1.0 was just minutes ago even though it can be considered breaking .

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
