### PR TITLE
Fetch and deploy upstream roles and rolebindings

### DIFF
--- a/class/kyverno.yml
+++ b/class/kyverno.yml
@@ -37,6 +37,12 @@ parameters:
         source: ${kyverno:manifest_url}/k8s-resource/clusterrolebindings.yaml
         output_path: dependencies/kyverno/manifests/kyverno/${kyverno:manifest_version}/clusterrolebindings.yaml
       - type: https
+        source: ${kyverno:manifest_url}/k8s-resource/roles.yaml
+        output_path: dependencies/kyverno/manifests/kyverno/${kyverno:manifest_version}/roles.yaml
+      - type: https
+        source: ${kyverno:manifest_url}/k8s-resource/rolebindings.yaml
+        output_path: dependencies/kyverno/manifests/kyverno/${kyverno:manifest_version}/rolebindings.yaml
+      - type: https
         source: ${kyverno:manifest_url}/k8s-resource/serviceaccount.yaml
         output_path: dependencies/kyverno/manifests/kyverno/${kyverno:manifest_version}/serviceaccount.yaml
       - type: https

--- a/tests/golden/defaults/kyverno/kyverno/02_role-kyverno-leaderelection.yaml
+++ b/tests/golden/defaults/kyverno/kyverno/02_role-kyverno-leaderelection.yaml
@@ -1,0 +1,31 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: kyverno
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: syn
+  name: kyverno:leaderelection
+  namespace: syn-kyverno
+rules:
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - delete
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch

--- a/tests/golden/defaults/kyverno/kyverno/02_rolebinding-kyverno-leaderelection.yaml
+++ b/tests/golden/defaults/kyverno/kyverno/02_rolebinding-kyverno-leaderelection.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: kyverno
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: syn
+  name: kyverno:leaderelection
+  namespace: syn-kyverno
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kyverno:leaderelection
+subjects:
+  - kind: ServiceAccount
+    name: kyverno-service-account
+    namespace: syn-kyverno


### PR DESCRIPTION
Without the missing role and rolebinding, Kyverno can't start unless some custom configuration (e.g. granting Kyverno `cluster-admin`) gives Kyverno the permission to create `leases.coordination.k8s.io` in its namespace.




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
