### PR TITLE
Add option to define ClusterPolicies via inventory

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,17 +1,17 @@
 {
   "template": "https://github.com/projectsyn/commodore-component-template.git",
-  "commit": "a700b9ffffa95d9a9f2ab7e9101d4fe8887a0343",
+  "commit": "32f6976d3a3028d3fdb34ea312454f2ea7fda4a2",
   "checkout": "main",
   "context": {
     "cookiecutter": {
       "name": "kyverno",
       "slug": "kyverno",
       "parameter_key": "kyverno",
-      "test_cases": "defaults",
+      "test_cases": "defaults policies",
       "add_lib": "y",
       "add_pp": "n",
       "add_golden": "y",
-      "add_matrix": "n",
+      "add_matrix": "y",
       "add_go_unit": "y",
       "copyright_holder": "VSHN AG <info@vshn.ch>",
       "copyright_year": "2021",

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,6 +29,11 @@ jobs:
           args: 'check'
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        instance:
+          - defaults
+          - policies
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}
@@ -48,9 +53,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - name: Compile component
-        run: make test
+        run: make test -e instance=${{ matrix.instance }}
   golden:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        instance:
+          - defaults
+          - policies
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}
@@ -59,4 +69,4 @@ jobs:
         with:
           path: ${{ env.COMPONENT_NAME }}
       - name: Golden diff
-        run: make golden-diff
+        run: make golden-diff -e instance=${{ matrix.instance }}

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,22 @@ golden-diff: commodore_args += -f tests/$(instance).yml
 golden-diff: clean .compile ## Diff compile output against the reference version. Review output and run `make gen-golden golden-diff` if this target fails.
 	@git diff --exit-code --minimal --no-index -- tests/golden/$(instance) compiled/
 
+.PHONY: golden-diff-all
+golden-diff-all: recursive_target=golden-diff
+golden-diff-all: $(test_instances) ## Run golden-diff for all instances. Note: this doesn't work when running make with multiple parallel jobs (-j != 1).
+
+.PHONY: gen-golden-all
+gen-golden-all: recursive_target=gen-golden
+gen-golden-all: $(test_instances) ## Run gen-golden for all instances. Note: this doesn't work when running make with multiple parallel jobs (-j != 1).
+
+.PHONY: lint_kubent_all
+lint_kubent_all: recursive_target=lint_kubent
+lint_kubent_all: $(test_instances) ## Lint deprecated Kubernetes API versions for all golden test instances. Will exit on first error. Note: this doesn't work when running make with multiple parallel jobs (-j != 1).
+
+.PHONY: $(test_instances)
+$(test_instances):
+	$(MAKE) $(recursive_target) -e instance=$(basename $(@F))
+
 .PHONY: clean
 clean: ## Clean the project
 	rm -rf .cache compiled dependencies vendor helmcharts jsonnetfile*.json || true

--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -58,3 +58,4 @@ KUBENT_IMAGE    ?= docker.io/projectsyn/kubent:latest
 KUBENT_DOCKER   ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) --entrypoint=/app/kubent $(KUBENT_IMAGE)
 
 instance ?= defaults
+test_instances = tests/defaults.yml tests/policies.yml

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -18,6 +18,8 @@ parameters:
 
     secrets: {}
 
+    clusterpolicies: {}
+
     monitoring:
       enabled: true
       alerts:

--- a/class/kyverno.yml
+++ b/class/kyverno.yml
@@ -65,5 +65,6 @@ parameters:
           - kyverno/component/kyverno.jsonnet
           - kyverno/component/rolebindings.jsonnet
           - kyverno/component/monitoring.jsonnet
+          - kyverno/component/policies.jsonnet
         input_type: jsonnet
         output_path: kyverno/

--- a/component/policies.jsonnet
+++ b/component/policies.jsonnet
@@ -1,0 +1,22 @@
+local kyverno = import '../lib/kyverno.libsonnet';
+local common = import 'common.libsonnet';
+local com = import 'lib/commodore.libjsonnet';
+local kap = import 'lib/kapitan.libjsonnet';
+local kube = import 'lib/kube.libjsonnet';
+local inv = kap.inventory();
+
+local params = inv.parameters.kyverno;
+
+local clusterpolicies = com.generateResources(
+  params.clusterpolicies,
+  function(name) kyverno.ClusterPolicy(name) {
+    metadata+: {
+      labels+: common.Labels,
+    },
+  },
+);
+
+
+{
+  [if std.length(clusterpolicies) > 0 then '80_policies']: clusterpolicies,
+}

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -19,6 +19,33 @@ type:: dictionary
 Dictionary containing the container images used by this component.
 
 
+== `clusterpolicies`
+
+[horizontal]
+type:: dictionary
+default:: `{}`
+example::
++
+[source,yaml]
+----
+clusterpolicies:
+  restrict-registries:  # <1>
+    metadata:
+      annotations:
+        policies.kyverno.io/title: Example Policy
+        policies.kyverno.io/subject: Pod
+      spec:
+        validationFailureAction: enforce
+        background: true
+        rules:
+          - ...
+----
+<1> Key will be used as the default value for `metadata.name`
+
+Dictionary containing `ClusterPolicy.kyverno.io/v1` objects to be managed.
+Previously defined policies can be removed by setting `policy-name: null` in the dictionary.
+
+
 == `monitoring.enabled`
 
 [horizontal]

--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
   ],
   "postUpgradeTasks": {
     "commands": [
-      "make gen-golden"
+      "make gen-golden-all"
     ],
     "fileFilters": [ "tests/golden/**" ],
     "executionMode": "update"

--- a/tests/golden/policies/kyverno/kyverno/00_crds/kyverno.io_clusterpolicies.yaml
+++ b/tests/golden/policies/kyverno/kyverno/00_crds/kyverno.io_clusterpolicies.yaml
@@ -1,0 +1,2176 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.0
+  creationTimestamp: null
+  name: clusterpolicies.kyverno.io
+spec:
+  group: kyverno.io
+  names:
+    kind: ClusterPolicy
+    listKind: ClusterPolicyList
+    plural: clusterpolicies
+    shortNames:
+    - cpol
+    singular: clusterpolicy
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.background
+      name: Background
+      type: string
+    - jsonPath: .spec.validationFailureAction
+      name: Action
+      type: string
+    - jsonPath: .spec.failurePolicy
+      name: Failure Policy
+      priority: 1
+      type: string
+    - jsonPath: .status.ready
+      name: Ready
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: ClusterPolicy declares validation, mutation, and generation behaviors
+          for matching resources.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec declares policy behaviors.
+            properties:
+              background:
+                description: Background controls if rules are applied to existing
+                  resources during a background scan. Optional. Default value is "true".
+                  The value must be set to "false" if the policy rule uses variables
+                  that are only available in the admission review request (e.g. user
+                  name).
+                type: boolean
+              failurePolicy:
+                description: FailurePolicy defines how unrecognized errors from the
+                  admission endpoint are handled. Rules within the same policy share
+                  the same failure behavior. Allowed values are Ignore or Fail. Defaults
+                  to Fail.
+                enum:
+                - Ignore
+                - Fail
+                type: string
+              rules:
+                description: Rules is a list of Rule instances. A Policy contains
+                  multiple rules and each rule can validate, mutate, or generate resources.
+                items:
+                  description: Rule defines a validation, mutation, or generation
+                    control for matching resources. Each rules contains a match declaration
+                    to select resources, and an optional exclude declaration to specify
+                    which resources to exclude.
+                  properties:
+                    context:
+                      description: Context defines variables and data sources that
+                        can be used during rule execution.
+                      items:
+                        description: ContextEntry adds variables and data sources
+                          to a rule Context. Either a ConfigMap reference or a APILookup
+                          must be provided.
+                        properties:
+                          apiCall:
+                            description: APICall defines an HTTP request to the Kubernetes
+                              API server. The JSON data retrieved is stored in the
+                              context.
+                            properties:
+                              jmesPath:
+                                description: JMESPath is an optional JSON Match Expression
+                                  that can be used to transform the JSON response
+                                  returned from the API server. For example a JMESPath
+                                  of "items | length(@)" applied to the API server
+                                  response to the URLPath "/apis/apps/v1/deployments"
+                                  will return the total count of deployments across
+                                  all namespaces.
+                                type: string
+                              urlPath:
+                                description: URLPath is the URL path to be used in
+                                  the HTTP GET request to the Kubernetes API server
+                                  (e.g. "/api/v1/namespaces" or  "/apis/apps/v1/deployments").
+                                  The format required is the same format used by the
+                                  `kubectl get --raw` command.
+                                type: string
+                            required:
+                            - urlPath
+                            type: object
+                          configMap:
+                            description: ConfigMap is the ConfigMap reference.
+                            properties:
+                              name:
+                                description: Name is the ConfigMap name.
+                                type: string
+                              namespace:
+                                description: Namespace is the ConfigMap namespace.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          imageRegistry:
+                            description: ImageRegistry defines requests to an OCI/Docker
+                              V2 registry to fetch image details.
+                            properties:
+                              jmesPath:
+                                description: JMESPath is an optional JSON Match Expression
+                                  that can be used to transform the ImageData struct
+                                  returned as a result of processing the image reference.
+                                type: string
+                              reference:
+                                description: 'Reference is image reference to a container
+                                  image in the registry. Example: ghcr.io/kyverno/kyverno:latest'
+                                type: string
+                            required:
+                            - reference
+                            type: object
+                          name:
+                            description: Name is the variable name.
+                            type: string
+                        type: object
+                      type: array
+                    exclude:
+                      description: ExcludeResources defines when this policy rule
+                        should not be applied. The exclude criteria can include resource
+                        information (e.g. kind, name, namespace, labels) and admission
+                        review request information like the name or role.
+                      properties:
+                        all:
+                          description: All allows specifying resources which will
+                            be ANDed
+                          items:
+                            description: ResourceFilter allow users to "AND" or "OR"
+                              between resources
+                            properties:
+                              clusterRoles:
+                                description: ClusterRoles is the list of cluster-wide
+                                  role names for the user.
+                                items:
+                                  type: string
+                                type: array
+                              resources:
+                                description: ResourceDescription contains information
+                                  about the resource being created or modified.
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations is a  map of annotations
+                                      (key-value pairs of type string). Annotation
+                                      keys and values support the wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (matches at least one character).
+                                    type: object
+                                  kinds:
+                                    description: Kinds is a list of resource kinds.
+                                    items:
+                                      type: string
+                                    type: array
+                                  name:
+                                    description: Name is the name of the resource.
+                                      The name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character).
+                                    type: string
+                                  names:
+                                    description: 'Names are the names of the resources.
+                                      Each name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character). NOTE: "Name" is being deprecated
+                                      in favor of "Names".'
+                                    items:
+                                      type: string
+                                    type: array
+                                  namespaceSelector:
+                                    description: 'NamespaceSelector is a label selector
+                                      for the resource namespace. Label keys and values
+                                      in `matchLabels` support the wildcard characters
+                                      `*` (matches zero or many characters) and `?`
+                                      (matches one character).Wildcards allows writing
+                                      label selectors like ["storage.k8s.io/*": "*"].
+                                      Note that using ["*" : "*"] matches any key
+                                      and value but does not match an empty label
+                                      set.'
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: Namespaces is a list of namespaces
+                                      names. Each name supports wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (at least one character).
+                                    items:
+                                      type: string
+                                    type: array
+                                  selector:
+                                    description: 'Selector is a label selector. Label
+                                      keys and values in `matchLabels` support the
+                                      wildcard characters `*` (matches zero or many
+                                      characters) and `?` (matches one character).
+                                      Wildcards allows writing label selectors like
+                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                      : "*"] matches any key and value but does not
+                                      match an empty label set.'
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                type: object
+                              roles:
+                                description: Roles is the list of namespaced role
+                                  names for the user.
+                                items:
+                                  type: string
+                                type: array
+                              subjects:
+                                description: Subjects is the list of subject names
+                                  like users, user groups, and service accounts.
+                                items:
+                                  description: Subject contains a reference to the
+                                    object or user identities a role binding applies
+                                    to.  This can either hold a direct API object
+                                    reference, or a value for non-objects such as
+                                    user and group names.
+                                  properties:
+                                    apiGroup:
+                                      description: APIGroup holds the API group of
+                                        the referenced subject. Defaults to "" for
+                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
+                                        for User and Group subjects.
+                                      type: string
+                                    kind:
+                                      description: Kind of object being referenced.
+                                        Values defined by this API group are "User",
+                                        "Group", and "ServiceAccount". If the Authorizer
+                                        does not recognized the kind value, the Authorizer
+                                        should report an error.
+                                      type: string
+                                    name:
+                                      description: Name of the object being referenced.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the referenced object.  If
+                                        the object kind is non-namespace, such as
+                                        "User" or "Group", and this value is not empty
+                                        the Authorizer should report an error.
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                type: array
+                            type: object
+                          type: array
+                        any:
+                          description: Any allows specifying resources which will
+                            be ORed
+                          items:
+                            description: ResourceFilter allow users to "AND" or "OR"
+                              between resources
+                            properties:
+                              clusterRoles:
+                                description: ClusterRoles is the list of cluster-wide
+                                  role names for the user.
+                                items:
+                                  type: string
+                                type: array
+                              resources:
+                                description: ResourceDescription contains information
+                                  about the resource being created or modified.
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations is a  map of annotations
+                                      (key-value pairs of type string). Annotation
+                                      keys and values support the wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (matches at least one character).
+                                    type: object
+                                  kinds:
+                                    description: Kinds is a list of resource kinds.
+                                    items:
+                                      type: string
+                                    type: array
+                                  name:
+                                    description: Name is the name of the resource.
+                                      The name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character).
+                                    type: string
+                                  names:
+                                    description: 'Names are the names of the resources.
+                                      Each name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character). NOTE: "Name" is being deprecated
+                                      in favor of "Names".'
+                                    items:
+                                      type: string
+                                    type: array
+                                  namespaceSelector:
+                                    description: 'NamespaceSelector is a label selector
+                                      for the resource namespace. Label keys and values
+                                      in `matchLabels` support the wildcard characters
+                                      `*` (matches zero or many characters) and `?`
+                                      (matches one character).Wildcards allows writing
+                                      label selectors like ["storage.k8s.io/*": "*"].
+                                      Note that using ["*" : "*"] matches any key
+                                      and value but does not match an empty label
+                                      set.'
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: Namespaces is a list of namespaces
+                                      names. Each name supports wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (at least one character).
+                                    items:
+                                      type: string
+                                    type: array
+                                  selector:
+                                    description: 'Selector is a label selector. Label
+                                      keys and values in `matchLabels` support the
+                                      wildcard characters `*` (matches zero or many
+                                      characters) and `?` (matches one character).
+                                      Wildcards allows writing label selectors like
+                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                      : "*"] matches any key and value but does not
+                                      match an empty label set.'
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                type: object
+                              roles:
+                                description: Roles is the list of namespaced role
+                                  names for the user.
+                                items:
+                                  type: string
+                                type: array
+                              subjects:
+                                description: Subjects is the list of subject names
+                                  like users, user groups, and service accounts.
+                                items:
+                                  description: Subject contains a reference to the
+                                    object or user identities a role binding applies
+                                    to.  This can either hold a direct API object
+                                    reference, or a value for non-objects such as
+                                    user and group names.
+                                  properties:
+                                    apiGroup:
+                                      description: APIGroup holds the API group of
+                                        the referenced subject. Defaults to "" for
+                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
+                                        for User and Group subjects.
+                                      type: string
+                                    kind:
+                                      description: Kind of object being referenced.
+                                        Values defined by this API group are "User",
+                                        "Group", and "ServiceAccount". If the Authorizer
+                                        does not recognized the kind value, the Authorizer
+                                        should report an error.
+                                      type: string
+                                    name:
+                                      description: Name of the object being referenced.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the referenced object.  If
+                                        the object kind is non-namespace, such as
+                                        "User" or "Group", and this value is not empty
+                                        the Authorizer should report an error.
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                type: array
+                            type: object
+                          type: array
+                        clusterRoles:
+                          description: ClusterRoles is the list of cluster-wide role
+                            names for the user.
+                          items:
+                            type: string
+                          type: array
+                        resources:
+                          description: ResourceDescription contains information about
+                            the resource being created or modified. Specifying ResourceDescription
+                            directly under exclude is being deprecated. Please specify
+                            under "any" or "all" instead.
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a  map of annotations (key-value
+                                pairs of type string). Annotation keys and values
+                                support the wildcard characters "*" (matches zero
+                                or many characters) and "?" (matches at least one
+                                character).
+                              type: object
+                            kinds:
+                              description: Kinds is a list of resource kinds.
+                              items:
+                                type: string
+                              type: array
+                            name:
+                              description: Name is the name of the resource. The name
+                                supports wildcard characters "*" (matches zero or
+                                many characters) and "?" (at least one character).
+                              type: string
+                            names:
+                              description: 'Names are the names of the resources.
+                                Each name supports wildcard characters "*" (matches
+                                zero or many characters) and "?" (at least one character).
+                                NOTE: "Name" is being deprecated in favor of "Names".'
+                              items:
+                                type: string
+                              type: array
+                            namespaceSelector:
+                              description: 'NamespaceSelector is a label selector
+                                for the resource namespace. Label keys and values
+                                in `matchLabels` support the wildcard characters `*`
+                                (matches zero or many characters) and `?` (matches
+                                one character).Wildcards allows writing label selectors
+                                like ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                : "*"] matches any key and value but does not match
+                                an empty label set.'
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaces:
+                              description: Namespaces is a list of namespaces names.
+                                Each name supports wildcard characters "*" (matches
+                                zero or many characters) and "?" (at least one character).
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: 'Selector is a label selector. Label keys
+                                and values in `matchLabels` support the wildcard characters
+                                `*` (matches zero or many characters) and `?` (matches
+                                one character). Wildcards allows writing label selectors
+                                like ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                : "*"] matches any key and value but does not match
+                                an empty label set.'
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                          type: object
+                        roles:
+                          description: Roles is the list of namespaced role names
+                            for the user.
+                          items:
+                            type: string
+                          type: array
+                        subjects:
+                          description: Subjects is the list of subject names like
+                            users, user groups, and service accounts.
+                          items:
+                            description: Subject contains a reference to the object
+                              or user identities a role binding applies to.  This
+                              can either hold a direct API object reference, or a
+                              value for non-objects such as user and group names.
+                            properties:
+                              apiGroup:
+                                description: APIGroup holds the API group of the referenced
+                                  subject. Defaults to "" for ServiceAccount subjects.
+                                  Defaults to "rbac.authorization.k8s.io" for User
+                                  and Group subjects.
+                                type: string
+                              kind:
+                                description: Kind of object being referenced. Values
+                                  defined by this API group are "User", "Group", and
+                                  "ServiceAccount". If the Authorizer does not recognized
+                                  the kind value, the Authorizer should report an
+                                  error.
+                                type: string
+                              name:
+                                description: Name of the object being referenced.
+                                type: string
+                              namespace:
+                                description: Namespace of the referenced object.  If
+                                  the object kind is non-namespace, such as "User"
+                                  or "Group", and this value is not empty the Authorizer
+                                  should report an error.
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                          type: array
+                      type: object
+                    generate:
+                      description: Generation is used to create new resources.
+                      properties:
+                        apiVersion:
+                          description: APIVersion specifies resource apiVersion.
+                          type: string
+                        clone:
+                          description: Clone specifies the source resource used to
+                            populate each generated resource. At most one of Data
+                            or Clone can be specified. If neither are provided, the
+                            generated resource will be created with default data only.
+                          properties:
+                            name:
+                              description: Name specifies name of the resource.
+                              type: string
+                            namespace:
+                              description: Namespace specifies source resource namespace.
+                              type: string
+                          type: object
+                        data:
+                          description: Data provides the resource declaration used
+                            to populate each generated resource. At most one of Data
+                            or Clone must be specified. If neither are provided, the
+                            generated resource will be created with default data only.
+                          x-kubernetes-preserve-unknown-fields: true
+                        kind:
+                          description: Kind specifies resource kind.
+                          type: string
+                        name:
+                          description: Name specifies the resource name.
+                          type: string
+                        namespace:
+                          description: Namespace specifies resource namespace.
+                          type: string
+                        synchronize:
+                          description: Synchronize controls if generated resources
+                            should be kept in-sync with their source resource. If
+                            Synchronize is set to "true" changes to generated resources
+                            will be overwritten with resource data from Data or the
+                            resource specified in the Clone declaration. Optional.
+                            Defaults to "false" if not specified.
+                          type: boolean
+                      type: object
+                    match:
+                      description: MatchResources defines when this policy rule should
+                        be applied. The match criteria can include resource information
+                        (e.g. kind, name, namespace, labels) and admission review
+                        request information like the user name or role. At least one
+                        kind is required.
+                      properties:
+                        all:
+                          description: All allows specifying resources which will
+                            be ANDed
+                          items:
+                            description: ResourceFilter allow users to "AND" or "OR"
+                              between resources
+                            properties:
+                              clusterRoles:
+                                description: ClusterRoles is the list of cluster-wide
+                                  role names for the user.
+                                items:
+                                  type: string
+                                type: array
+                              resources:
+                                description: ResourceDescription contains information
+                                  about the resource being created or modified.
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations is a  map of annotations
+                                      (key-value pairs of type string). Annotation
+                                      keys and values support the wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (matches at least one character).
+                                    type: object
+                                  kinds:
+                                    description: Kinds is a list of resource kinds.
+                                    items:
+                                      type: string
+                                    type: array
+                                  name:
+                                    description: Name is the name of the resource.
+                                      The name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character).
+                                    type: string
+                                  names:
+                                    description: 'Names are the names of the resources.
+                                      Each name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character). NOTE: "Name" is being deprecated
+                                      in favor of "Names".'
+                                    items:
+                                      type: string
+                                    type: array
+                                  namespaceSelector:
+                                    description: 'NamespaceSelector is a label selector
+                                      for the resource namespace. Label keys and values
+                                      in `matchLabels` support the wildcard characters
+                                      `*` (matches zero or many characters) and `?`
+                                      (matches one character).Wildcards allows writing
+                                      label selectors like ["storage.k8s.io/*": "*"].
+                                      Note that using ["*" : "*"] matches any key
+                                      and value but does not match an empty label
+                                      set.'
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: Namespaces is a list of namespaces
+                                      names. Each name supports wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (at least one character).
+                                    items:
+                                      type: string
+                                    type: array
+                                  selector:
+                                    description: 'Selector is a label selector. Label
+                                      keys and values in `matchLabels` support the
+                                      wildcard characters `*` (matches zero or many
+                                      characters) and `?` (matches one character).
+                                      Wildcards allows writing label selectors like
+                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                      : "*"] matches any key and value but does not
+                                      match an empty label set.'
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                type: object
+                              roles:
+                                description: Roles is the list of namespaced role
+                                  names for the user.
+                                items:
+                                  type: string
+                                type: array
+                              subjects:
+                                description: Subjects is the list of subject names
+                                  like users, user groups, and service accounts.
+                                items:
+                                  description: Subject contains a reference to the
+                                    object or user identities a role binding applies
+                                    to.  This can either hold a direct API object
+                                    reference, or a value for non-objects such as
+                                    user and group names.
+                                  properties:
+                                    apiGroup:
+                                      description: APIGroup holds the API group of
+                                        the referenced subject. Defaults to "" for
+                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
+                                        for User and Group subjects.
+                                      type: string
+                                    kind:
+                                      description: Kind of object being referenced.
+                                        Values defined by this API group are "User",
+                                        "Group", and "ServiceAccount". If the Authorizer
+                                        does not recognized the kind value, the Authorizer
+                                        should report an error.
+                                      type: string
+                                    name:
+                                      description: Name of the object being referenced.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the referenced object.  If
+                                        the object kind is non-namespace, such as
+                                        "User" or "Group", and this value is not empty
+                                        the Authorizer should report an error.
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                type: array
+                            type: object
+                          type: array
+                        any:
+                          description: Any allows specifying resources which will
+                            be ORed
+                          items:
+                            description: ResourceFilter allow users to "AND" or "OR"
+                              between resources
+                            properties:
+                              clusterRoles:
+                                description: ClusterRoles is the list of cluster-wide
+                                  role names for the user.
+                                items:
+                                  type: string
+                                type: array
+                              resources:
+                                description: ResourceDescription contains information
+                                  about the resource being created or modified.
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations is a  map of annotations
+                                      (key-value pairs of type string). Annotation
+                                      keys and values support the wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (matches at least one character).
+                                    type: object
+                                  kinds:
+                                    description: Kinds is a list of resource kinds.
+                                    items:
+                                      type: string
+                                    type: array
+                                  name:
+                                    description: Name is the name of the resource.
+                                      The name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character).
+                                    type: string
+                                  names:
+                                    description: 'Names are the names of the resources.
+                                      Each name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character). NOTE: "Name" is being deprecated
+                                      in favor of "Names".'
+                                    items:
+                                      type: string
+                                    type: array
+                                  namespaceSelector:
+                                    description: 'NamespaceSelector is a label selector
+                                      for the resource namespace. Label keys and values
+                                      in `matchLabels` support the wildcard characters
+                                      `*` (matches zero or many characters) and `?`
+                                      (matches one character).Wildcards allows writing
+                                      label selectors like ["storage.k8s.io/*": "*"].
+                                      Note that using ["*" : "*"] matches any key
+                                      and value but does not match an empty label
+                                      set.'
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: Namespaces is a list of namespaces
+                                      names. Each name supports wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (at least one character).
+                                    items:
+                                      type: string
+                                    type: array
+                                  selector:
+                                    description: 'Selector is a label selector. Label
+                                      keys and values in `matchLabels` support the
+                                      wildcard characters `*` (matches zero or many
+                                      characters) and `?` (matches one character).
+                                      Wildcards allows writing label selectors like
+                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                      : "*"] matches any key and value but does not
+                                      match an empty label set.'
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                type: object
+                              roles:
+                                description: Roles is the list of namespaced role
+                                  names for the user.
+                                items:
+                                  type: string
+                                type: array
+                              subjects:
+                                description: Subjects is the list of subject names
+                                  like users, user groups, and service accounts.
+                                items:
+                                  description: Subject contains a reference to the
+                                    object or user identities a role binding applies
+                                    to.  This can either hold a direct API object
+                                    reference, or a value for non-objects such as
+                                    user and group names.
+                                  properties:
+                                    apiGroup:
+                                      description: APIGroup holds the API group of
+                                        the referenced subject. Defaults to "" for
+                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
+                                        for User and Group subjects.
+                                      type: string
+                                    kind:
+                                      description: Kind of object being referenced.
+                                        Values defined by this API group are "User",
+                                        "Group", and "ServiceAccount". If the Authorizer
+                                        does not recognized the kind value, the Authorizer
+                                        should report an error.
+                                      type: string
+                                    name:
+                                      description: Name of the object being referenced.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the referenced object.  If
+                                        the object kind is non-namespace, such as
+                                        "User" or "Group", and this value is not empty
+                                        the Authorizer should report an error.
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                type: array
+                            type: object
+                          type: array
+                        clusterRoles:
+                          description: ClusterRoles is the list of cluster-wide role
+                            names for the user.
+                          items:
+                            type: string
+                          type: array
+                        resources:
+                          description: ResourceDescription contains information about
+                            the resource being created or modified. Requires at least
+                            one tag to be specified when under MatchResources. Specifying
+                            ResourceDescription directly under match is being deprecated.
+                            Please specify under "any" or "all" instead.
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a  map of annotations (key-value
+                                pairs of type string). Annotation keys and values
+                                support the wildcard characters "*" (matches zero
+                                or many characters) and "?" (matches at least one
+                                character).
+                              type: object
+                            kinds:
+                              description: Kinds is a list of resource kinds.
+                              items:
+                                type: string
+                              type: array
+                            name:
+                              description: Name is the name of the resource. The name
+                                supports wildcard characters "*" (matches zero or
+                                many characters) and "?" (at least one character).
+                              type: string
+                            names:
+                              description: 'Names are the names of the resources.
+                                Each name supports wildcard characters "*" (matches
+                                zero or many characters) and "?" (at least one character).
+                                NOTE: "Name" is being deprecated in favor of "Names".'
+                              items:
+                                type: string
+                              type: array
+                            namespaceSelector:
+                              description: 'NamespaceSelector is a label selector
+                                for the resource namespace. Label keys and values
+                                in `matchLabels` support the wildcard characters `*`
+                                (matches zero or many characters) and `?` (matches
+                                one character).Wildcards allows writing label selectors
+                                like ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                : "*"] matches any key and value but does not match
+                                an empty label set.'
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaces:
+                              description: Namespaces is a list of namespaces names.
+                                Each name supports wildcard characters "*" (matches
+                                zero or many characters) and "?" (at least one character).
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: 'Selector is a label selector. Label keys
+                                and values in `matchLabels` support the wildcard characters
+                                `*` (matches zero or many characters) and `?` (matches
+                                one character). Wildcards allows writing label selectors
+                                like ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                : "*"] matches any key and value but does not match
+                                an empty label set.'
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                          type: object
+                        roles:
+                          description: Roles is the list of namespaced role names
+                            for the user.
+                          items:
+                            type: string
+                          type: array
+                        subjects:
+                          description: Subjects is the list of subject names like
+                            users, user groups, and service accounts.
+                          items:
+                            description: Subject contains a reference to the object
+                              or user identities a role binding applies to.  This
+                              can either hold a direct API object reference, or a
+                              value for non-objects such as user and group names.
+                            properties:
+                              apiGroup:
+                                description: APIGroup holds the API group of the referenced
+                                  subject. Defaults to "" for ServiceAccount subjects.
+                                  Defaults to "rbac.authorization.k8s.io" for User
+                                  and Group subjects.
+                                type: string
+                              kind:
+                                description: Kind of object being referenced. Values
+                                  defined by this API group are "User", "Group", and
+                                  "ServiceAccount". If the Authorizer does not recognized
+                                  the kind value, the Authorizer should report an
+                                  error.
+                                type: string
+                              name:
+                                description: Name of the object being referenced.
+                                type: string
+                              namespace:
+                                description: Namespace of the referenced object.  If
+                                  the object kind is non-namespace, such as "User"
+                                  or "Group", and this value is not empty the Authorizer
+                                  should report an error.
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                          type: array
+                      type: object
+                    mutate:
+                      description: Mutation is used to modify matching resources.
+                      properties:
+                        foreach:
+                          description: ForEachMutation applies policy rule changes
+                            to nested elements.
+                          items:
+                            description: ForEachMutation applies policy rule changes
+                              to nested elements.
+                            properties:
+                              context:
+                                description: Context defines variables and data sources
+                                  that can be used during rule execution.
+                                items:
+                                  description: ContextEntry adds variables and data
+                                    sources to a rule Context. Either a ConfigMap
+                                    reference or a APILookup must be provided.
+                                  properties:
+                                    apiCall:
+                                      description: APICall defines an HTTP request
+                                        to the Kubernetes API server. The JSON data
+                                        retrieved is stored in the context.
+                                      properties:
+                                        jmesPath:
+                                          description: JMESPath is an optional JSON
+                                            Match Expression that can be used to transform
+                                            the JSON response returned from the API
+                                            server. For example a JMESPath of "items
+                                            | length(@)" applied to the API server
+                                            response to the URLPath "/apis/apps/v1/deployments"
+                                            will return the total count of deployments
+                                            across all namespaces.
+                                          type: string
+                                        urlPath:
+                                          description: URLPath is the URL path to
+                                            be used in the HTTP GET request to the
+                                            Kubernetes API server (e.g. "/api/v1/namespaces"
+                                            or  "/apis/apps/v1/deployments"). The
+                                            format required is the same format used
+                                            by the `kubectl get --raw` command.
+                                          type: string
+                                      required:
+                                      - urlPath
+                                      type: object
+                                    configMap:
+                                      description: ConfigMap is the ConfigMap reference.
+                                      properties:
+                                        name:
+                                          description: Name is the ConfigMap name.
+                                          type: string
+                                        namespace:
+                                          description: Namespace is the ConfigMap
+                                            namespace.
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    imageRegistry:
+                                      description: ImageRegistry defines requests
+                                        to an OCI/Docker V2 registry to fetch image
+                                        details.
+                                      properties:
+                                        jmesPath:
+                                          description: JMESPath is an optional JSON
+                                            Match Expression that can be used to transform
+                                            the ImageData struct returned as a result
+                                            of processing the image reference.
+                                          type: string
+                                        reference:
+                                          description: 'Reference is image reference
+                                            to a container image in the registry.
+                                            Example: ghcr.io/kyverno/kyverno:latest'
+                                          type: string
+                                      required:
+                                      - reference
+                                      type: object
+                                    name:
+                                      description: Name is the variable name.
+                                      type: string
+                                  type: object
+                                type: array
+                              list:
+                                description: List specifies a JMESPath expression
+                                  that results in one or more elements to which the
+                                  validation logic is applied.
+                                type: string
+                              patchStrategicMerge:
+                                description: PatchStrategicMerge is a strategic merge
+                                  patch used to modify resources. See https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/
+                                  and https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.
+                                x-kubernetes-preserve-unknown-fields: true
+                              patchesJson6902:
+                                description: PatchesJSON6902 is a list of RFC 6902
+                                  JSON Patch declarations used to modify resources.
+                                  See https://tools.ietf.org/html/rfc6902 and https://kubectl.docs.kubernetes.io/references/kustomize/patchesjson6902/.
+                                type: string
+                              preconditions:
+                                description: 'AnyAllConditions are used to determine
+                                  if a policy rule should be applied by evaluating
+                                  a set of conditions. The declaration can contain
+                                  nested `any` or `all` statements. See: https://kyverno.io/docs/writing-policies/preconditions/'
+                                properties:
+                                  all:
+                                    description: AllConditions enable variable-based
+                                      conditional rule execution. This is useful for
+                                      finer control of when an rule is applied. A
+                                      condition can reference object data using JMESPath
+                                      notation. Here, all of the conditions need to
+                                      pass
+                                    items:
+                                      description: Condition defines variable-based
+                                        conditional criteria for rule execution.
+                                      properties:
+                                        key:
+                                          description: Key is the context entry (using
+                                            JMESPath) for conditional rule evaluation.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                        operator:
+                                          description: 'Operator is the conditional
+                                            operation to perform. Valid operators
+                                            are: Equals, NotEquals, In, AnyIn, AllIn,
+                                            NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,
+                                            GreaterThan, LessThanOrEquals, LessThan,
+                                            DurationGreaterThanOrEquals, DurationGreaterThan,
+                                            DurationLessThanOrEquals, DurationLessThan'
+                                          enum:
+                                          - Equals
+                                          - NotEquals
+                                          - In
+                                          - AnyIn
+                                          - AllIn
+                                          - NotIn
+                                          - AnyNotIn
+                                          - AllNotIn
+                                          - GreaterThanOrEquals
+                                          - GreaterThan
+                                          - LessThanOrEquals
+                                          - LessThan
+                                          - DurationGreaterThanOrEquals
+                                          - DurationGreaterThan
+                                          - DurationLessThanOrEquals
+                                          - DurationLessThan
+                                          type: string
+                                        value:
+                                          description: Value is the conditional value,
+                                            or set of values. The values can be fixed
+                                            set or can be variables declared using
+                                            using JMESPath.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                    type: array
+                                  any:
+                                    description: AnyConditions enable variable-based
+                                      conditional rule execution. This is useful for
+                                      finer control of when an rule is applied. A
+                                      condition can reference object data using JMESPath
+                                      notation. Here, at least one of the conditions
+                                      need to pass
+                                    items:
+                                      description: Condition defines variable-based
+                                        conditional criteria for rule execution.
+                                      properties:
+                                        key:
+                                          description: Key is the context entry (using
+                                            JMESPath) for conditional rule evaluation.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                        operator:
+                                          description: 'Operator is the conditional
+                                            operation to perform. Valid operators
+                                            are: Equals, NotEquals, In, AnyIn, AllIn,
+                                            NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,
+                                            GreaterThan, LessThanOrEquals, LessThan,
+                                            DurationGreaterThanOrEquals, DurationGreaterThan,
+                                            DurationLessThanOrEquals, DurationLessThan'
+                                          enum:
+                                          - Equals
+                                          - NotEquals
+                                          - In
+                                          - AnyIn
+                                          - AllIn
+                                          - NotIn
+                                          - AnyNotIn
+                                          - AllNotIn
+                                          - GreaterThanOrEquals
+                                          - GreaterThan
+                                          - LessThanOrEquals
+                                          - LessThan
+                                          - DurationGreaterThanOrEquals
+                                          - DurationGreaterThan
+                                          - DurationLessThanOrEquals
+                                          - DurationLessThan
+                                          type: string
+                                        value:
+                                          description: Value is the conditional value,
+                                            or set of values. The values can be fixed
+                                            set or can be variables declared using
+                                            using JMESPath.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                    type: array
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          type: array
+                        patchStrategicMerge:
+                          description: PatchStrategicMerge is a strategic merge patch
+                            used to modify resources. See https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/
+                            and https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.
+                          x-kubernetes-preserve-unknown-fields: true
+                        patchesJson6902:
+                          description: PatchesJSON6902 is a list of RFC 6902 JSON
+                            Patch declarations used to modify resources. See https://tools.ietf.org/html/rfc6902
+                            and https://kubectl.docs.kubernetes.io/references/kustomize/patchesjson6902/.
+                          type: string
+                      type: object
+                    name:
+                      description: Name is a label to identify the rule, It must be
+                        unique within the policy.
+                      maxLength: 63
+                      type: string
+                    preconditions:
+                      description: 'Preconditions are used to determine if a policy
+                        rule should be applied by evaluating a set of conditions.
+                        The declaration can contain nested `any` or `all` statements.
+                        A direct list of conditions (without `any` or `all` statements
+                        is supported for backwards compatibility but will be deprecated
+                        in the next major release. See: https://kyverno.io/docs/writing-policies/preconditions/'
+                      x-kubernetes-preserve-unknown-fields: true
+                    validate:
+                      description: Validation is used to validate matching resources.
+                      properties:
+                        anyPattern:
+                          description: AnyPattern specifies list of validation patterns.
+                            At least one of the patterns must be satisfied for the
+                            validation rule to succeed.
+                          x-kubernetes-preserve-unknown-fields: true
+                        deny:
+                          description: Deny defines conditions used to pass or fail
+                            a validation rule.
+                          properties:
+                            conditions:
+                              description: 'Multiple conditions can be declared under
+                                an `any` or `all` statement. A direct list of conditions
+                                (without `any` or `all` statements) is also supported
+                                for backwards compatibility but will be deprecated
+                                in the next major release. See: https://kyverno.io/docs/writing-policies/validate/#deny-rules'
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                        foreach:
+                          description: ForEach applies policy rule changes to nested
+                            elements.
+                          items:
+                            description: ForEachValidation applies policy rule checks
+                              to nested elements.
+                            properties:
+                              anyPattern:
+                                description: AnyPattern specifies list of validation
+                                  patterns. At least one of the patterns must be satisfied
+                                  for the validation rule to succeed.
+                                x-kubernetes-preserve-unknown-fields: true
+                              context:
+                                description: Context defines variables and data sources
+                                  that can be used during rule execution.
+                                items:
+                                  description: ContextEntry adds variables and data
+                                    sources to a rule Context. Either a ConfigMap
+                                    reference or a APILookup must be provided.
+                                  properties:
+                                    apiCall:
+                                      description: APICall defines an HTTP request
+                                        to the Kubernetes API server. The JSON data
+                                        retrieved is stored in the context.
+                                      properties:
+                                        jmesPath:
+                                          description: JMESPath is an optional JSON
+                                            Match Expression that can be used to transform
+                                            the JSON response returned from the API
+                                            server. For example a JMESPath of "items
+                                            | length(@)" applied to the API server
+                                            response to the URLPath "/apis/apps/v1/deployments"
+                                            will return the total count of deployments
+                                            across all namespaces.
+                                          type: string
+                                        urlPath:
+                                          description: URLPath is the URL path to
+                                            be used in the HTTP GET request to the
+                                            Kubernetes API server (e.g. "/api/v1/namespaces"
+                                            or  "/apis/apps/v1/deployments"). The
+                                            format required is the same format used
+                                            by the `kubectl get --raw` command.
+                                          type: string
+                                      required:
+                                      - urlPath
+                                      type: object
+                                    configMap:
+                                      description: ConfigMap is the ConfigMap reference.
+                                      properties:
+                                        name:
+                                          description: Name is the ConfigMap name.
+                                          type: string
+                                        namespace:
+                                          description: Namespace is the ConfigMap
+                                            namespace.
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    imageRegistry:
+                                      description: ImageRegistry defines requests
+                                        to an OCI/Docker V2 registry to fetch image
+                                        details.
+                                      properties:
+                                        jmesPath:
+                                          description: JMESPath is an optional JSON
+                                            Match Expression that can be used to transform
+                                            the ImageData struct returned as a result
+                                            of processing the image reference.
+                                          type: string
+                                        reference:
+                                          description: 'Reference is image reference
+                                            to a container image in the registry.
+                                            Example: ghcr.io/kyverno/kyverno:latest'
+                                          type: string
+                                      required:
+                                      - reference
+                                      type: object
+                                    name:
+                                      description: Name is the variable name.
+                                      type: string
+                                  type: object
+                                type: array
+                              deny:
+                                description: Deny defines conditions used to pass
+                                  or fail a validation rule.
+                                properties:
+                                  conditions:
+                                    description: 'Multiple conditions can be declared
+                                      under an `any` or `all` statement. A direct
+                                      list of conditions (without `any` or `all` statements)
+                                      is also supported for backwards compatibility
+                                      but will be deprecated in the next major release.
+                                      See: https://kyverno.io/docs/writing-policies/validate/#deny-rules'
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              elementScope:
+                                description: ElementScope specifies whether to use
+                                  the current list element as the scope for validation.
+                                  Defaults to "true" if not specified. When set to
+                                  "false", "request.object" is used as the validation
+                                  scope within the foreach block to allow referencing
+                                  other elements in the subtree.
+                                type: boolean
+                              list:
+                                description: List specifies a JMESPath expression
+                                  that results in one or more elements to which the
+                                  validation logic is applied.
+                                type: string
+                              pattern:
+                                description: Pattern specifies an overlay-style pattern
+                                  used to check resources.
+                                x-kubernetes-preserve-unknown-fields: true
+                              preconditions:
+                                description: 'AnyAllConditions are used to determine
+                                  if a policy rule should be applied by evaluating
+                                  a set of conditions. The declaration can contain
+                                  nested `any` or `all` statements. See: https://kyverno.io/docs/writing-policies/preconditions/'
+                                properties:
+                                  all:
+                                    description: AllConditions enable variable-based
+                                      conditional rule execution. This is useful for
+                                      finer control of when an rule is applied. A
+                                      condition can reference object data using JMESPath
+                                      notation. Here, all of the conditions need to
+                                      pass
+                                    items:
+                                      description: Condition defines variable-based
+                                        conditional criteria for rule execution.
+                                      properties:
+                                        key:
+                                          description: Key is the context entry (using
+                                            JMESPath) for conditional rule evaluation.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                        operator:
+                                          description: 'Operator is the conditional
+                                            operation to perform. Valid operators
+                                            are: Equals, NotEquals, In, AnyIn, AllIn,
+                                            NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,
+                                            GreaterThan, LessThanOrEquals, LessThan,
+                                            DurationGreaterThanOrEquals, DurationGreaterThan,
+                                            DurationLessThanOrEquals, DurationLessThan'
+                                          enum:
+                                          - Equals
+                                          - NotEquals
+                                          - In
+                                          - AnyIn
+                                          - AllIn
+                                          - NotIn
+                                          - AnyNotIn
+                                          - AllNotIn
+                                          - GreaterThanOrEquals
+                                          - GreaterThan
+                                          - LessThanOrEquals
+                                          - LessThan
+                                          - DurationGreaterThanOrEquals
+                                          - DurationGreaterThan
+                                          - DurationLessThanOrEquals
+                                          - DurationLessThan
+                                          type: string
+                                        value:
+                                          description: Value is the conditional value,
+                                            or set of values. The values can be fixed
+                                            set or can be variables declared using
+                                            using JMESPath.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                    type: array
+                                  any:
+                                    description: AnyConditions enable variable-based
+                                      conditional rule execution. This is useful for
+                                      finer control of when an rule is applied. A
+                                      condition can reference object data using JMESPath
+                                      notation. Here, at least one of the conditions
+                                      need to pass
+                                    items:
+                                      description: Condition defines variable-based
+                                        conditional criteria for rule execution.
+                                      properties:
+                                        key:
+                                          description: Key is the context entry (using
+                                            JMESPath) for conditional rule evaluation.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                        operator:
+                                          description: 'Operator is the conditional
+                                            operation to perform. Valid operators
+                                            are: Equals, NotEquals, In, AnyIn, AllIn,
+                                            NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,
+                                            GreaterThan, LessThanOrEquals, LessThan,
+                                            DurationGreaterThanOrEquals, DurationGreaterThan,
+                                            DurationLessThanOrEquals, DurationLessThan'
+                                          enum:
+                                          - Equals
+                                          - NotEquals
+                                          - In
+                                          - AnyIn
+                                          - AllIn
+                                          - NotIn
+                                          - AnyNotIn
+                                          - AllNotIn
+                                          - GreaterThanOrEquals
+                                          - GreaterThan
+                                          - LessThanOrEquals
+                                          - LessThan
+                                          - DurationGreaterThanOrEquals
+                                          - DurationGreaterThan
+                                          - DurationLessThanOrEquals
+                                          - DurationLessThan
+                                          type: string
+                                        value:
+                                          description: Value is the conditional value,
+                                            or set of values. The values can be fixed
+                                            set or can be variables declared using
+                                            using JMESPath.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                    type: array
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          type: array
+                        message:
+                          description: Message specifies a custom message to be displayed
+                            on failure.
+                          type: string
+                        pattern:
+                          description: Pattern specifies an overlay-style pattern
+                            used to check resources.
+                          x-kubernetes-preserve-unknown-fields: true
+                      type: object
+                    verifyImages:
+                      description: VerifyImages is used to verify image signatures
+                        and mutate them to add a digest
+                      items:
+                        description: ImageVerification validates that images that
+                          match the specified pattern are signed with the supplied
+                          public key. Once the image is verified it is mutated to
+                          include the SHA digest retrieved during the registration.
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: Annotations are used for image verification.
+                              Every specified key-value pair must exist and match
+                              in the verified payload. The payload may contain other
+                              key-value pairs.
+                            type: object
+                          attestations:
+                            description: Attestations are optional checks for signed
+                              in-toto Statements used to verify the image. See https://github.com/in-toto/attestation.
+                              Kyverno fetches signed attestations from the OCI registry
+                              and decodes them into a list of Statement declarations.
+                            items:
+                              description: Attestation are checks for signed in-toto
+                                Statements that are used to verify the image. See
+                                https://github.com/in-toto/attestation. Kyverno fetches
+                                signed attestations from the OCI registry and decodes
+                                them into a list of Statements.
+                              properties:
+                                conditions:
+                                  description: Conditions are used to verify attributes
+                                    within a Predicate. If no Conditions are specified
+                                    the attestation check is satisfied as long there
+                                    are predicates that match the predicate type.
+                                  items:
+                                    description: AnyAllConditions consists of conditions
+                                      wrapped denoting a logical criteria to be fulfilled.
+                                      AnyConditions get fulfilled when at least one
+                                      of its sub-conditions passes. AllConditions
+                                      get fulfilled only when all of its sub-conditions
+                                      pass.
+                                    properties:
+                                      all:
+                                        description: AllConditions enable variable-based
+                                          conditional rule execution. This is useful
+                                          for finer control of when an rule is applied.
+                                          A condition can reference object data using
+                                          JMESPath notation. Here, all of the conditions
+                                          need to pass
+                                        items:
+                                          description: Condition defines variable-based
+                                            conditional criteria for rule execution.
+                                          properties:
+                                            key:
+                                              description: Key is the context entry
+                                                (using JMESPath) for conditional rule
+                                                evaluation.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            operator:
+                                              description: 'Operator is the conditional
+                                                operation to perform. Valid operators
+                                                are: Equals, NotEquals, In, AnyIn,
+                                                AllIn, NotIn, AnyNotIn, AllNotIn,
+                                                GreaterThanOrEquals, GreaterThan,
+                                                LessThanOrEquals, LessThan, DurationGreaterThanOrEquals,
+                                                DurationGreaterThan, DurationLessThanOrEquals,
+                                                DurationLessThan'
+                                              enum:
+                                              - Equals
+                                              - NotEquals
+                                              - In
+                                              - AnyIn
+                                              - AllIn
+                                              - NotIn
+                                              - AnyNotIn
+                                              - AllNotIn
+                                              - GreaterThanOrEquals
+                                              - GreaterThan
+                                              - LessThanOrEquals
+                                              - LessThan
+                                              - DurationGreaterThanOrEquals
+                                              - DurationGreaterThan
+                                              - DurationLessThanOrEquals
+                                              - DurationLessThan
+                                              type: string
+                                            value:
+                                              description: Value is the conditional
+                                                value, or set of values. The values
+                                                can be fixed set or can be variables
+                                                declared using using JMESPath.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                        type: array
+                                      any:
+                                        description: AnyConditions enable variable-based
+                                          conditional rule execution. This is useful
+                                          for finer control of when an rule is applied.
+                                          A condition can reference object data using
+                                          JMESPath notation. Here, at least one of
+                                          the conditions need to pass
+                                        items:
+                                          description: Condition defines variable-based
+                                            conditional criteria for rule execution.
+                                          properties:
+                                            key:
+                                              description: Key is the context entry
+                                                (using JMESPath) for conditional rule
+                                                evaluation.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            operator:
+                                              description: 'Operator is the conditional
+                                                operation to perform. Valid operators
+                                                are: Equals, NotEquals, In, AnyIn,
+                                                AllIn, NotIn, AnyNotIn, AllNotIn,
+                                                GreaterThanOrEquals, GreaterThan,
+                                                LessThanOrEquals, LessThan, DurationGreaterThanOrEquals,
+                                                DurationGreaterThan, DurationLessThanOrEquals,
+                                                DurationLessThan'
+                                              enum:
+                                              - Equals
+                                              - NotEquals
+                                              - In
+                                              - AnyIn
+                                              - AllIn
+                                              - NotIn
+                                              - AnyNotIn
+                                              - AllNotIn
+                                              - GreaterThanOrEquals
+                                              - GreaterThan
+                                              - LessThanOrEquals
+                                              - LessThan
+                                              - DurationGreaterThanOrEquals
+                                              - DurationGreaterThan
+                                              - DurationLessThanOrEquals
+                                              - DurationLessThan
+                                              type: string
+                                            value:
+                                              description: Value is the conditional
+                                                value, or set of values. The values
+                                                can be fixed set or can be variables
+                                                declared using using JMESPath.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                        type: array
+                                    type: object
+                                  type: array
+                                predicateType:
+                                  description: PredicateType defines the type of Predicate
+                                    contained within the Statement.
+                                  type: string
+                              type: object
+                            type: array
+                          image:
+                            description: 'Image is the image name consisting of the
+                              registry address, repository, image, and tag. Wildcards
+                              (''*'' and ''?'') are allowed. See: https://kubernetes.io/docs/concepts/containers/images.'
+                            type: string
+                          issuer:
+                            description: Issuer is the certificate issuer used for
+                              keyless signing.
+                            type: string
+                          key:
+                            description: Key is the PEM encoded public key that the
+                              image or attestation is signed with.
+                            type: string
+                          repository:
+                            description: Repository is an optional alternate OCI repository
+                              to use for image signatures that match this rule. If
+                              specified Repository will override the default OCI image
+                              repository configured for the installation.
+                            type: string
+                          roots:
+                            description: Roots is the PEM encoded Root certificate
+                              chain used for keyless signing
+                            type: string
+                          subject:
+                            description: Subject is the verified identity used for
+                              keyless signing, for example the email address
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                type: array
+              schemaValidation:
+                description: SchemaValidation skips policy validation checks. Optional.
+                  The default value is set to "true", it must be set to "false" to
+                  disable the validation checks.
+                type: boolean
+              validationFailureAction:
+                description: ValidationFailureAction controls if a validation policy
+                  rule failure should disallow the admission review request (enforce),
+                  or allow (audit) the admission review request and report an error
+                  in a policy report. Optional. The default value is "audit".
+                enum:
+                - audit
+                - enforce
+                type: string
+              validationFailureActionOverrides:
+                description: ValidationFailureActionOverrides is a Cluter Policy attribute
+                  that specifies ValidationFailureAction namespace-wise. It overrides
+                  ValidationFailureAction for the specified namespaces.
+                items:
+                  properties:
+                    action:
+                      enum:
+                      - audit
+                      - enforce
+                      type: string
+                    namespaces:
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                type: array
+              webhookTimeoutSeconds:
+                description: WebhookTimeoutSeconds specifies the maximum time in seconds
+                  allowed to apply this policy. After the configured time expires,
+                  the admission request may fail, or may simply ignore the policy
+                  results, based on the failure policy. The default timeout is 10s,
+                  the value must be between 1 and 30 seconds.
+                format: int32
+                type: integer
+            type: object
+          status:
+            description: Status contains policy runtime data.
+            properties:
+              ready:
+                description: Ready indicates if the policy is ready to serve the admission
+                  request
+                type: boolean
+            required:
+            - ready
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/tests/golden/policies/kyverno/kyverno/00_crds/kyverno.io_clusterreportchangerequests.yaml
+++ b/tests/golden/policies/kyverno/kyverno/00_crds/kyverno.io_clusterreportchangerequests.yaml
@@ -1,0 +1,675 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.0
+  creationTimestamp: null
+  name: clusterreportchangerequests.kyverno.io
+spec:
+  group: kyverno.io
+  names:
+    kind: ClusterReportChangeRequest
+    listKind: ClusterReportChangeRequestList
+    plural: clusterreportchangerequests
+    shortNames:
+    - crcr
+    singular: clusterreportchangerequest
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .scope.kind
+      name: Kind
+      priority: 1
+      type: string
+    - jsonPath: .scope.name
+      name: Name
+      priority: 1
+      type: string
+    - jsonPath: .summary.pass
+      name: Pass
+      type: integer
+    - jsonPath: .summary.fail
+      name: Fail
+      type: integer
+    - jsonPath: .summary.warn
+      name: Warn
+      type: integer
+    - jsonPath: .summary.error
+      name: Error
+      type: integer
+    - jsonPath: .summary.skip
+      name: Skip
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ClusterReportChangeRequest is the Schema for the ClusterReportChangeRequests
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          results:
+            description: PolicyReportResult provides result details
+            items:
+              description: PolicyReportResult provides the result for an individual
+                policy
+              properties:
+                category:
+                  description: Category indicates policy category
+                  type: string
+                data:
+                  additionalProperties:
+                    type: string
+                  description: Data provides additional information for the policy
+                    rule
+                  type: object
+                message:
+                  description: Message is a short user friendly description of the
+                    policy rule
+                  type: string
+                policy:
+                  description: Policy is the name of the policy
+                  type: string
+                resourceSelector:
+                  description: ResourceSelector is an optional selector for policy
+                    results that apply to multiple resources. For example, a policy
+                    result may apply to all pods that match a label. Either a Resource
+                    or a ResourceSelector can be specified. If neither are provided,
+                    the result is assumed to be for the policy report scope.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                resources:
+                  description: Resources is an optional reference to the resource
+                    checked by the policy and rule
+                  items:
+                    description: 'ObjectReference contains enough information to let
+                      you inspect or modify the referred object. --- New uses of this
+                      type are discouraged because of difficulty describing its usage
+                      when embedded in APIs.  1. Ignored fields.  It includes many
+                      fields which are not generally honored.  For instance, ResourceVersion
+                      and FieldPath are both very rarely valid in actual usage.  2.
+                      Invalid usage help.  It is impossible to add specific help for
+                      individual usage.  In most embedded usages, there are particular     restrictions
+                      like, "must refer only to types A and B" or "UID not honored"
+                      or "name must be restricted".     Those cannot be well described
+                      when embedded.  3. Inconsistent validation.  Because the usages
+                      are different, the validation rules are different by usage,
+                      which makes it hard for users to predict what will happen.  4.
+                      The fields are both imprecise and overly precise.  Kind is not
+                      a precise mapping to a URL. This can produce ambiguity     during
+                      interpretation and require a REST mapping.  In most cases, the
+                      dependency is on the group,resource tuple     and the version
+                      of the actual struct is irrelevant.  5. We cannot easily change
+                      it.  Because this type is embedded in many locations, updates
+                      to this type     will affect numerous schemas.  Don''t make
+                      new APIs embed an underspecified API type they do not control.
+                      Instead of using this type, create a locally provided and used
+                      type that is well-focused on your reference. For example, ServiceReferences
+                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                      .'
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object. TODO: this design is not final and this field
+                          is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                  type: array
+                rule:
+                  description: Rule is the name of the policy rule
+                  type: string
+                scored:
+                  description: Scored indicates if this policy rule is scored
+                  type: boolean
+                severity:
+                  description: Severity indicates policy severity
+                  enum:
+                  - high
+                  - low
+                  - medium
+                  type: string
+                status:
+                  description: Status indicates the result of the policy rule check
+                  enum:
+                  - pass
+                  - fail
+                  - warn
+                  - error
+                  - skip
+                  type: string
+              required:
+              - policy
+              type: object
+            type: array
+          scope:
+            description: Scope is an optional reference to the report scope (e.g.
+              a Deployment, Namespace, or Node)
+            properties:
+              apiVersion:
+                description: API version of the referent.
+                type: string
+              fieldPath:
+                description: 'If referring to a piece of an object instead of an entire
+                  object, this string should contain a valid JSON/Go field access
+                  statement, such as desiredState.manifest.containers[2]. For example,
+                  if the object reference is to a container within a pod, this would
+                  take on a value like: "spec.containers{name}" (where "name" refers
+                  to the name of the container that triggered the event) or if no
+                  container name is specified "spec.containers[2]" (container with
+                  index 2 in this pod). This syntax is chosen only to have some well-defined
+                  way of referencing a part of an object. TODO: this design is not
+                  final and this field is subject to change in the future.'
+                type: string
+              kind:
+                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              name:
+                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                type: string
+              namespace:
+                description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                type: string
+              resourceVersion:
+                description: 'Specific resourceVersion to which this reference is
+                  made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                type: string
+              uid:
+                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                type: string
+            type: object
+          scopeSelector:
+            description: ScopeSelector is an optional selector for multiple scopes
+              (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
+              should be specified.
+            properties:
+              matchExpressions:
+                description: matchExpressions is a list of label selector requirements.
+                  The requirements are ANDed.
+                items:
+                  description: A label selector requirement is a selector that contains
+                    values, a key, and an operator that relates the key and values.
+                  properties:
+                    key:
+                      description: key is the label key that the selector applies
+                        to.
+                      type: string
+                    operator:
+                      description: operator represents a key's relationship to a set
+                        of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                      type: string
+                    values:
+                      description: values is an array of string values. If the operator
+                        is In or NotIn, the values array must be non-empty. If the
+                        operator is Exists or DoesNotExist, the values array must
+                        be empty. This array is replaced during a strategic merge
+                        patch.
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - key
+                  - operator
+                  type: object
+                type: array
+              matchLabels:
+                additionalProperties:
+                  type: string
+                description: matchLabels is a map of {key,value} pairs. A single {key,value}
+                  in the matchLabels map is equivalent to an element of matchExpressions,
+                  whose key field is "key", the operator is "In", and the values array
+                  contains only "value". The requirements are ANDed.
+                type: object
+            type: object
+          summary:
+            description: PolicyReportSummary provides a summary of results
+            properties:
+              error:
+                description: Error provides the count of policies that could not be
+                  evaluated
+                type: integer
+              fail:
+                description: Fail provides the count of policies whose requirements
+                  were not met
+                type: integer
+              pass:
+                description: Pass provides the count of policies whose requirements
+                  were met
+                type: integer
+              skip:
+                description: Skip indicates the count of policies that were not selected
+                  for evaluation
+                type: integer
+              warn:
+                description: Warn provides the count of unscored policies whose requirements
+                  were not met
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources: {}
+  - additionalPrinterColumns:
+    - jsonPath: .scope.kind
+      name: Kind
+      priority: 1
+      type: string
+    - jsonPath: .scope.name
+      name: Name
+      priority: 1
+      type: string
+    - jsonPath: .summary.pass
+      name: Pass
+      type: integer
+    - jsonPath: .summary.fail
+      name: Fail
+      type: integer
+    - jsonPath: .summary.warn
+      name: Warn
+      type: integer
+    - jsonPath: .summary.error
+      name: Error
+      type: integer
+    - jsonPath: .summary.skip
+      name: Skip
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: ClusterReportChangeRequest is the Schema for the ClusterReportChangeRequests
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          results:
+            description: PolicyReportResult provides result details
+            items:
+              description: PolicyReportResult provides the result for an individual
+                policy
+              properties:
+                category:
+                  description: Category indicates policy category
+                  type: string
+                message:
+                  description: Message is a short user friendly description of the
+                    policy rule
+                  type: string
+                policy:
+                  description: Policy is the name of the policy
+                  type: string
+                properties:
+                  additionalProperties:
+                    type: string
+                  description: Properties provides additional information for the
+                    policy rule
+                  type: object
+                resourceSelector:
+                  description: ResourceSelector is an optional selector for policy
+                    results that apply to multiple resources. For example, a policy
+                    result may apply to all pods that match a label. Either a Resource
+                    or a ResourceSelector can be specified. If neither are provided,
+                    the result is assumed to be for the policy report scope.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                resources:
+                  description: Resources is an optional reference to the resource
+                    checked by the policy and rule
+                  items:
+                    description: 'ObjectReference contains enough information to let
+                      you inspect or modify the referred object. --- New uses of this
+                      type are discouraged because of difficulty describing its usage
+                      when embedded in APIs.  1. Ignored fields.  It includes many
+                      fields which are not generally honored.  For instance, ResourceVersion
+                      and FieldPath are both very rarely valid in actual usage.  2.
+                      Invalid usage help.  It is impossible to add specific help for
+                      individual usage.  In most embedded usages, there are particular     restrictions
+                      like, "must refer only to types A and B" or "UID not honored"
+                      or "name must be restricted".     Those cannot be well described
+                      when embedded.  3. Inconsistent validation.  Because the usages
+                      are different, the validation rules are different by usage,
+                      which makes it hard for users to predict what will happen.  4.
+                      The fields are both imprecise and overly precise.  Kind is not
+                      a precise mapping to a URL. This can produce ambiguity     during
+                      interpretation and require a REST mapping.  In most cases, the
+                      dependency is on the group,resource tuple     and the version
+                      of the actual struct is irrelevant.  5. We cannot easily change
+                      it.  Because this type is embedded in many locations, updates
+                      to this type     will affect numerous schemas.  Don''t make
+                      new APIs embed an underspecified API type they do not control.
+                      Instead of using this type, create a locally provided and used
+                      type that is well-focused on your reference. For example, ServiceReferences
+                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                      .'
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object. TODO: this design is not final and this field
+                          is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                  type: array
+                result:
+                  description: Result indicates the outcome of the policy rule execution
+                  enum:
+                  - pass
+                  - fail
+                  - warn
+                  - error
+                  - skip
+                  type: string
+                rule:
+                  description: Rule is the name of the policy rule
+                  type: string
+                scored:
+                  description: Scored indicates if this policy rule is scored
+                  type: boolean
+                severity:
+                  description: Severity indicates policy severity
+                  enum:
+                  - high
+                  - low
+                  - medium
+                  type: string
+                source:
+                  description: Source is an identifier for the policy engine that
+                    manages this report
+                  type: string
+                timestamp:
+                  description: Timestamp indicates the time the result was found
+                  properties:
+                    nanos:
+                      description: Non-negative fractions of a second at nanosecond
+                        resolution. Negative second values with fractions must still
+                        have non-negative nanos values that count forward in time.
+                        Must be from 0 to 999,999,999 inclusive. This field may be
+                        limited in precision depending on context.
+                      format: int32
+                      type: integer
+                    seconds:
+                      description: Represents seconds of UTC time since Unix epoch
+                        1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
+                        9999-12-31T23:59:59Z inclusive.
+                      format: int64
+                      type: integer
+                  required:
+                  - nanos
+                  - seconds
+                  type: object
+              required:
+              - policy
+              type: object
+            type: array
+          scope:
+            description: Scope is an optional reference to the report scope (e.g.
+              a Deployment, Namespace, or Node)
+            properties:
+              apiVersion:
+                description: API version of the referent.
+                type: string
+              fieldPath:
+                description: 'If referring to a piece of an object instead of an entire
+                  object, this string should contain a valid JSON/Go field access
+                  statement, such as desiredState.manifest.containers[2]. For example,
+                  if the object reference is to a container within a pod, this would
+                  take on a value like: "spec.containers{name}" (where "name" refers
+                  to the name of the container that triggered the event) or if no
+                  container name is specified "spec.containers[2]" (container with
+                  index 2 in this pod). This syntax is chosen only to have some well-defined
+                  way of referencing a part of an object. TODO: this design is not
+                  final and this field is subject to change in the future.'
+                type: string
+              kind:
+                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              name:
+                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                type: string
+              namespace:
+                description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                type: string
+              resourceVersion:
+                description: 'Specific resourceVersion to which this reference is
+                  made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                type: string
+              uid:
+                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                type: string
+            type: object
+          scopeSelector:
+            description: ScopeSelector is an optional selector for multiple scopes
+              (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
+              should be specified.
+            properties:
+              matchExpressions:
+                description: matchExpressions is a list of label selector requirements.
+                  The requirements are ANDed.
+                items:
+                  description: A label selector requirement is a selector that contains
+                    values, a key, and an operator that relates the key and values.
+                  properties:
+                    key:
+                      description: key is the label key that the selector applies
+                        to.
+                      type: string
+                    operator:
+                      description: operator represents a key's relationship to a set
+                        of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                      type: string
+                    values:
+                      description: values is an array of string values. If the operator
+                        is In or NotIn, the values array must be non-empty. If the
+                        operator is Exists or DoesNotExist, the values array must
+                        be empty. This array is replaced during a strategic merge
+                        patch.
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - key
+                  - operator
+                  type: object
+                type: array
+              matchLabels:
+                additionalProperties:
+                  type: string
+                description: matchLabels is a map of {key,value} pairs. A single {key,value}
+                  in the matchLabels map is equivalent to an element of matchExpressions,
+                  whose key field is "key", the operator is "In", and the values array
+                  contains only "value". The requirements are ANDed.
+                type: object
+            type: object
+          summary:
+            description: PolicyReportSummary provides a summary of results
+            properties:
+              error:
+                description: Error provides the count of policies that could not be
+                  evaluated
+                type: integer
+              fail:
+                description: Fail provides the count of policies whose requirements
+                  were not met
+                type: integer
+              pass:
+                description: Pass provides the count of policies whose requirements
+                  were met
+                type: integer
+              skip:
+                description: Skip indicates the count of policies that were not selected
+                  for evaluation
+                type: integer
+              warn:
+                description: Warn provides the count of unscored policies whose requirements
+                  were not met
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/tests/golden/policies/kyverno/kyverno/00_crds/kyverno.io_generaterequests.yaml
+++ b/tests/golden/policies/kyverno/kyverno/00_crds/kyverno.io_generaterequests.yaml
@@ -1,0 +1,192 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.0
+  creationTimestamp: null
+  name: generaterequests.kyverno.io
+spec:
+  group: kyverno.io
+  names:
+    kind: GenerateRequest
+    listKind: GenerateRequestList
+    plural: generaterequests
+    shortNames:
+    - gr
+    singular: generaterequest
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.policy
+      name: Policy
+      type: string
+    - jsonPath: .spec.resource.kind
+      name: ResourceKind
+      type: string
+    - jsonPath: .spec.resource.name
+      name: ResourceName
+      type: string
+    - jsonPath: .spec.resource.namespace
+      name: ResourceNamespace
+      type: string
+    - jsonPath: .status.state
+      name: status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: GenerateRequest is a request to process generate rule.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec is the information to identify the generate request.
+            properties:
+              context:
+                description: Context ...
+                properties:
+                  admissionRequestInfo:
+                    description: AdmissionRequestInfoObject stores the admission request
+                      and operation details
+                    properties:
+                      admissionRequest:
+                        type: string
+                      operation:
+                        description: Operation is the type of resource operation being
+                          checked for admission control
+                        type: string
+                    type: object
+                  userInfo:
+                    description: RequestInfo contains permission info carried in an
+                      admission request.
+                    properties:
+                      clusterRoles:
+                        description: ClusterRoles is a list of possible clusterRoles
+                          send the request.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      roles:
+                        description: Roles is a list of possible role send the request.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      userInfo:
+                        description: UserInfo is the userInfo carried in the admission
+                          request.
+                        properties:
+                          extra:
+                            additionalProperties:
+                              description: ExtraValue masks the value so protobuf
+                                can generate
+                              items:
+                                type: string
+                              type: array
+                            description: Any additional information provided by the
+                              authenticator.
+                            type: object
+                          groups:
+                            description: The names of groups this user is a part of.
+                            items:
+                              type: string
+                            type: array
+                          uid:
+                            description: A unique value that identifies this user
+                              across time. If this user is deleted and another user
+                              by the same name is added, they will have different
+                              UIDs.
+                            type: string
+                          username:
+                            description: The name that uniquely identifies this user
+                              among all active users.
+                            type: string
+                        type: object
+                    type: object
+                type: object
+              policy:
+                description: Specifies the name of the policy.
+                type: string
+              resource:
+                description: ResourceSpec is the information to identify the generate
+                  request.
+                properties:
+                  apiVersion:
+                    description: APIVersion specifies resource apiVersion.
+                    type: string
+                  kind:
+                    description: Kind specifies resource kind.
+                    type: string
+                  name:
+                    description: Name specifies the resource name.
+                    type: string
+                  namespace:
+                    description: Namespace specifies resource namespace.
+                    type: string
+                type: object
+            required:
+            - context
+            - policy
+            - resource
+            type: object
+          status:
+            description: Status contains statistics related to generate request.
+            properties:
+              generatedResources:
+                description: This will track the resources that are generated by the
+                  generate Policy. Will be used during clean up resources.
+                items:
+                  description: ResourceSpec contains information to identify a resource.
+                  properties:
+                    apiVersion:
+                      description: APIVersion specifies resource apiVersion.
+                      type: string
+                    kind:
+                      description: Kind specifies resource kind.
+                      type: string
+                    name:
+                      description: Name specifies the resource name.
+                      type: string
+                    namespace:
+                      description: Namespace specifies resource namespace.
+                      type: string
+                  type: object
+                type: array
+              message:
+                description: Specifies request status message.
+                type: string
+              state:
+                description: State represents state of the generate request.
+                type: string
+            required:
+            - state
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/tests/golden/policies/kyverno/kyverno/00_crds/kyverno.io_policies.yaml
+++ b/tests/golden/policies/kyverno/kyverno/00_crds/kyverno.io_policies.yaml
@@ -1,0 +1,2178 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.0
+  creationTimestamp: null
+  name: policies.kyverno.io
+spec:
+  group: kyverno.io
+  names:
+    kind: Policy
+    listKind: PolicyList
+    plural: policies
+    shortNames:
+    - pol
+    singular: policy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.background
+      name: Background
+      type: string
+    - jsonPath: .spec.validationFailureAction
+      name: Action
+      type: string
+    - jsonPath: .spec.failurePolicy
+      name: Failure Policy
+      priority: 1
+      type: string
+    - jsonPath: .status.ready
+      name: Ready
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: 'Policy declares validation, mutation, and generation behaviors
+          for matching resources. See: https://kyverno.io/docs/writing-policies/ for
+          more information.'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines policy behaviors and contains one or more rules.
+            properties:
+              background:
+                description: Background controls if rules are applied to existing
+                  resources during a background scan. Optional. Default value is "true".
+                  The value must be set to "false" if the policy rule uses variables
+                  that are only available in the admission review request (e.g. user
+                  name).
+                type: boolean
+              failurePolicy:
+                description: FailurePolicy defines how unrecognized errors from the
+                  admission endpoint are handled. Rules within the same policy share
+                  the same failure behavior. Allowed values are Ignore or Fail. Defaults
+                  to Fail.
+                enum:
+                - Ignore
+                - Fail
+                type: string
+              rules:
+                description: Rules is a list of Rule instances. A Policy contains
+                  multiple rules and each rule can validate, mutate, or generate resources.
+                items:
+                  description: Rule defines a validation, mutation, or generation
+                    control for matching resources. Each rules contains a match declaration
+                    to select resources, and an optional exclude declaration to specify
+                    which resources to exclude.
+                  properties:
+                    context:
+                      description: Context defines variables and data sources that
+                        can be used during rule execution.
+                      items:
+                        description: ContextEntry adds variables and data sources
+                          to a rule Context. Either a ConfigMap reference or a APILookup
+                          must be provided.
+                        properties:
+                          apiCall:
+                            description: APICall defines an HTTP request to the Kubernetes
+                              API server. The JSON data retrieved is stored in the
+                              context.
+                            properties:
+                              jmesPath:
+                                description: JMESPath is an optional JSON Match Expression
+                                  that can be used to transform the JSON response
+                                  returned from the API server. For example a JMESPath
+                                  of "items | length(@)" applied to the API server
+                                  response to the URLPath "/apis/apps/v1/deployments"
+                                  will return the total count of deployments across
+                                  all namespaces.
+                                type: string
+                              urlPath:
+                                description: URLPath is the URL path to be used in
+                                  the HTTP GET request to the Kubernetes API server
+                                  (e.g. "/api/v1/namespaces" or  "/apis/apps/v1/deployments").
+                                  The format required is the same format used by the
+                                  `kubectl get --raw` command.
+                                type: string
+                            required:
+                            - urlPath
+                            type: object
+                          configMap:
+                            description: ConfigMap is the ConfigMap reference.
+                            properties:
+                              name:
+                                description: Name is the ConfigMap name.
+                                type: string
+                              namespace:
+                                description: Namespace is the ConfigMap namespace.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          imageRegistry:
+                            description: ImageRegistry defines requests to an OCI/Docker
+                              V2 registry to fetch image details.
+                            properties:
+                              jmesPath:
+                                description: JMESPath is an optional JSON Match Expression
+                                  that can be used to transform the ImageData struct
+                                  returned as a result of processing the image reference.
+                                type: string
+                              reference:
+                                description: 'Reference is image reference to a container
+                                  image in the registry. Example: ghcr.io/kyverno/kyverno:latest'
+                                type: string
+                            required:
+                            - reference
+                            type: object
+                          name:
+                            description: Name is the variable name.
+                            type: string
+                        type: object
+                      type: array
+                    exclude:
+                      description: ExcludeResources defines when this policy rule
+                        should not be applied. The exclude criteria can include resource
+                        information (e.g. kind, name, namespace, labels) and admission
+                        review request information like the name or role.
+                      properties:
+                        all:
+                          description: All allows specifying resources which will
+                            be ANDed
+                          items:
+                            description: ResourceFilter allow users to "AND" or "OR"
+                              between resources
+                            properties:
+                              clusterRoles:
+                                description: ClusterRoles is the list of cluster-wide
+                                  role names for the user.
+                                items:
+                                  type: string
+                                type: array
+                              resources:
+                                description: ResourceDescription contains information
+                                  about the resource being created or modified.
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations is a  map of annotations
+                                      (key-value pairs of type string). Annotation
+                                      keys and values support the wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (matches at least one character).
+                                    type: object
+                                  kinds:
+                                    description: Kinds is a list of resource kinds.
+                                    items:
+                                      type: string
+                                    type: array
+                                  name:
+                                    description: Name is the name of the resource.
+                                      The name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character).
+                                    type: string
+                                  names:
+                                    description: 'Names are the names of the resources.
+                                      Each name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character). NOTE: "Name" is being deprecated
+                                      in favor of "Names".'
+                                    items:
+                                      type: string
+                                    type: array
+                                  namespaceSelector:
+                                    description: 'NamespaceSelector is a label selector
+                                      for the resource namespace. Label keys and values
+                                      in `matchLabels` support the wildcard characters
+                                      `*` (matches zero or many characters) and `?`
+                                      (matches one character).Wildcards allows writing
+                                      label selectors like ["storage.k8s.io/*": "*"].
+                                      Note that using ["*" : "*"] matches any key
+                                      and value but does not match an empty label
+                                      set.'
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: Namespaces is a list of namespaces
+                                      names. Each name supports wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (at least one character).
+                                    items:
+                                      type: string
+                                    type: array
+                                  selector:
+                                    description: 'Selector is a label selector. Label
+                                      keys and values in `matchLabels` support the
+                                      wildcard characters `*` (matches zero or many
+                                      characters) and `?` (matches one character).
+                                      Wildcards allows writing label selectors like
+                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                      : "*"] matches any key and value but does not
+                                      match an empty label set.'
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                type: object
+                              roles:
+                                description: Roles is the list of namespaced role
+                                  names for the user.
+                                items:
+                                  type: string
+                                type: array
+                              subjects:
+                                description: Subjects is the list of subject names
+                                  like users, user groups, and service accounts.
+                                items:
+                                  description: Subject contains a reference to the
+                                    object or user identities a role binding applies
+                                    to.  This can either hold a direct API object
+                                    reference, or a value for non-objects such as
+                                    user and group names.
+                                  properties:
+                                    apiGroup:
+                                      description: APIGroup holds the API group of
+                                        the referenced subject. Defaults to "" for
+                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
+                                        for User and Group subjects.
+                                      type: string
+                                    kind:
+                                      description: Kind of object being referenced.
+                                        Values defined by this API group are "User",
+                                        "Group", and "ServiceAccount". If the Authorizer
+                                        does not recognized the kind value, the Authorizer
+                                        should report an error.
+                                      type: string
+                                    name:
+                                      description: Name of the object being referenced.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the referenced object.  If
+                                        the object kind is non-namespace, such as
+                                        "User" or "Group", and this value is not empty
+                                        the Authorizer should report an error.
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                type: array
+                            type: object
+                          type: array
+                        any:
+                          description: Any allows specifying resources which will
+                            be ORed
+                          items:
+                            description: ResourceFilter allow users to "AND" or "OR"
+                              between resources
+                            properties:
+                              clusterRoles:
+                                description: ClusterRoles is the list of cluster-wide
+                                  role names for the user.
+                                items:
+                                  type: string
+                                type: array
+                              resources:
+                                description: ResourceDescription contains information
+                                  about the resource being created or modified.
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations is a  map of annotations
+                                      (key-value pairs of type string). Annotation
+                                      keys and values support the wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (matches at least one character).
+                                    type: object
+                                  kinds:
+                                    description: Kinds is a list of resource kinds.
+                                    items:
+                                      type: string
+                                    type: array
+                                  name:
+                                    description: Name is the name of the resource.
+                                      The name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character).
+                                    type: string
+                                  names:
+                                    description: 'Names are the names of the resources.
+                                      Each name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character). NOTE: "Name" is being deprecated
+                                      in favor of "Names".'
+                                    items:
+                                      type: string
+                                    type: array
+                                  namespaceSelector:
+                                    description: 'NamespaceSelector is a label selector
+                                      for the resource namespace. Label keys and values
+                                      in `matchLabels` support the wildcard characters
+                                      `*` (matches zero or many characters) and `?`
+                                      (matches one character).Wildcards allows writing
+                                      label selectors like ["storage.k8s.io/*": "*"].
+                                      Note that using ["*" : "*"] matches any key
+                                      and value but does not match an empty label
+                                      set.'
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: Namespaces is a list of namespaces
+                                      names. Each name supports wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (at least one character).
+                                    items:
+                                      type: string
+                                    type: array
+                                  selector:
+                                    description: 'Selector is a label selector. Label
+                                      keys and values in `matchLabels` support the
+                                      wildcard characters `*` (matches zero or many
+                                      characters) and `?` (matches one character).
+                                      Wildcards allows writing label selectors like
+                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                      : "*"] matches any key and value but does not
+                                      match an empty label set.'
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                type: object
+                              roles:
+                                description: Roles is the list of namespaced role
+                                  names for the user.
+                                items:
+                                  type: string
+                                type: array
+                              subjects:
+                                description: Subjects is the list of subject names
+                                  like users, user groups, and service accounts.
+                                items:
+                                  description: Subject contains a reference to the
+                                    object or user identities a role binding applies
+                                    to.  This can either hold a direct API object
+                                    reference, or a value for non-objects such as
+                                    user and group names.
+                                  properties:
+                                    apiGroup:
+                                      description: APIGroup holds the API group of
+                                        the referenced subject. Defaults to "" for
+                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
+                                        for User and Group subjects.
+                                      type: string
+                                    kind:
+                                      description: Kind of object being referenced.
+                                        Values defined by this API group are "User",
+                                        "Group", and "ServiceAccount". If the Authorizer
+                                        does not recognized the kind value, the Authorizer
+                                        should report an error.
+                                      type: string
+                                    name:
+                                      description: Name of the object being referenced.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the referenced object.  If
+                                        the object kind is non-namespace, such as
+                                        "User" or "Group", and this value is not empty
+                                        the Authorizer should report an error.
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                type: array
+                            type: object
+                          type: array
+                        clusterRoles:
+                          description: ClusterRoles is the list of cluster-wide role
+                            names for the user.
+                          items:
+                            type: string
+                          type: array
+                        resources:
+                          description: ResourceDescription contains information about
+                            the resource being created or modified. Specifying ResourceDescription
+                            directly under exclude is being deprecated. Please specify
+                            under "any" or "all" instead.
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a  map of annotations (key-value
+                                pairs of type string). Annotation keys and values
+                                support the wildcard characters "*" (matches zero
+                                or many characters) and "?" (matches at least one
+                                character).
+                              type: object
+                            kinds:
+                              description: Kinds is a list of resource kinds.
+                              items:
+                                type: string
+                              type: array
+                            name:
+                              description: Name is the name of the resource. The name
+                                supports wildcard characters "*" (matches zero or
+                                many characters) and "?" (at least one character).
+                              type: string
+                            names:
+                              description: 'Names are the names of the resources.
+                                Each name supports wildcard characters "*" (matches
+                                zero or many characters) and "?" (at least one character).
+                                NOTE: "Name" is being deprecated in favor of "Names".'
+                              items:
+                                type: string
+                              type: array
+                            namespaceSelector:
+                              description: 'NamespaceSelector is a label selector
+                                for the resource namespace. Label keys and values
+                                in `matchLabels` support the wildcard characters `*`
+                                (matches zero or many characters) and `?` (matches
+                                one character).Wildcards allows writing label selectors
+                                like ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                : "*"] matches any key and value but does not match
+                                an empty label set.'
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaces:
+                              description: Namespaces is a list of namespaces names.
+                                Each name supports wildcard characters "*" (matches
+                                zero or many characters) and "?" (at least one character).
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: 'Selector is a label selector. Label keys
+                                and values in `matchLabels` support the wildcard characters
+                                `*` (matches zero or many characters) and `?` (matches
+                                one character). Wildcards allows writing label selectors
+                                like ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                : "*"] matches any key and value but does not match
+                                an empty label set.'
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                          type: object
+                        roles:
+                          description: Roles is the list of namespaced role names
+                            for the user.
+                          items:
+                            type: string
+                          type: array
+                        subjects:
+                          description: Subjects is the list of subject names like
+                            users, user groups, and service accounts.
+                          items:
+                            description: Subject contains a reference to the object
+                              or user identities a role binding applies to.  This
+                              can either hold a direct API object reference, or a
+                              value for non-objects such as user and group names.
+                            properties:
+                              apiGroup:
+                                description: APIGroup holds the API group of the referenced
+                                  subject. Defaults to "" for ServiceAccount subjects.
+                                  Defaults to "rbac.authorization.k8s.io" for User
+                                  and Group subjects.
+                                type: string
+                              kind:
+                                description: Kind of object being referenced. Values
+                                  defined by this API group are "User", "Group", and
+                                  "ServiceAccount". If the Authorizer does not recognized
+                                  the kind value, the Authorizer should report an
+                                  error.
+                                type: string
+                              name:
+                                description: Name of the object being referenced.
+                                type: string
+                              namespace:
+                                description: Namespace of the referenced object.  If
+                                  the object kind is non-namespace, such as "User"
+                                  or "Group", and this value is not empty the Authorizer
+                                  should report an error.
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                          type: array
+                      type: object
+                    generate:
+                      description: Generation is used to create new resources.
+                      properties:
+                        apiVersion:
+                          description: APIVersion specifies resource apiVersion.
+                          type: string
+                        clone:
+                          description: Clone specifies the source resource used to
+                            populate each generated resource. At most one of Data
+                            or Clone can be specified. If neither are provided, the
+                            generated resource will be created with default data only.
+                          properties:
+                            name:
+                              description: Name specifies name of the resource.
+                              type: string
+                            namespace:
+                              description: Namespace specifies source resource namespace.
+                              type: string
+                          type: object
+                        data:
+                          description: Data provides the resource declaration used
+                            to populate each generated resource. At most one of Data
+                            or Clone must be specified. If neither are provided, the
+                            generated resource will be created with default data only.
+                          x-kubernetes-preserve-unknown-fields: true
+                        kind:
+                          description: Kind specifies resource kind.
+                          type: string
+                        name:
+                          description: Name specifies the resource name.
+                          type: string
+                        namespace:
+                          description: Namespace specifies resource namespace.
+                          type: string
+                        synchronize:
+                          description: Synchronize controls if generated resources
+                            should be kept in-sync with their source resource. If
+                            Synchronize is set to "true" changes to generated resources
+                            will be overwritten with resource data from Data or the
+                            resource specified in the Clone declaration. Optional.
+                            Defaults to "false" if not specified.
+                          type: boolean
+                      type: object
+                    match:
+                      description: MatchResources defines when this policy rule should
+                        be applied. The match criteria can include resource information
+                        (e.g. kind, name, namespace, labels) and admission review
+                        request information like the user name or role. At least one
+                        kind is required.
+                      properties:
+                        all:
+                          description: All allows specifying resources which will
+                            be ANDed
+                          items:
+                            description: ResourceFilter allow users to "AND" or "OR"
+                              between resources
+                            properties:
+                              clusterRoles:
+                                description: ClusterRoles is the list of cluster-wide
+                                  role names for the user.
+                                items:
+                                  type: string
+                                type: array
+                              resources:
+                                description: ResourceDescription contains information
+                                  about the resource being created or modified.
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations is a  map of annotations
+                                      (key-value pairs of type string). Annotation
+                                      keys and values support the wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (matches at least one character).
+                                    type: object
+                                  kinds:
+                                    description: Kinds is a list of resource kinds.
+                                    items:
+                                      type: string
+                                    type: array
+                                  name:
+                                    description: Name is the name of the resource.
+                                      The name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character).
+                                    type: string
+                                  names:
+                                    description: 'Names are the names of the resources.
+                                      Each name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character). NOTE: "Name" is being deprecated
+                                      in favor of "Names".'
+                                    items:
+                                      type: string
+                                    type: array
+                                  namespaceSelector:
+                                    description: 'NamespaceSelector is a label selector
+                                      for the resource namespace. Label keys and values
+                                      in `matchLabels` support the wildcard characters
+                                      `*` (matches zero or many characters) and `?`
+                                      (matches one character).Wildcards allows writing
+                                      label selectors like ["storage.k8s.io/*": "*"].
+                                      Note that using ["*" : "*"] matches any key
+                                      and value but does not match an empty label
+                                      set.'
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: Namespaces is a list of namespaces
+                                      names. Each name supports wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (at least one character).
+                                    items:
+                                      type: string
+                                    type: array
+                                  selector:
+                                    description: 'Selector is a label selector. Label
+                                      keys and values in `matchLabels` support the
+                                      wildcard characters `*` (matches zero or many
+                                      characters) and `?` (matches one character).
+                                      Wildcards allows writing label selectors like
+                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                      : "*"] matches any key and value but does not
+                                      match an empty label set.'
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                type: object
+                              roles:
+                                description: Roles is the list of namespaced role
+                                  names for the user.
+                                items:
+                                  type: string
+                                type: array
+                              subjects:
+                                description: Subjects is the list of subject names
+                                  like users, user groups, and service accounts.
+                                items:
+                                  description: Subject contains a reference to the
+                                    object or user identities a role binding applies
+                                    to.  This can either hold a direct API object
+                                    reference, or a value for non-objects such as
+                                    user and group names.
+                                  properties:
+                                    apiGroup:
+                                      description: APIGroup holds the API group of
+                                        the referenced subject. Defaults to "" for
+                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
+                                        for User and Group subjects.
+                                      type: string
+                                    kind:
+                                      description: Kind of object being referenced.
+                                        Values defined by this API group are "User",
+                                        "Group", and "ServiceAccount". If the Authorizer
+                                        does not recognized the kind value, the Authorizer
+                                        should report an error.
+                                      type: string
+                                    name:
+                                      description: Name of the object being referenced.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the referenced object.  If
+                                        the object kind is non-namespace, such as
+                                        "User" or "Group", and this value is not empty
+                                        the Authorizer should report an error.
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                type: array
+                            type: object
+                          type: array
+                        any:
+                          description: Any allows specifying resources which will
+                            be ORed
+                          items:
+                            description: ResourceFilter allow users to "AND" or "OR"
+                              between resources
+                            properties:
+                              clusterRoles:
+                                description: ClusterRoles is the list of cluster-wide
+                                  role names for the user.
+                                items:
+                                  type: string
+                                type: array
+                              resources:
+                                description: ResourceDescription contains information
+                                  about the resource being created or modified.
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations is a  map of annotations
+                                      (key-value pairs of type string). Annotation
+                                      keys and values support the wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (matches at least one character).
+                                    type: object
+                                  kinds:
+                                    description: Kinds is a list of resource kinds.
+                                    items:
+                                      type: string
+                                    type: array
+                                  name:
+                                    description: Name is the name of the resource.
+                                      The name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character).
+                                    type: string
+                                  names:
+                                    description: 'Names are the names of the resources.
+                                      Each name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character). NOTE: "Name" is being deprecated
+                                      in favor of "Names".'
+                                    items:
+                                      type: string
+                                    type: array
+                                  namespaceSelector:
+                                    description: 'NamespaceSelector is a label selector
+                                      for the resource namespace. Label keys and values
+                                      in `matchLabels` support the wildcard characters
+                                      `*` (matches zero or many characters) and `?`
+                                      (matches one character).Wildcards allows writing
+                                      label selectors like ["storage.k8s.io/*": "*"].
+                                      Note that using ["*" : "*"] matches any key
+                                      and value but does not match an empty label
+                                      set.'
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: Namespaces is a list of namespaces
+                                      names. Each name supports wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (at least one character).
+                                    items:
+                                      type: string
+                                    type: array
+                                  selector:
+                                    description: 'Selector is a label selector. Label
+                                      keys and values in `matchLabels` support the
+                                      wildcard characters `*` (matches zero or many
+                                      characters) and `?` (matches one character).
+                                      Wildcards allows writing label selectors like
+                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                      : "*"] matches any key and value but does not
+                                      match an empty label set.'
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                type: object
+                              roles:
+                                description: Roles is the list of namespaced role
+                                  names for the user.
+                                items:
+                                  type: string
+                                type: array
+                              subjects:
+                                description: Subjects is the list of subject names
+                                  like users, user groups, and service accounts.
+                                items:
+                                  description: Subject contains a reference to the
+                                    object or user identities a role binding applies
+                                    to.  This can either hold a direct API object
+                                    reference, or a value for non-objects such as
+                                    user and group names.
+                                  properties:
+                                    apiGroup:
+                                      description: APIGroup holds the API group of
+                                        the referenced subject. Defaults to "" for
+                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
+                                        for User and Group subjects.
+                                      type: string
+                                    kind:
+                                      description: Kind of object being referenced.
+                                        Values defined by this API group are "User",
+                                        "Group", and "ServiceAccount". If the Authorizer
+                                        does not recognized the kind value, the Authorizer
+                                        should report an error.
+                                      type: string
+                                    name:
+                                      description: Name of the object being referenced.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the referenced object.  If
+                                        the object kind is non-namespace, such as
+                                        "User" or "Group", and this value is not empty
+                                        the Authorizer should report an error.
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                type: array
+                            type: object
+                          type: array
+                        clusterRoles:
+                          description: ClusterRoles is the list of cluster-wide role
+                            names for the user.
+                          items:
+                            type: string
+                          type: array
+                        resources:
+                          description: ResourceDescription contains information about
+                            the resource being created or modified. Requires at least
+                            one tag to be specified when under MatchResources. Specifying
+                            ResourceDescription directly under match is being deprecated.
+                            Please specify under "any" or "all" instead.
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a  map of annotations (key-value
+                                pairs of type string). Annotation keys and values
+                                support the wildcard characters "*" (matches zero
+                                or many characters) and "?" (matches at least one
+                                character).
+                              type: object
+                            kinds:
+                              description: Kinds is a list of resource kinds.
+                              items:
+                                type: string
+                              type: array
+                            name:
+                              description: Name is the name of the resource. The name
+                                supports wildcard characters "*" (matches zero or
+                                many characters) and "?" (at least one character).
+                              type: string
+                            names:
+                              description: 'Names are the names of the resources.
+                                Each name supports wildcard characters "*" (matches
+                                zero or many characters) and "?" (at least one character).
+                                NOTE: "Name" is being deprecated in favor of "Names".'
+                              items:
+                                type: string
+                              type: array
+                            namespaceSelector:
+                              description: 'NamespaceSelector is a label selector
+                                for the resource namespace. Label keys and values
+                                in `matchLabels` support the wildcard characters `*`
+                                (matches zero or many characters) and `?` (matches
+                                one character).Wildcards allows writing label selectors
+                                like ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                : "*"] matches any key and value but does not match
+                                an empty label set.'
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaces:
+                              description: Namespaces is a list of namespaces names.
+                                Each name supports wildcard characters "*" (matches
+                                zero or many characters) and "?" (at least one character).
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: 'Selector is a label selector. Label keys
+                                and values in `matchLabels` support the wildcard characters
+                                `*` (matches zero or many characters) and `?` (matches
+                                one character). Wildcards allows writing label selectors
+                                like ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                : "*"] matches any key and value but does not match
+                                an empty label set.'
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                          type: object
+                        roles:
+                          description: Roles is the list of namespaced role names
+                            for the user.
+                          items:
+                            type: string
+                          type: array
+                        subjects:
+                          description: Subjects is the list of subject names like
+                            users, user groups, and service accounts.
+                          items:
+                            description: Subject contains a reference to the object
+                              or user identities a role binding applies to.  This
+                              can either hold a direct API object reference, or a
+                              value for non-objects such as user and group names.
+                            properties:
+                              apiGroup:
+                                description: APIGroup holds the API group of the referenced
+                                  subject. Defaults to "" for ServiceAccount subjects.
+                                  Defaults to "rbac.authorization.k8s.io" for User
+                                  and Group subjects.
+                                type: string
+                              kind:
+                                description: Kind of object being referenced. Values
+                                  defined by this API group are "User", "Group", and
+                                  "ServiceAccount". If the Authorizer does not recognized
+                                  the kind value, the Authorizer should report an
+                                  error.
+                                type: string
+                              name:
+                                description: Name of the object being referenced.
+                                type: string
+                              namespace:
+                                description: Namespace of the referenced object.  If
+                                  the object kind is non-namespace, such as "User"
+                                  or "Group", and this value is not empty the Authorizer
+                                  should report an error.
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                          type: array
+                      type: object
+                    mutate:
+                      description: Mutation is used to modify matching resources.
+                      properties:
+                        foreach:
+                          description: ForEachMutation applies policy rule changes
+                            to nested elements.
+                          items:
+                            description: ForEachMutation applies policy rule changes
+                              to nested elements.
+                            properties:
+                              context:
+                                description: Context defines variables and data sources
+                                  that can be used during rule execution.
+                                items:
+                                  description: ContextEntry adds variables and data
+                                    sources to a rule Context. Either a ConfigMap
+                                    reference or a APILookup must be provided.
+                                  properties:
+                                    apiCall:
+                                      description: APICall defines an HTTP request
+                                        to the Kubernetes API server. The JSON data
+                                        retrieved is stored in the context.
+                                      properties:
+                                        jmesPath:
+                                          description: JMESPath is an optional JSON
+                                            Match Expression that can be used to transform
+                                            the JSON response returned from the API
+                                            server. For example a JMESPath of "items
+                                            | length(@)" applied to the API server
+                                            response to the URLPath "/apis/apps/v1/deployments"
+                                            will return the total count of deployments
+                                            across all namespaces.
+                                          type: string
+                                        urlPath:
+                                          description: URLPath is the URL path to
+                                            be used in the HTTP GET request to the
+                                            Kubernetes API server (e.g. "/api/v1/namespaces"
+                                            or  "/apis/apps/v1/deployments"). The
+                                            format required is the same format used
+                                            by the `kubectl get --raw` command.
+                                          type: string
+                                      required:
+                                      - urlPath
+                                      type: object
+                                    configMap:
+                                      description: ConfigMap is the ConfigMap reference.
+                                      properties:
+                                        name:
+                                          description: Name is the ConfigMap name.
+                                          type: string
+                                        namespace:
+                                          description: Namespace is the ConfigMap
+                                            namespace.
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    imageRegistry:
+                                      description: ImageRegistry defines requests
+                                        to an OCI/Docker V2 registry to fetch image
+                                        details.
+                                      properties:
+                                        jmesPath:
+                                          description: JMESPath is an optional JSON
+                                            Match Expression that can be used to transform
+                                            the ImageData struct returned as a result
+                                            of processing the image reference.
+                                          type: string
+                                        reference:
+                                          description: 'Reference is image reference
+                                            to a container image in the registry.
+                                            Example: ghcr.io/kyverno/kyverno:latest'
+                                          type: string
+                                      required:
+                                      - reference
+                                      type: object
+                                    name:
+                                      description: Name is the variable name.
+                                      type: string
+                                  type: object
+                                type: array
+                              list:
+                                description: List specifies a JMESPath expression
+                                  that results in one or more elements to which the
+                                  validation logic is applied.
+                                type: string
+                              patchStrategicMerge:
+                                description: PatchStrategicMerge is a strategic merge
+                                  patch used to modify resources. See https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/
+                                  and https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.
+                                x-kubernetes-preserve-unknown-fields: true
+                              patchesJson6902:
+                                description: PatchesJSON6902 is a list of RFC 6902
+                                  JSON Patch declarations used to modify resources.
+                                  See https://tools.ietf.org/html/rfc6902 and https://kubectl.docs.kubernetes.io/references/kustomize/patchesjson6902/.
+                                type: string
+                              preconditions:
+                                description: 'AnyAllConditions are used to determine
+                                  if a policy rule should be applied by evaluating
+                                  a set of conditions. The declaration can contain
+                                  nested `any` or `all` statements. See: https://kyverno.io/docs/writing-policies/preconditions/'
+                                properties:
+                                  all:
+                                    description: AllConditions enable variable-based
+                                      conditional rule execution. This is useful for
+                                      finer control of when an rule is applied. A
+                                      condition can reference object data using JMESPath
+                                      notation. Here, all of the conditions need to
+                                      pass
+                                    items:
+                                      description: Condition defines variable-based
+                                        conditional criteria for rule execution.
+                                      properties:
+                                        key:
+                                          description: Key is the context entry (using
+                                            JMESPath) for conditional rule evaluation.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                        operator:
+                                          description: 'Operator is the conditional
+                                            operation to perform. Valid operators
+                                            are: Equals, NotEquals, In, AnyIn, AllIn,
+                                            NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,
+                                            GreaterThan, LessThanOrEquals, LessThan,
+                                            DurationGreaterThanOrEquals, DurationGreaterThan,
+                                            DurationLessThanOrEquals, DurationLessThan'
+                                          enum:
+                                          - Equals
+                                          - NotEquals
+                                          - In
+                                          - AnyIn
+                                          - AllIn
+                                          - NotIn
+                                          - AnyNotIn
+                                          - AllNotIn
+                                          - GreaterThanOrEquals
+                                          - GreaterThan
+                                          - LessThanOrEquals
+                                          - LessThan
+                                          - DurationGreaterThanOrEquals
+                                          - DurationGreaterThan
+                                          - DurationLessThanOrEquals
+                                          - DurationLessThan
+                                          type: string
+                                        value:
+                                          description: Value is the conditional value,
+                                            or set of values. The values can be fixed
+                                            set or can be variables declared using
+                                            using JMESPath.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                    type: array
+                                  any:
+                                    description: AnyConditions enable variable-based
+                                      conditional rule execution. This is useful for
+                                      finer control of when an rule is applied. A
+                                      condition can reference object data using JMESPath
+                                      notation. Here, at least one of the conditions
+                                      need to pass
+                                    items:
+                                      description: Condition defines variable-based
+                                        conditional criteria for rule execution.
+                                      properties:
+                                        key:
+                                          description: Key is the context entry (using
+                                            JMESPath) for conditional rule evaluation.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                        operator:
+                                          description: 'Operator is the conditional
+                                            operation to perform. Valid operators
+                                            are: Equals, NotEquals, In, AnyIn, AllIn,
+                                            NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,
+                                            GreaterThan, LessThanOrEquals, LessThan,
+                                            DurationGreaterThanOrEquals, DurationGreaterThan,
+                                            DurationLessThanOrEquals, DurationLessThan'
+                                          enum:
+                                          - Equals
+                                          - NotEquals
+                                          - In
+                                          - AnyIn
+                                          - AllIn
+                                          - NotIn
+                                          - AnyNotIn
+                                          - AllNotIn
+                                          - GreaterThanOrEquals
+                                          - GreaterThan
+                                          - LessThanOrEquals
+                                          - LessThan
+                                          - DurationGreaterThanOrEquals
+                                          - DurationGreaterThan
+                                          - DurationLessThanOrEquals
+                                          - DurationLessThan
+                                          type: string
+                                        value:
+                                          description: Value is the conditional value,
+                                            or set of values. The values can be fixed
+                                            set or can be variables declared using
+                                            using JMESPath.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                    type: array
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          type: array
+                        patchStrategicMerge:
+                          description: PatchStrategicMerge is a strategic merge patch
+                            used to modify resources. See https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/
+                            and https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.
+                          x-kubernetes-preserve-unknown-fields: true
+                        patchesJson6902:
+                          description: PatchesJSON6902 is a list of RFC 6902 JSON
+                            Patch declarations used to modify resources. See https://tools.ietf.org/html/rfc6902
+                            and https://kubectl.docs.kubernetes.io/references/kustomize/patchesjson6902/.
+                          type: string
+                      type: object
+                    name:
+                      description: Name is a label to identify the rule, It must be
+                        unique within the policy.
+                      maxLength: 63
+                      type: string
+                    preconditions:
+                      description: 'Preconditions are used to determine if a policy
+                        rule should be applied by evaluating a set of conditions.
+                        The declaration can contain nested `any` or `all` statements.
+                        A direct list of conditions (without `any` or `all` statements
+                        is supported for backwards compatibility but will be deprecated
+                        in the next major release. See: https://kyverno.io/docs/writing-policies/preconditions/'
+                      x-kubernetes-preserve-unknown-fields: true
+                    validate:
+                      description: Validation is used to validate matching resources.
+                      properties:
+                        anyPattern:
+                          description: AnyPattern specifies list of validation patterns.
+                            At least one of the patterns must be satisfied for the
+                            validation rule to succeed.
+                          x-kubernetes-preserve-unknown-fields: true
+                        deny:
+                          description: Deny defines conditions used to pass or fail
+                            a validation rule.
+                          properties:
+                            conditions:
+                              description: 'Multiple conditions can be declared under
+                                an `any` or `all` statement. A direct list of conditions
+                                (without `any` or `all` statements) is also supported
+                                for backwards compatibility but will be deprecated
+                                in the next major release. See: https://kyverno.io/docs/writing-policies/validate/#deny-rules'
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                        foreach:
+                          description: ForEach applies policy rule changes to nested
+                            elements.
+                          items:
+                            description: ForEachValidation applies policy rule checks
+                              to nested elements.
+                            properties:
+                              anyPattern:
+                                description: AnyPattern specifies list of validation
+                                  patterns. At least one of the patterns must be satisfied
+                                  for the validation rule to succeed.
+                                x-kubernetes-preserve-unknown-fields: true
+                              context:
+                                description: Context defines variables and data sources
+                                  that can be used during rule execution.
+                                items:
+                                  description: ContextEntry adds variables and data
+                                    sources to a rule Context. Either a ConfigMap
+                                    reference or a APILookup must be provided.
+                                  properties:
+                                    apiCall:
+                                      description: APICall defines an HTTP request
+                                        to the Kubernetes API server. The JSON data
+                                        retrieved is stored in the context.
+                                      properties:
+                                        jmesPath:
+                                          description: JMESPath is an optional JSON
+                                            Match Expression that can be used to transform
+                                            the JSON response returned from the API
+                                            server. For example a JMESPath of "items
+                                            | length(@)" applied to the API server
+                                            response to the URLPath "/apis/apps/v1/deployments"
+                                            will return the total count of deployments
+                                            across all namespaces.
+                                          type: string
+                                        urlPath:
+                                          description: URLPath is the URL path to
+                                            be used in the HTTP GET request to the
+                                            Kubernetes API server (e.g. "/api/v1/namespaces"
+                                            or  "/apis/apps/v1/deployments"). The
+                                            format required is the same format used
+                                            by the `kubectl get --raw` command.
+                                          type: string
+                                      required:
+                                      - urlPath
+                                      type: object
+                                    configMap:
+                                      description: ConfigMap is the ConfigMap reference.
+                                      properties:
+                                        name:
+                                          description: Name is the ConfigMap name.
+                                          type: string
+                                        namespace:
+                                          description: Namespace is the ConfigMap
+                                            namespace.
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    imageRegistry:
+                                      description: ImageRegistry defines requests
+                                        to an OCI/Docker V2 registry to fetch image
+                                        details.
+                                      properties:
+                                        jmesPath:
+                                          description: JMESPath is an optional JSON
+                                            Match Expression that can be used to transform
+                                            the ImageData struct returned as a result
+                                            of processing the image reference.
+                                          type: string
+                                        reference:
+                                          description: 'Reference is image reference
+                                            to a container image in the registry.
+                                            Example: ghcr.io/kyverno/kyverno:latest'
+                                          type: string
+                                      required:
+                                      - reference
+                                      type: object
+                                    name:
+                                      description: Name is the variable name.
+                                      type: string
+                                  type: object
+                                type: array
+                              deny:
+                                description: Deny defines conditions used to pass
+                                  or fail a validation rule.
+                                properties:
+                                  conditions:
+                                    description: 'Multiple conditions can be declared
+                                      under an `any` or `all` statement. A direct
+                                      list of conditions (without `any` or `all` statements)
+                                      is also supported for backwards compatibility
+                                      but will be deprecated in the next major release.
+                                      See: https://kyverno.io/docs/writing-policies/validate/#deny-rules'
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              elementScope:
+                                description: ElementScope specifies whether to use
+                                  the current list element as the scope for validation.
+                                  Defaults to "true" if not specified. When set to
+                                  "false", "request.object" is used as the validation
+                                  scope within the foreach block to allow referencing
+                                  other elements in the subtree.
+                                type: boolean
+                              list:
+                                description: List specifies a JMESPath expression
+                                  that results in one or more elements to which the
+                                  validation logic is applied.
+                                type: string
+                              pattern:
+                                description: Pattern specifies an overlay-style pattern
+                                  used to check resources.
+                                x-kubernetes-preserve-unknown-fields: true
+                              preconditions:
+                                description: 'AnyAllConditions are used to determine
+                                  if a policy rule should be applied by evaluating
+                                  a set of conditions. The declaration can contain
+                                  nested `any` or `all` statements. See: https://kyverno.io/docs/writing-policies/preconditions/'
+                                properties:
+                                  all:
+                                    description: AllConditions enable variable-based
+                                      conditional rule execution. This is useful for
+                                      finer control of when an rule is applied. A
+                                      condition can reference object data using JMESPath
+                                      notation. Here, all of the conditions need to
+                                      pass
+                                    items:
+                                      description: Condition defines variable-based
+                                        conditional criteria for rule execution.
+                                      properties:
+                                        key:
+                                          description: Key is the context entry (using
+                                            JMESPath) for conditional rule evaluation.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                        operator:
+                                          description: 'Operator is the conditional
+                                            operation to perform. Valid operators
+                                            are: Equals, NotEquals, In, AnyIn, AllIn,
+                                            NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,
+                                            GreaterThan, LessThanOrEquals, LessThan,
+                                            DurationGreaterThanOrEquals, DurationGreaterThan,
+                                            DurationLessThanOrEquals, DurationLessThan'
+                                          enum:
+                                          - Equals
+                                          - NotEquals
+                                          - In
+                                          - AnyIn
+                                          - AllIn
+                                          - NotIn
+                                          - AnyNotIn
+                                          - AllNotIn
+                                          - GreaterThanOrEquals
+                                          - GreaterThan
+                                          - LessThanOrEquals
+                                          - LessThan
+                                          - DurationGreaterThanOrEquals
+                                          - DurationGreaterThan
+                                          - DurationLessThanOrEquals
+                                          - DurationLessThan
+                                          type: string
+                                        value:
+                                          description: Value is the conditional value,
+                                            or set of values. The values can be fixed
+                                            set or can be variables declared using
+                                            using JMESPath.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                    type: array
+                                  any:
+                                    description: AnyConditions enable variable-based
+                                      conditional rule execution. This is useful for
+                                      finer control of when an rule is applied. A
+                                      condition can reference object data using JMESPath
+                                      notation. Here, at least one of the conditions
+                                      need to pass
+                                    items:
+                                      description: Condition defines variable-based
+                                        conditional criteria for rule execution.
+                                      properties:
+                                        key:
+                                          description: Key is the context entry (using
+                                            JMESPath) for conditional rule evaluation.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                        operator:
+                                          description: 'Operator is the conditional
+                                            operation to perform. Valid operators
+                                            are: Equals, NotEquals, In, AnyIn, AllIn,
+                                            NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,
+                                            GreaterThan, LessThanOrEquals, LessThan,
+                                            DurationGreaterThanOrEquals, DurationGreaterThan,
+                                            DurationLessThanOrEquals, DurationLessThan'
+                                          enum:
+                                          - Equals
+                                          - NotEquals
+                                          - In
+                                          - AnyIn
+                                          - AllIn
+                                          - NotIn
+                                          - AnyNotIn
+                                          - AllNotIn
+                                          - GreaterThanOrEquals
+                                          - GreaterThan
+                                          - LessThanOrEquals
+                                          - LessThan
+                                          - DurationGreaterThanOrEquals
+                                          - DurationGreaterThan
+                                          - DurationLessThanOrEquals
+                                          - DurationLessThan
+                                          type: string
+                                        value:
+                                          description: Value is the conditional value,
+                                            or set of values. The values can be fixed
+                                            set or can be variables declared using
+                                            using JMESPath.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                    type: array
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          type: array
+                        message:
+                          description: Message specifies a custom message to be displayed
+                            on failure.
+                          type: string
+                        pattern:
+                          description: Pattern specifies an overlay-style pattern
+                            used to check resources.
+                          x-kubernetes-preserve-unknown-fields: true
+                      type: object
+                    verifyImages:
+                      description: VerifyImages is used to verify image signatures
+                        and mutate them to add a digest
+                      items:
+                        description: ImageVerification validates that images that
+                          match the specified pattern are signed with the supplied
+                          public key. Once the image is verified it is mutated to
+                          include the SHA digest retrieved during the registration.
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: Annotations are used for image verification.
+                              Every specified key-value pair must exist and match
+                              in the verified payload. The payload may contain other
+                              key-value pairs.
+                            type: object
+                          attestations:
+                            description: Attestations are optional checks for signed
+                              in-toto Statements used to verify the image. See https://github.com/in-toto/attestation.
+                              Kyverno fetches signed attestations from the OCI registry
+                              and decodes them into a list of Statement declarations.
+                            items:
+                              description: Attestation are checks for signed in-toto
+                                Statements that are used to verify the image. See
+                                https://github.com/in-toto/attestation. Kyverno fetches
+                                signed attestations from the OCI registry and decodes
+                                them into a list of Statements.
+                              properties:
+                                conditions:
+                                  description: Conditions are used to verify attributes
+                                    within a Predicate. If no Conditions are specified
+                                    the attestation check is satisfied as long there
+                                    are predicates that match the predicate type.
+                                  items:
+                                    description: AnyAllConditions consists of conditions
+                                      wrapped denoting a logical criteria to be fulfilled.
+                                      AnyConditions get fulfilled when at least one
+                                      of its sub-conditions passes. AllConditions
+                                      get fulfilled only when all of its sub-conditions
+                                      pass.
+                                    properties:
+                                      all:
+                                        description: AllConditions enable variable-based
+                                          conditional rule execution. This is useful
+                                          for finer control of when an rule is applied.
+                                          A condition can reference object data using
+                                          JMESPath notation. Here, all of the conditions
+                                          need to pass
+                                        items:
+                                          description: Condition defines variable-based
+                                            conditional criteria for rule execution.
+                                          properties:
+                                            key:
+                                              description: Key is the context entry
+                                                (using JMESPath) for conditional rule
+                                                evaluation.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            operator:
+                                              description: 'Operator is the conditional
+                                                operation to perform. Valid operators
+                                                are: Equals, NotEquals, In, AnyIn,
+                                                AllIn, NotIn, AnyNotIn, AllNotIn,
+                                                GreaterThanOrEquals, GreaterThan,
+                                                LessThanOrEquals, LessThan, DurationGreaterThanOrEquals,
+                                                DurationGreaterThan, DurationLessThanOrEquals,
+                                                DurationLessThan'
+                                              enum:
+                                              - Equals
+                                              - NotEquals
+                                              - In
+                                              - AnyIn
+                                              - AllIn
+                                              - NotIn
+                                              - AnyNotIn
+                                              - AllNotIn
+                                              - GreaterThanOrEquals
+                                              - GreaterThan
+                                              - LessThanOrEquals
+                                              - LessThan
+                                              - DurationGreaterThanOrEquals
+                                              - DurationGreaterThan
+                                              - DurationLessThanOrEquals
+                                              - DurationLessThan
+                                              type: string
+                                            value:
+                                              description: Value is the conditional
+                                                value, or set of values. The values
+                                                can be fixed set or can be variables
+                                                declared using using JMESPath.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                        type: array
+                                      any:
+                                        description: AnyConditions enable variable-based
+                                          conditional rule execution. This is useful
+                                          for finer control of when an rule is applied.
+                                          A condition can reference object data using
+                                          JMESPath notation. Here, at least one of
+                                          the conditions need to pass
+                                        items:
+                                          description: Condition defines variable-based
+                                            conditional criteria for rule execution.
+                                          properties:
+                                            key:
+                                              description: Key is the context entry
+                                                (using JMESPath) for conditional rule
+                                                evaluation.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            operator:
+                                              description: 'Operator is the conditional
+                                                operation to perform. Valid operators
+                                                are: Equals, NotEquals, In, AnyIn,
+                                                AllIn, NotIn, AnyNotIn, AllNotIn,
+                                                GreaterThanOrEquals, GreaterThan,
+                                                LessThanOrEquals, LessThan, DurationGreaterThanOrEquals,
+                                                DurationGreaterThan, DurationLessThanOrEquals,
+                                                DurationLessThan'
+                                              enum:
+                                              - Equals
+                                              - NotEquals
+                                              - In
+                                              - AnyIn
+                                              - AllIn
+                                              - NotIn
+                                              - AnyNotIn
+                                              - AllNotIn
+                                              - GreaterThanOrEquals
+                                              - GreaterThan
+                                              - LessThanOrEquals
+                                              - LessThan
+                                              - DurationGreaterThanOrEquals
+                                              - DurationGreaterThan
+                                              - DurationLessThanOrEquals
+                                              - DurationLessThan
+                                              type: string
+                                            value:
+                                              description: Value is the conditional
+                                                value, or set of values. The values
+                                                can be fixed set or can be variables
+                                                declared using using JMESPath.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                        type: array
+                                    type: object
+                                  type: array
+                                predicateType:
+                                  description: PredicateType defines the type of Predicate
+                                    contained within the Statement.
+                                  type: string
+                              type: object
+                            type: array
+                          image:
+                            description: 'Image is the image name consisting of the
+                              registry address, repository, image, and tag. Wildcards
+                              (''*'' and ''?'') are allowed. See: https://kubernetes.io/docs/concepts/containers/images.'
+                            type: string
+                          issuer:
+                            description: Issuer is the certificate issuer used for
+                              keyless signing.
+                            type: string
+                          key:
+                            description: Key is the PEM encoded public key that the
+                              image or attestation is signed with.
+                            type: string
+                          repository:
+                            description: Repository is an optional alternate OCI repository
+                              to use for image signatures that match this rule. If
+                              specified Repository will override the default OCI image
+                              repository configured for the installation.
+                            type: string
+                          roots:
+                            description: Roots is the PEM encoded Root certificate
+                              chain used for keyless signing
+                            type: string
+                          subject:
+                            description: Subject is the verified identity used for
+                              keyless signing, for example the email address
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                type: array
+              schemaValidation:
+                description: SchemaValidation skips policy validation checks. Optional.
+                  The default value is set to "true", it must be set to "false" to
+                  disable the validation checks.
+                type: boolean
+              validationFailureAction:
+                description: ValidationFailureAction controls if a validation policy
+                  rule failure should disallow the admission review request (enforce),
+                  or allow (audit) the admission review request and report an error
+                  in a policy report. Optional. The default value is "audit".
+                enum:
+                - audit
+                - enforce
+                type: string
+              validationFailureActionOverrides:
+                description: ValidationFailureActionOverrides is a Cluter Policy attribute
+                  that specifies ValidationFailureAction namespace-wise. It overrides
+                  ValidationFailureAction for the specified namespaces.
+                items:
+                  properties:
+                    action:
+                      enum:
+                      - audit
+                      - enforce
+                      type: string
+                    namespaces:
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                type: array
+              webhookTimeoutSeconds:
+                description: WebhookTimeoutSeconds specifies the maximum time in seconds
+                  allowed to apply this policy. After the configured time expires,
+                  the admission request may fail, or may simply ignore the policy
+                  results, based on the failure policy. The default timeout is 10s,
+                  the value must be between 1 and 30 seconds.
+                format: int32
+                type: integer
+            type: object
+          status:
+            description: Status contains policy runtime information. Deprecated. Policy
+              metrics are available via the metrics endpoint
+            properties:
+              ready:
+                description: Ready indicates if the policy is ready to serve the admission
+                  request
+                type: boolean
+            required:
+            - ready
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/tests/golden/policies/kyverno/kyverno/00_crds/kyverno.io_reportchangerequests.yaml
+++ b/tests/golden/policies/kyverno/kyverno/00_crds/kyverno.io_reportchangerequests.yaml
@@ -1,0 +1,675 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.0
+  creationTimestamp: null
+  name: reportchangerequests.kyverno.io
+spec:
+  group: kyverno.io
+  names:
+    kind: ReportChangeRequest
+    listKind: ReportChangeRequestList
+    plural: reportchangerequests
+    shortNames:
+    - rcr
+    singular: reportchangerequest
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .scope.kind
+      name: Kind
+      priority: 1
+      type: string
+    - jsonPath: .scope.name
+      name: Name
+      priority: 1
+      type: string
+    - jsonPath: .summary.pass
+      name: Pass
+      type: integer
+    - jsonPath: .summary.fail
+      name: Fail
+      type: integer
+    - jsonPath: .summary.warn
+      name: Warn
+      type: integer
+    - jsonPath: .summary.error
+      name: Error
+      type: integer
+    - jsonPath: .summary.skip
+      name: Skip
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ReportChangeRequest is the Schema for the ReportChangeRequests
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          results:
+            description: PolicyReportResult provides result details
+            items:
+              description: PolicyReportResult provides the result for an individual
+                policy
+              properties:
+                category:
+                  description: Category indicates policy category
+                  type: string
+                data:
+                  additionalProperties:
+                    type: string
+                  description: Data provides additional information for the policy
+                    rule
+                  type: object
+                message:
+                  description: Message is a short user friendly description of the
+                    policy rule
+                  type: string
+                policy:
+                  description: Policy is the name of the policy
+                  type: string
+                resourceSelector:
+                  description: ResourceSelector is an optional selector for policy
+                    results that apply to multiple resources. For example, a policy
+                    result may apply to all pods that match a label. Either a Resource
+                    or a ResourceSelector can be specified. If neither are provided,
+                    the result is assumed to be for the policy report scope.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                resources:
+                  description: Resources is an optional reference to the resource
+                    checked by the policy and rule
+                  items:
+                    description: 'ObjectReference contains enough information to let
+                      you inspect or modify the referred object. --- New uses of this
+                      type are discouraged because of difficulty describing its usage
+                      when embedded in APIs.  1. Ignored fields.  It includes many
+                      fields which are not generally honored.  For instance, ResourceVersion
+                      and FieldPath are both very rarely valid in actual usage.  2.
+                      Invalid usage help.  It is impossible to add specific help for
+                      individual usage.  In most embedded usages, there are particular     restrictions
+                      like, "must refer only to types A and B" or "UID not honored"
+                      or "name must be restricted".     Those cannot be well described
+                      when embedded.  3. Inconsistent validation.  Because the usages
+                      are different, the validation rules are different by usage,
+                      which makes it hard for users to predict what will happen.  4.
+                      The fields are both imprecise and overly precise.  Kind is not
+                      a precise mapping to a URL. This can produce ambiguity     during
+                      interpretation and require a REST mapping.  In most cases, the
+                      dependency is on the group,resource tuple     and the version
+                      of the actual struct is irrelevant.  5. We cannot easily change
+                      it.  Because this type is embedded in many locations, updates
+                      to this type     will affect numerous schemas.  Don''t make
+                      new APIs embed an underspecified API type they do not control.
+                      Instead of using this type, create a locally provided and used
+                      type that is well-focused on your reference. For example, ServiceReferences
+                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                      .'
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object. TODO: this design is not final and this field
+                          is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                  type: array
+                rule:
+                  description: Rule is the name of the policy rule
+                  type: string
+                scored:
+                  description: Scored indicates if this policy rule is scored
+                  type: boolean
+                severity:
+                  description: Severity indicates policy severity
+                  enum:
+                  - high
+                  - low
+                  - medium
+                  type: string
+                status:
+                  description: Status indicates the result of the policy rule check
+                  enum:
+                  - pass
+                  - fail
+                  - warn
+                  - error
+                  - skip
+                  type: string
+              required:
+              - policy
+              type: object
+            type: array
+          scope:
+            description: Scope is an optional reference to the report scope (e.g.
+              a Deployment, Namespace, or Node)
+            properties:
+              apiVersion:
+                description: API version of the referent.
+                type: string
+              fieldPath:
+                description: 'If referring to a piece of an object instead of an entire
+                  object, this string should contain a valid JSON/Go field access
+                  statement, such as desiredState.manifest.containers[2]. For example,
+                  if the object reference is to a container within a pod, this would
+                  take on a value like: "spec.containers{name}" (where "name" refers
+                  to the name of the container that triggered the event) or if no
+                  container name is specified "spec.containers[2]" (container with
+                  index 2 in this pod). This syntax is chosen only to have some well-defined
+                  way of referencing a part of an object. TODO: this design is not
+                  final and this field is subject to change in the future.'
+                type: string
+              kind:
+                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              name:
+                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                type: string
+              namespace:
+                description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                type: string
+              resourceVersion:
+                description: 'Specific resourceVersion to which this reference is
+                  made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                type: string
+              uid:
+                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                type: string
+            type: object
+          scopeSelector:
+            description: ScopeSelector is an optional selector for multiple scopes
+              (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
+              should be specified.
+            properties:
+              matchExpressions:
+                description: matchExpressions is a list of label selector requirements.
+                  The requirements are ANDed.
+                items:
+                  description: A label selector requirement is a selector that contains
+                    values, a key, and an operator that relates the key and values.
+                  properties:
+                    key:
+                      description: key is the label key that the selector applies
+                        to.
+                      type: string
+                    operator:
+                      description: operator represents a key's relationship to a set
+                        of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                      type: string
+                    values:
+                      description: values is an array of string values. If the operator
+                        is In or NotIn, the values array must be non-empty. If the
+                        operator is Exists or DoesNotExist, the values array must
+                        be empty. This array is replaced during a strategic merge
+                        patch.
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - key
+                  - operator
+                  type: object
+                type: array
+              matchLabels:
+                additionalProperties:
+                  type: string
+                description: matchLabels is a map of {key,value} pairs. A single {key,value}
+                  in the matchLabels map is equivalent to an element of matchExpressions,
+                  whose key field is "key", the operator is "In", and the values array
+                  contains only "value". The requirements are ANDed.
+                type: object
+            type: object
+          summary:
+            description: PolicyReportSummary provides a summary of results
+            properties:
+              error:
+                description: Error provides the count of policies that could not be
+                  evaluated
+                type: integer
+              fail:
+                description: Fail provides the count of policies whose requirements
+                  were not met
+                type: integer
+              pass:
+                description: Pass provides the count of policies whose requirements
+                  were met
+                type: integer
+              skip:
+                description: Skip indicates the count of policies that were not selected
+                  for evaluation
+                type: integer
+              warn:
+                description: Warn provides the count of unscored policies whose requirements
+                  were not met
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources: {}
+  - additionalPrinterColumns:
+    - jsonPath: .scope.kind
+      name: Kind
+      priority: 1
+      type: string
+    - jsonPath: .scope.name
+      name: Name
+      priority: 1
+      type: string
+    - jsonPath: .summary.pass
+      name: Pass
+      type: integer
+    - jsonPath: .summary.fail
+      name: Fail
+      type: integer
+    - jsonPath: .summary.warn
+      name: Warn
+      type: integer
+    - jsonPath: .summary.error
+      name: Error
+      type: integer
+    - jsonPath: .summary.skip
+      name: Skip
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: ReportChangeRequest is the Schema for the ReportChangeRequests
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          results:
+            description: PolicyReportResult provides result details
+            items:
+              description: PolicyReportResult provides the result for an individual
+                policy
+              properties:
+                category:
+                  description: Category indicates policy category
+                  type: string
+                message:
+                  description: Message is a short user friendly description of the
+                    policy rule
+                  type: string
+                policy:
+                  description: Policy is the name of the policy
+                  type: string
+                properties:
+                  additionalProperties:
+                    type: string
+                  description: Properties provides additional information for the
+                    policy rule
+                  type: object
+                resourceSelector:
+                  description: ResourceSelector is an optional selector for policy
+                    results that apply to multiple resources. For example, a policy
+                    result may apply to all pods that match a label. Either a Resource
+                    or a ResourceSelector can be specified. If neither are provided,
+                    the result is assumed to be for the policy report scope.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                resources:
+                  description: Resources is an optional reference to the resource
+                    checked by the policy and rule
+                  items:
+                    description: 'ObjectReference contains enough information to let
+                      you inspect or modify the referred object. --- New uses of this
+                      type are discouraged because of difficulty describing its usage
+                      when embedded in APIs.  1. Ignored fields.  It includes many
+                      fields which are not generally honored.  For instance, ResourceVersion
+                      and FieldPath are both very rarely valid in actual usage.  2.
+                      Invalid usage help.  It is impossible to add specific help for
+                      individual usage.  In most embedded usages, there are particular     restrictions
+                      like, "must refer only to types A and B" or "UID not honored"
+                      or "name must be restricted".     Those cannot be well described
+                      when embedded.  3. Inconsistent validation.  Because the usages
+                      are different, the validation rules are different by usage,
+                      which makes it hard for users to predict what will happen.  4.
+                      The fields are both imprecise and overly precise.  Kind is not
+                      a precise mapping to a URL. This can produce ambiguity     during
+                      interpretation and require a REST mapping.  In most cases, the
+                      dependency is on the group,resource tuple     and the version
+                      of the actual struct is irrelevant.  5. We cannot easily change
+                      it.  Because this type is embedded in many locations, updates
+                      to this type     will affect numerous schemas.  Don''t make
+                      new APIs embed an underspecified API type they do not control.
+                      Instead of using this type, create a locally provided and used
+                      type that is well-focused on your reference. For example, ServiceReferences
+                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                      .'
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object. TODO: this design is not final and this field
+                          is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                  type: array
+                result:
+                  description: Result indicates the outcome of the policy rule execution
+                  enum:
+                  - pass
+                  - fail
+                  - warn
+                  - error
+                  - skip
+                  type: string
+                rule:
+                  description: Rule is the name of the policy rule
+                  type: string
+                scored:
+                  description: Scored indicates if this policy rule is scored
+                  type: boolean
+                severity:
+                  description: Severity indicates policy severity
+                  enum:
+                  - high
+                  - low
+                  - medium
+                  type: string
+                source:
+                  description: Source is an identifier for the policy engine that
+                    manages this report
+                  type: string
+                timestamp:
+                  description: Timestamp indicates the time the result was found
+                  properties:
+                    nanos:
+                      description: Non-negative fractions of a second at nanosecond
+                        resolution. Negative second values with fractions must still
+                        have non-negative nanos values that count forward in time.
+                        Must be from 0 to 999,999,999 inclusive. This field may be
+                        limited in precision depending on context.
+                      format: int32
+                      type: integer
+                    seconds:
+                      description: Represents seconds of UTC time since Unix epoch
+                        1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
+                        9999-12-31T23:59:59Z inclusive.
+                      format: int64
+                      type: integer
+                  required:
+                  - nanos
+                  - seconds
+                  type: object
+              required:
+              - policy
+              type: object
+            type: array
+          scope:
+            description: Scope is an optional reference to the report scope (e.g.
+              a Deployment, Namespace, or Node)
+            properties:
+              apiVersion:
+                description: API version of the referent.
+                type: string
+              fieldPath:
+                description: 'If referring to a piece of an object instead of an entire
+                  object, this string should contain a valid JSON/Go field access
+                  statement, such as desiredState.manifest.containers[2]. For example,
+                  if the object reference is to a container within a pod, this would
+                  take on a value like: "spec.containers{name}" (where "name" refers
+                  to the name of the container that triggered the event) or if no
+                  container name is specified "spec.containers[2]" (container with
+                  index 2 in this pod). This syntax is chosen only to have some well-defined
+                  way of referencing a part of an object. TODO: this design is not
+                  final and this field is subject to change in the future.'
+                type: string
+              kind:
+                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              name:
+                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                type: string
+              namespace:
+                description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                type: string
+              resourceVersion:
+                description: 'Specific resourceVersion to which this reference is
+                  made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                type: string
+              uid:
+                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                type: string
+            type: object
+          scopeSelector:
+            description: ScopeSelector is an optional selector for multiple scopes
+              (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
+              should be specified.
+            properties:
+              matchExpressions:
+                description: matchExpressions is a list of label selector requirements.
+                  The requirements are ANDed.
+                items:
+                  description: A label selector requirement is a selector that contains
+                    values, a key, and an operator that relates the key and values.
+                  properties:
+                    key:
+                      description: key is the label key that the selector applies
+                        to.
+                      type: string
+                    operator:
+                      description: operator represents a key's relationship to a set
+                        of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                      type: string
+                    values:
+                      description: values is an array of string values. If the operator
+                        is In or NotIn, the values array must be non-empty. If the
+                        operator is Exists or DoesNotExist, the values array must
+                        be empty. This array is replaced during a strategic merge
+                        patch.
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - key
+                  - operator
+                  type: object
+                type: array
+              matchLabels:
+                additionalProperties:
+                  type: string
+                description: matchLabels is a map of {key,value} pairs. A single {key,value}
+                  in the matchLabels map is equivalent to an element of matchExpressions,
+                  whose key field is "key", the operator is "In", and the values array
+                  contains only "value". The requirements are ANDed.
+                type: object
+            type: object
+          summary:
+            description: PolicyReportSummary provides a summary of results
+            properties:
+              error:
+                description: Error provides the count of policies that could not be
+                  evaluated
+                type: integer
+              fail:
+                description: Fail provides the count of policies whose requirements
+                  were not met
+                type: integer
+              pass:
+                description: Pass provides the count of policies whose requirements
+                  were met
+                type: integer
+              skip:
+                description: Skip indicates the count of policies that were not selected
+                  for evaluation
+                type: integer
+              warn:
+                description: Warn provides the count of unscored policies whose requirements
+                  were not met
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/tests/golden/policies/kyverno/kyverno/00_crds/wgpolicyk8s.io_clusterpolicyreports.yaml
+++ b/tests/golden/policies/kyverno/kyverno/00_crds/wgpolicyk8s.io_clusterpolicyreports.yaml
@@ -1,0 +1,675 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.0
+  creationTimestamp: null
+  name: clusterpolicyreports.wgpolicyk8s.io
+spec:
+  group: wgpolicyk8s.io
+  names:
+    kind: ClusterPolicyReport
+    listKind: ClusterPolicyReportList
+    plural: clusterpolicyreports
+    shortNames:
+    - cpolr
+    singular: clusterpolicyreport
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .scope.kind
+      name: Kind
+      priority: 1
+      type: string
+    - jsonPath: .scope.name
+      name: Name
+      priority: 1
+      type: string
+    - jsonPath: .summary.pass
+      name: Pass
+      type: integer
+    - jsonPath: .summary.fail
+      name: Fail
+      type: integer
+    - jsonPath: .summary.warn
+      name: Warn
+      type: integer
+    - jsonPath: .summary.error
+      name: Error
+      type: integer
+    - jsonPath: .summary.skip
+      name: Skip
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ClusterPolicyReport is the Schema for the clusterpolicyreports
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          results:
+            description: PolicyReportResult provides result details
+            items:
+              description: PolicyReportResult provides the result for an individual
+                policy
+              properties:
+                category:
+                  description: Category indicates policy category
+                  type: string
+                data:
+                  additionalProperties:
+                    type: string
+                  description: Data provides additional information for the policy
+                    rule
+                  type: object
+                message:
+                  description: Message is a short user friendly description of the
+                    policy rule
+                  type: string
+                policy:
+                  description: Policy is the name of the policy
+                  type: string
+                resourceSelector:
+                  description: ResourceSelector is an optional selector for policy
+                    results that apply to multiple resources. For example, a policy
+                    result may apply to all pods that match a label. Either a Resource
+                    or a ResourceSelector can be specified. If neither are provided,
+                    the result is assumed to be for the policy report scope.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                resources:
+                  description: Resources is an optional reference to the resource
+                    checked by the policy and rule
+                  items:
+                    description: 'ObjectReference contains enough information to let
+                      you inspect or modify the referred object. --- New uses of this
+                      type are discouraged because of difficulty describing its usage
+                      when embedded in APIs.  1. Ignored fields.  It includes many
+                      fields which are not generally honored.  For instance, ResourceVersion
+                      and FieldPath are both very rarely valid in actual usage.  2.
+                      Invalid usage help.  It is impossible to add specific help for
+                      individual usage.  In most embedded usages, there are particular     restrictions
+                      like, "must refer only to types A and B" or "UID not honored"
+                      or "name must be restricted".     Those cannot be well described
+                      when embedded.  3. Inconsistent validation.  Because the usages
+                      are different, the validation rules are different by usage,
+                      which makes it hard for users to predict what will happen.  4.
+                      The fields are both imprecise and overly precise.  Kind is not
+                      a precise mapping to a URL. This can produce ambiguity     during
+                      interpretation and require a REST mapping.  In most cases, the
+                      dependency is on the group,resource tuple     and the version
+                      of the actual struct is irrelevant.  5. We cannot easily change
+                      it.  Because this type is embedded in many locations, updates
+                      to this type     will affect numerous schemas.  Don''t make
+                      new APIs embed an underspecified API type they do not control.
+                      Instead of using this type, create a locally provided and used
+                      type that is well-focused on your reference. For example, ServiceReferences
+                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                      .'
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object. TODO: this design is not final and this field
+                          is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                  type: array
+                rule:
+                  description: Rule is the name of the policy rule
+                  type: string
+                scored:
+                  description: Scored indicates if this policy rule is scored
+                  type: boolean
+                severity:
+                  description: Severity indicates policy severity
+                  enum:
+                  - high
+                  - low
+                  - medium
+                  type: string
+                status:
+                  description: Status indicates the result of the policy rule check
+                  enum:
+                  - pass
+                  - fail
+                  - warn
+                  - error
+                  - skip
+                  type: string
+              required:
+              - policy
+              type: object
+            type: array
+          scope:
+            description: Scope is an optional reference to the report scope (e.g.
+              a Deployment, Namespace, or Node)
+            properties:
+              apiVersion:
+                description: API version of the referent.
+                type: string
+              fieldPath:
+                description: 'If referring to a piece of an object instead of an entire
+                  object, this string should contain a valid JSON/Go field access
+                  statement, such as desiredState.manifest.containers[2]. For example,
+                  if the object reference is to a container within a pod, this would
+                  take on a value like: "spec.containers{name}" (where "name" refers
+                  to the name of the container that triggered the event) or if no
+                  container name is specified "spec.containers[2]" (container with
+                  index 2 in this pod). This syntax is chosen only to have some well-defined
+                  way of referencing a part of an object. TODO: this design is not
+                  final and this field is subject to change in the future.'
+                type: string
+              kind:
+                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              name:
+                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                type: string
+              namespace:
+                description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                type: string
+              resourceVersion:
+                description: 'Specific resourceVersion to which this reference is
+                  made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                type: string
+              uid:
+                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                type: string
+            type: object
+          scopeSelector:
+            description: ScopeSelector is an optional selector for multiple scopes
+              (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
+              should be specified.
+            properties:
+              matchExpressions:
+                description: matchExpressions is a list of label selector requirements.
+                  The requirements are ANDed.
+                items:
+                  description: A label selector requirement is a selector that contains
+                    values, a key, and an operator that relates the key and values.
+                  properties:
+                    key:
+                      description: key is the label key that the selector applies
+                        to.
+                      type: string
+                    operator:
+                      description: operator represents a key's relationship to a set
+                        of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                      type: string
+                    values:
+                      description: values is an array of string values. If the operator
+                        is In or NotIn, the values array must be non-empty. If the
+                        operator is Exists or DoesNotExist, the values array must
+                        be empty. This array is replaced during a strategic merge
+                        patch.
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - key
+                  - operator
+                  type: object
+                type: array
+              matchLabels:
+                additionalProperties:
+                  type: string
+                description: matchLabels is a map of {key,value} pairs. A single {key,value}
+                  in the matchLabels map is equivalent to an element of matchExpressions,
+                  whose key field is "key", the operator is "In", and the values array
+                  contains only "value". The requirements are ANDed.
+                type: object
+            type: object
+          summary:
+            description: PolicyReportSummary provides a summary of results
+            properties:
+              error:
+                description: Error provides the count of policies that could not be
+                  evaluated
+                type: integer
+              fail:
+                description: Fail provides the count of policies whose requirements
+                  were not met
+                type: integer
+              pass:
+                description: Pass provides the count of policies whose requirements
+                  were met
+                type: integer
+              skip:
+                description: Skip indicates the count of policies that were not selected
+                  for evaluation
+                type: integer
+              warn:
+                description: Warn provides the count of unscored policies whose requirements
+                  were not met
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources: {}
+  - additionalPrinterColumns:
+    - jsonPath: .scope.kind
+      name: Kind
+      priority: 1
+      type: string
+    - jsonPath: .scope.name
+      name: Name
+      priority: 1
+      type: string
+    - jsonPath: .summary.pass
+      name: Pass
+      type: integer
+    - jsonPath: .summary.fail
+      name: Fail
+      type: integer
+    - jsonPath: .summary.warn
+      name: Warn
+      type: integer
+    - jsonPath: .summary.error
+      name: Error
+      type: integer
+    - jsonPath: .summary.skip
+      name: Skip
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: ClusterPolicyReport is the Schema for the clusterpolicyreports
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          results:
+            description: PolicyReportResult provides result details
+            items:
+              description: PolicyReportResult provides the result for an individual
+                policy
+              properties:
+                category:
+                  description: Category indicates policy category
+                  type: string
+                message:
+                  description: Message is a short user friendly description of the
+                    policy rule
+                  type: string
+                policy:
+                  description: Policy is the name of the policy
+                  type: string
+                properties:
+                  additionalProperties:
+                    type: string
+                  description: Properties provides additional information for the
+                    policy rule
+                  type: object
+                resourceSelector:
+                  description: ResourceSelector is an optional selector for policy
+                    results that apply to multiple resources. For example, a policy
+                    result may apply to all pods that match a label. Either a Resource
+                    or a ResourceSelector can be specified. If neither are provided,
+                    the result is assumed to be for the policy report scope.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                resources:
+                  description: Resources is an optional reference to the resource
+                    checked by the policy and rule
+                  items:
+                    description: 'ObjectReference contains enough information to let
+                      you inspect or modify the referred object. --- New uses of this
+                      type are discouraged because of difficulty describing its usage
+                      when embedded in APIs.  1. Ignored fields.  It includes many
+                      fields which are not generally honored.  For instance, ResourceVersion
+                      and FieldPath are both very rarely valid in actual usage.  2.
+                      Invalid usage help.  It is impossible to add specific help for
+                      individual usage.  In most embedded usages, there are particular     restrictions
+                      like, "must refer only to types A and B" or "UID not honored"
+                      or "name must be restricted".     Those cannot be well described
+                      when embedded.  3. Inconsistent validation.  Because the usages
+                      are different, the validation rules are different by usage,
+                      which makes it hard for users to predict what will happen.  4.
+                      The fields are both imprecise and overly precise.  Kind is not
+                      a precise mapping to a URL. This can produce ambiguity     during
+                      interpretation and require a REST mapping.  In most cases, the
+                      dependency is on the group,resource tuple     and the version
+                      of the actual struct is irrelevant.  5. We cannot easily change
+                      it.  Because this type is embedded in many locations, updates
+                      to this type     will affect numerous schemas.  Don''t make
+                      new APIs embed an underspecified API type they do not control.
+                      Instead of using this type, create a locally provided and used
+                      type that is well-focused on your reference. For example, ServiceReferences
+                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                      .'
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object. TODO: this design is not final and this field
+                          is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                  type: array
+                result:
+                  description: Result indicates the outcome of the policy rule execution
+                  enum:
+                  - pass
+                  - fail
+                  - warn
+                  - error
+                  - skip
+                  type: string
+                rule:
+                  description: Rule is the name of the policy rule
+                  type: string
+                scored:
+                  description: Scored indicates if this policy rule is scored
+                  type: boolean
+                severity:
+                  description: Severity indicates policy severity
+                  enum:
+                  - high
+                  - low
+                  - medium
+                  type: string
+                source:
+                  description: Source is an identifier for the policy engine that
+                    manages this report
+                  type: string
+                timestamp:
+                  description: Timestamp indicates the time the result was found
+                  properties:
+                    nanos:
+                      description: Non-negative fractions of a second at nanosecond
+                        resolution. Negative second values with fractions must still
+                        have non-negative nanos values that count forward in time.
+                        Must be from 0 to 999,999,999 inclusive. This field may be
+                        limited in precision depending on context.
+                      format: int32
+                      type: integer
+                    seconds:
+                      description: Represents seconds of UTC time since Unix epoch
+                        1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
+                        9999-12-31T23:59:59Z inclusive.
+                      format: int64
+                      type: integer
+                  required:
+                  - nanos
+                  - seconds
+                  type: object
+              required:
+              - policy
+              type: object
+            type: array
+          scope:
+            description: Scope is an optional reference to the report scope (e.g.
+              a Deployment, Namespace, or Node)
+            properties:
+              apiVersion:
+                description: API version of the referent.
+                type: string
+              fieldPath:
+                description: 'If referring to a piece of an object instead of an entire
+                  object, this string should contain a valid JSON/Go field access
+                  statement, such as desiredState.manifest.containers[2]. For example,
+                  if the object reference is to a container within a pod, this would
+                  take on a value like: "spec.containers{name}" (where "name" refers
+                  to the name of the container that triggered the event) or if no
+                  container name is specified "spec.containers[2]" (container with
+                  index 2 in this pod). This syntax is chosen only to have some well-defined
+                  way of referencing a part of an object. TODO: this design is not
+                  final and this field is subject to change in the future.'
+                type: string
+              kind:
+                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              name:
+                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                type: string
+              namespace:
+                description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                type: string
+              resourceVersion:
+                description: 'Specific resourceVersion to which this reference is
+                  made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                type: string
+              uid:
+                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                type: string
+            type: object
+          scopeSelector:
+            description: ScopeSelector is an optional selector for multiple scopes
+              (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
+              should be specified.
+            properties:
+              matchExpressions:
+                description: matchExpressions is a list of label selector requirements.
+                  The requirements are ANDed.
+                items:
+                  description: A label selector requirement is a selector that contains
+                    values, a key, and an operator that relates the key and values.
+                  properties:
+                    key:
+                      description: key is the label key that the selector applies
+                        to.
+                      type: string
+                    operator:
+                      description: operator represents a key's relationship to a set
+                        of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                      type: string
+                    values:
+                      description: values is an array of string values. If the operator
+                        is In or NotIn, the values array must be non-empty. If the
+                        operator is Exists or DoesNotExist, the values array must
+                        be empty. This array is replaced during a strategic merge
+                        patch.
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - key
+                  - operator
+                  type: object
+                type: array
+              matchLabels:
+                additionalProperties:
+                  type: string
+                description: matchLabels is a map of {key,value} pairs. A single {key,value}
+                  in the matchLabels map is equivalent to an element of matchExpressions,
+                  whose key field is "key", the operator is "In", and the values array
+                  contains only "value". The requirements are ANDed.
+                type: object
+            type: object
+          summary:
+            description: PolicyReportSummary provides a summary of results
+            properties:
+              error:
+                description: Error provides the count of policies that could not be
+                  evaluated
+                type: integer
+              fail:
+                description: Fail provides the count of policies whose requirements
+                  were not met
+                type: integer
+              pass:
+                description: Pass provides the count of policies whose requirements
+                  were met
+                type: integer
+              skip:
+                description: Skip indicates the count of policies that were not selected
+                  for evaluation
+                type: integer
+              warn:
+                description: Warn provides the count of unscored policies whose requirements
+                  were not met
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/tests/golden/policies/kyverno/kyverno/00_crds/wgpolicyk8s.io_policyreports.yaml
+++ b/tests/golden/policies/kyverno/kyverno/00_crds/wgpolicyk8s.io_policyreports.yaml
@@ -1,0 +1,673 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.0
+  creationTimestamp: null
+  name: policyreports.wgpolicyk8s.io
+spec:
+  group: wgpolicyk8s.io
+  names:
+    kind: PolicyReport
+    listKind: PolicyReportList
+    plural: policyreports
+    shortNames:
+    - polr
+    singular: policyreport
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .scope.kind
+      name: Kind
+      priority: 1
+      type: string
+    - jsonPath: .scope.name
+      name: Name
+      priority: 1
+      type: string
+    - jsonPath: .summary.pass
+      name: Pass
+      type: integer
+    - jsonPath: .summary.fail
+      name: Fail
+      type: integer
+    - jsonPath: .summary.warn
+      name: Warn
+      type: integer
+    - jsonPath: .summary.error
+      name: Error
+      type: integer
+    - jsonPath: .summary.skip
+      name: Skip
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PolicyReport is the Schema for the policyreports API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          results:
+            description: PolicyReportResult provides result details
+            items:
+              description: PolicyReportResult provides the result for an individual
+                policy
+              properties:
+                category:
+                  description: Category indicates policy category
+                  type: string
+                data:
+                  additionalProperties:
+                    type: string
+                  description: Data provides additional information for the policy
+                    rule
+                  type: object
+                message:
+                  description: Message is a short user friendly description of the
+                    policy rule
+                  type: string
+                policy:
+                  description: Policy is the name of the policy
+                  type: string
+                resourceSelector:
+                  description: ResourceSelector is an optional selector for policy
+                    results that apply to multiple resources. For example, a policy
+                    result may apply to all pods that match a label. Either a Resource
+                    or a ResourceSelector can be specified. If neither are provided,
+                    the result is assumed to be for the policy report scope.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                resources:
+                  description: Resources is an optional reference to the resource
+                    checked by the policy and rule
+                  items:
+                    description: 'ObjectReference contains enough information to let
+                      you inspect or modify the referred object. --- New uses of this
+                      type are discouraged because of difficulty describing its usage
+                      when embedded in APIs.  1. Ignored fields.  It includes many
+                      fields which are not generally honored.  For instance, ResourceVersion
+                      and FieldPath are both very rarely valid in actual usage.  2.
+                      Invalid usage help.  It is impossible to add specific help for
+                      individual usage.  In most embedded usages, there are particular     restrictions
+                      like, "must refer only to types A and B" or "UID not honored"
+                      or "name must be restricted".     Those cannot be well described
+                      when embedded.  3. Inconsistent validation.  Because the usages
+                      are different, the validation rules are different by usage,
+                      which makes it hard for users to predict what will happen.  4.
+                      The fields are both imprecise and overly precise.  Kind is not
+                      a precise mapping to a URL. This can produce ambiguity     during
+                      interpretation and require a REST mapping.  In most cases, the
+                      dependency is on the group,resource tuple     and the version
+                      of the actual struct is irrelevant.  5. We cannot easily change
+                      it.  Because this type is embedded in many locations, updates
+                      to this type     will affect numerous schemas.  Don''t make
+                      new APIs embed an underspecified API type they do not control.
+                      Instead of using this type, create a locally provided and used
+                      type that is well-focused on your reference. For example, ServiceReferences
+                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                      .'
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object. TODO: this design is not final and this field
+                          is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                  type: array
+                rule:
+                  description: Rule is the name of the policy rule
+                  type: string
+                scored:
+                  description: Scored indicates if this policy rule is scored
+                  type: boolean
+                severity:
+                  description: Severity indicates policy severity
+                  enum:
+                  - high
+                  - low
+                  - medium
+                  type: string
+                status:
+                  description: Status indicates the result of the policy rule check
+                  enum:
+                  - pass
+                  - fail
+                  - warn
+                  - error
+                  - skip
+                  type: string
+              required:
+              - policy
+              type: object
+            type: array
+          scope:
+            description: Scope is an optional reference to the report scope (e.g.
+              a Deployment, Namespace, or Node)
+            properties:
+              apiVersion:
+                description: API version of the referent.
+                type: string
+              fieldPath:
+                description: 'If referring to a piece of an object instead of an entire
+                  object, this string should contain a valid JSON/Go field access
+                  statement, such as desiredState.manifest.containers[2]. For example,
+                  if the object reference is to a container within a pod, this would
+                  take on a value like: "spec.containers{name}" (where "name" refers
+                  to the name of the container that triggered the event) or if no
+                  container name is specified "spec.containers[2]" (container with
+                  index 2 in this pod). This syntax is chosen only to have some well-defined
+                  way of referencing a part of an object. TODO: this design is not
+                  final and this field is subject to change in the future.'
+                type: string
+              kind:
+                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              name:
+                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                type: string
+              namespace:
+                description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                type: string
+              resourceVersion:
+                description: 'Specific resourceVersion to which this reference is
+                  made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                type: string
+              uid:
+                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                type: string
+            type: object
+          scopeSelector:
+            description: ScopeSelector is an optional selector for multiple scopes
+              (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
+              should be specified.
+            properties:
+              matchExpressions:
+                description: matchExpressions is a list of label selector requirements.
+                  The requirements are ANDed.
+                items:
+                  description: A label selector requirement is a selector that contains
+                    values, a key, and an operator that relates the key and values.
+                  properties:
+                    key:
+                      description: key is the label key that the selector applies
+                        to.
+                      type: string
+                    operator:
+                      description: operator represents a key's relationship to a set
+                        of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                      type: string
+                    values:
+                      description: values is an array of string values. If the operator
+                        is In or NotIn, the values array must be non-empty. If the
+                        operator is Exists or DoesNotExist, the values array must
+                        be empty. This array is replaced during a strategic merge
+                        patch.
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - key
+                  - operator
+                  type: object
+                type: array
+              matchLabels:
+                additionalProperties:
+                  type: string
+                description: matchLabels is a map of {key,value} pairs. A single {key,value}
+                  in the matchLabels map is equivalent to an element of matchExpressions,
+                  whose key field is "key", the operator is "In", and the values array
+                  contains only "value". The requirements are ANDed.
+                type: object
+            type: object
+          summary:
+            description: PolicyReportSummary provides a summary of results
+            properties:
+              error:
+                description: Error provides the count of policies that could not be
+                  evaluated
+                type: integer
+              fail:
+                description: Fail provides the count of policies whose requirements
+                  were not met
+                type: integer
+              pass:
+                description: Pass provides the count of policies whose requirements
+                  were met
+                type: integer
+              skip:
+                description: Skip indicates the count of policies that were not selected
+                  for evaluation
+                type: integer
+              warn:
+                description: Warn provides the count of unscored policies whose requirements
+                  were not met
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources: {}
+  - additionalPrinterColumns:
+    - jsonPath: .scope.kind
+      name: Kind
+      priority: 1
+      type: string
+    - jsonPath: .scope.name
+      name: Name
+      priority: 1
+      type: string
+    - jsonPath: .summary.pass
+      name: Pass
+      type: integer
+    - jsonPath: .summary.fail
+      name: Fail
+      type: integer
+    - jsonPath: .summary.warn
+      name: Warn
+      type: integer
+    - jsonPath: .summary.error
+      name: Error
+      type: integer
+    - jsonPath: .summary.skip
+      name: Skip
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: PolicyReport is the Schema for the policyreports API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          results:
+            description: PolicyReportResult provides result details
+            items:
+              description: PolicyReportResult provides the result for an individual
+                policy
+              properties:
+                category:
+                  description: Category indicates policy category
+                  type: string
+                message:
+                  description: Message is a short user friendly description of the
+                    policy rule
+                  type: string
+                policy:
+                  description: Policy is the name of the policy
+                  type: string
+                properties:
+                  additionalProperties:
+                    type: string
+                  description: Properties provides additional information for the
+                    policy rule
+                  type: object
+                resourceSelector:
+                  description: ResourceSelector is an optional selector for policy
+                    results that apply to multiple resources. For example, a policy
+                    result may apply to all pods that match a label. Either a Resource
+                    or a ResourceSelector can be specified. If neither are provided,
+                    the result is assumed to be for the policy report scope.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                resources:
+                  description: Resources is an optional reference to the resource
+                    checked by the policy and rule
+                  items:
+                    description: 'ObjectReference contains enough information to let
+                      you inspect or modify the referred object. --- New uses of this
+                      type are discouraged because of difficulty describing its usage
+                      when embedded in APIs.  1. Ignored fields.  It includes many
+                      fields which are not generally honored.  For instance, ResourceVersion
+                      and FieldPath are both very rarely valid in actual usage.  2.
+                      Invalid usage help.  It is impossible to add specific help for
+                      individual usage.  In most embedded usages, there are particular     restrictions
+                      like, "must refer only to types A and B" or "UID not honored"
+                      or "name must be restricted".     Those cannot be well described
+                      when embedded.  3. Inconsistent validation.  Because the usages
+                      are different, the validation rules are different by usage,
+                      which makes it hard for users to predict what will happen.  4.
+                      The fields are both imprecise and overly precise.  Kind is not
+                      a precise mapping to a URL. This can produce ambiguity     during
+                      interpretation and require a REST mapping.  In most cases, the
+                      dependency is on the group,resource tuple     and the version
+                      of the actual struct is irrelevant.  5. We cannot easily change
+                      it.  Because this type is embedded in many locations, updates
+                      to this type     will affect numerous schemas.  Don''t make
+                      new APIs embed an underspecified API type they do not control.
+                      Instead of using this type, create a locally provided and used
+                      type that is well-focused on your reference. For example, ServiceReferences
+                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                      .'
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object. TODO: this design is not final and this field
+                          is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                  type: array
+                result:
+                  description: Result indicates the outcome of the policy rule execution
+                  enum:
+                  - pass
+                  - fail
+                  - warn
+                  - error
+                  - skip
+                  type: string
+                rule:
+                  description: Rule is the name of the policy rule
+                  type: string
+                scored:
+                  description: Scored indicates if this policy rule is scored
+                  type: boolean
+                severity:
+                  description: Severity indicates policy severity
+                  enum:
+                  - high
+                  - low
+                  - medium
+                  type: string
+                source:
+                  description: Source is an identifier for the policy engine that
+                    manages this report
+                  type: string
+                timestamp:
+                  description: Timestamp indicates the time the result was found
+                  properties:
+                    nanos:
+                      description: Non-negative fractions of a second at nanosecond
+                        resolution. Negative second values with fractions must still
+                        have non-negative nanos values that count forward in time.
+                        Must be from 0 to 999,999,999 inclusive. This field may be
+                        limited in precision depending on context.
+                      format: int32
+                      type: integer
+                    seconds:
+                      description: Represents seconds of UTC time since Unix epoch
+                        1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
+                        9999-12-31T23:59:59Z inclusive.
+                      format: int64
+                      type: integer
+                  required:
+                  - nanos
+                  - seconds
+                  type: object
+              required:
+              - policy
+              type: object
+            type: array
+          scope:
+            description: Scope is an optional reference to the report scope (e.g.
+              a Deployment, Namespace, or Node)
+            properties:
+              apiVersion:
+                description: API version of the referent.
+                type: string
+              fieldPath:
+                description: 'If referring to a piece of an object instead of an entire
+                  object, this string should contain a valid JSON/Go field access
+                  statement, such as desiredState.manifest.containers[2]. For example,
+                  if the object reference is to a container within a pod, this would
+                  take on a value like: "spec.containers{name}" (where "name" refers
+                  to the name of the container that triggered the event) or if no
+                  container name is specified "spec.containers[2]" (container with
+                  index 2 in this pod). This syntax is chosen only to have some well-defined
+                  way of referencing a part of an object. TODO: this design is not
+                  final and this field is subject to change in the future.'
+                type: string
+              kind:
+                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              name:
+                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                type: string
+              namespace:
+                description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                type: string
+              resourceVersion:
+                description: 'Specific resourceVersion to which this reference is
+                  made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                type: string
+              uid:
+                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                type: string
+            type: object
+          scopeSelector:
+            description: ScopeSelector is an optional selector for multiple scopes
+              (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
+              should be specified.
+            properties:
+              matchExpressions:
+                description: matchExpressions is a list of label selector requirements.
+                  The requirements are ANDed.
+                items:
+                  description: A label selector requirement is a selector that contains
+                    values, a key, and an operator that relates the key and values.
+                  properties:
+                    key:
+                      description: key is the label key that the selector applies
+                        to.
+                      type: string
+                    operator:
+                      description: operator represents a key's relationship to a set
+                        of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                      type: string
+                    values:
+                      description: values is an array of string values. If the operator
+                        is In or NotIn, the values array must be non-empty. If the
+                        operator is Exists or DoesNotExist, the values array must
+                        be empty. This array is replaced during a strategic merge
+                        patch.
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - key
+                  - operator
+                  type: object
+                type: array
+              matchLabels:
+                additionalProperties:
+                  type: string
+                description: matchLabels is a map of {key,value} pairs. A single {key,value}
+                  in the matchLabels map is equivalent to an element of matchExpressions,
+                  whose key field is "key", the operator is "In", and the values array
+                  contains only "value". The requirements are ANDed.
+                type: object
+            type: object
+          summary:
+            description: PolicyReportSummary provides a summary of results
+            properties:
+              error:
+                description: Error provides the count of policies that could not be
+                  evaluated
+                type: integer
+              fail:
+                description: Fail provides the count of policies whose requirements
+                  were not met
+                type: integer
+              pass:
+                description: Pass provides the count of policies whose requirements
+                  were met
+                type: integer
+              skip:
+                description: Skip indicates the count of policies that were not selected
+                  for evaluation
+                type: integer
+              warn:
+                description: Warn provides the count of unscored policies whose requirements
+                  were not met
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/tests/golden/policies/kyverno/kyverno/01_namespace.yaml
+++ b/tests/golden/policies/kyverno/kyverno/01_namespace.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/node-selector: node-role.kubernetes.io/master=
+  labels:
+    SYNMonitoring: main
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: syn
+    name: syn-kyverno
+    network-policies.syn.tools/no-defaults: 'true'
+    network-policies.syn.tools/purge-defaults: 'true'
+  name: syn-kyverno

--- a/tests/golden/policies/kyverno/kyverno/02_clusterrole-kyverno-events.yaml
+++ b/tests/golden/policies/kyverno/kyverno/02_clusterrole-kyverno-events.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: kyverno
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: syn
+  name: kyverno:events
+  namespace: syn-kyverno
+rules:
+  - apiGroups:
+      - '*'
+    resources:
+      - events
+    verbs:
+      - create
+      - update
+      - patch
+      - delete

--- a/tests/golden/policies/kyverno/kyverno/02_clusterrole-kyverno-generate.yaml
+++ b/tests/golden/policies/kyverno/kyverno/02_clusterrole-kyverno-generate.yaml
@@ -1,0 +1,45 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: kyverno
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: syn
+  name: kyverno:generate
+  namespace: syn-kyverno
+rules:
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+      - ingressclasses
+      - networkpolicies
+    verbs:
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ''
+    resources:
+      - namespaces
+      - configmaps
+      - secrets
+      - resourcequotas
+      - limitranges
+    verbs:
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - rolebindings
+      - roles
+    verbs:
+      - create
+      - update
+      - patch
+      - delete

--- a/tests/golden/policies/kyverno/kyverno/02_clusterrole-kyverno-policies.yaml
+++ b/tests/golden/policies/kyverno/kyverno/02_clusterrole-kyverno-policies.yaml
@@ -1,0 +1,49 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: kyverno
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: syn
+  name: kyverno:policies
+  namespace: syn-kyverno
+rules:
+  - apiGroups:
+      - kyverno.io
+    resources:
+      - policies
+      - policies/status
+      - clusterpolicies
+      - clusterpolicies/status
+      - generaterequests
+      - generaterequests/status
+      - reportchangerequests
+      - reportchangerequests/status
+      - clusterreportchangerequests
+      - clusterreportchangerequests/status
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+      - deletecollection
+  - apiGroups:
+      - wgpolicyk8s.io
+    resources:
+      - policyreports
+      - policyreports/status
+      - clusterpolicyreports
+      - clusterpolicyreports/status
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+      - deletecollection

--- a/tests/golden/policies/kyverno/kyverno/02_clusterrole-kyverno-userinfo.yaml
+++ b/tests/golden/policies/kyverno/kyverno/02_clusterrole-kyverno-userinfo.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: kyverno
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: syn
+  name: kyverno:userinfo
+  namespace: syn-kyverno
+rules:
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
+      - clusterroles
+      - rolebindings
+      - clusterrolebindings
+    verbs:
+      - watch
+      - list

--- a/tests/golden/policies/kyverno/kyverno/02_clusterrole-kyverno-view.yaml
+++ b/tests/golden/policies/kyverno/kyverno/02_clusterrole-kyverno-view.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: kyverno
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: syn
+  name: kyverno:view
+  namespace: syn-kyverno
+rules:
+  - apiGroups:
+      - '*'
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch

--- a/tests/golden/policies/kyverno/kyverno/02_clusterrole-kyverno-webhook.yaml
+++ b/tests/golden/policies/kyverno/kyverno/02_clusterrole-kyverno-webhook.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: kyverno
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: syn
+  name: kyverno:webhook
+  namespace: syn-kyverno
+rules:
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - mutatingwebhookconfigurations
+      - validatingwebhookconfigurations
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch

--- a/tests/golden/policies/kyverno/kyverno/02_clusterrolebinding-kyverno-events.yaml
+++ b/tests/golden/policies/kyverno/kyverno/02_clusterrolebinding-kyverno-events.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: kyverno
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: syn
+  name: kyverno:events
+  namespace: syn-kyverno
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kyverno:events
+subjects:
+  - kind: ServiceAccount
+    name: kyverno-service-account
+    namespace: syn-kyverno

--- a/tests/golden/policies/kyverno/kyverno/02_clusterrolebinding-kyverno-generate.yaml
+++ b/tests/golden/policies/kyverno/kyverno/02_clusterrolebinding-kyverno-generate.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: kyverno
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: syn
+  name: kyverno:generate
+  namespace: syn-kyverno
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kyverno:generate
+subjects:
+  - kind: ServiceAccount
+    name: kyverno-service-account
+    namespace: syn-kyverno

--- a/tests/golden/policies/kyverno/kyverno/02_clusterrolebinding-kyverno-policies.yaml
+++ b/tests/golden/policies/kyverno/kyverno/02_clusterrolebinding-kyverno-policies.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: kyverno
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: syn
+  name: kyverno:policies
+  namespace: syn-kyverno
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kyverno:policies
+subjects:
+  - kind: ServiceAccount
+    name: kyverno-service-account
+    namespace: syn-kyverno

--- a/tests/golden/policies/kyverno/kyverno/02_clusterrolebinding-kyverno-userinfo.yaml
+++ b/tests/golden/policies/kyverno/kyverno/02_clusterrolebinding-kyverno-userinfo.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: kyverno
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: syn
+  name: kyverno:userinfo
+  namespace: syn-kyverno
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kyverno:userinfo
+subjects:
+  - kind: ServiceAccount
+    name: kyverno-service-account
+    namespace: syn-kyverno

--- a/tests/golden/policies/kyverno/kyverno/02_clusterrolebinding-kyverno-view.yaml
+++ b/tests/golden/policies/kyverno/kyverno/02_clusterrolebinding-kyverno-view.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: kyverno
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: syn
+  name: kyverno:view
+  namespace: syn-kyverno
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kyverno:view
+subjects:
+  - kind: ServiceAccount
+    name: kyverno-service-account
+    namespace: syn-kyverno

--- a/tests/golden/policies/kyverno/kyverno/02_clusterrolebinding-kyverno-webhook.yaml
+++ b/tests/golden/policies/kyverno/kyverno/02_clusterrolebinding-kyverno-webhook.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: kyverno
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: syn
+  name: kyverno:webhook
+  namespace: syn-kyverno
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kyverno:webhook
+subjects:
+  - kind: ServiceAccount
+    name: kyverno-service-account
+    namespace: syn-kyverno

--- a/tests/golden/policies/kyverno/kyverno/02_configmap-kyverno-metrics.yaml
+++ b/tests/golden/policies/kyverno/kyverno/02_configmap-kyverno-metrics.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+data:
+  metricsRefreshInterval: 24h
+  namespaces: '{"exclude":[],"include":[]}'
+kind: ConfigMap
+metadata:
+  labels:
+    app: kyverno
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: syn
+  name: kyverno-metrics
+  namespace: syn-kyverno

--- a/tests/golden/policies/kyverno/kyverno/02_configmap-kyverno.yaml
+++ b/tests/golden/policies/kyverno/kyverno/02_configmap-kyverno.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+data:
+  excludeGroupRole: system:serviceaccounts:kube-system,system:nodes,system:kube-scheduler
+  generateSuccessEvents: 'false'
+  resourceFilters: '[Event,*,*][*,kube-system,*][*,kube-public,*][*,kube-node-lease,*][Node,*,*][APIService,*,*][TokenReview,*,*][SubjectAccessReview,*,*][SelfSubjectAccessReview,*,*][*,kyverno,*][Binding,*,*][ReplicaSet,*,*][ReportChangeRequest,*,*][ClusterReportChangeRequest,*,*][PolicyReport,*,*][ClusterPolicyReport,*,*]'
+kind: ConfigMap
+metadata:
+  labels:
+    app: kyverno
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: syn
+  name: kyverno
+  namespace: syn-kyverno

--- a/tests/golden/policies/kyverno/kyverno/02_deployment-kyverno.yaml
+++ b/tests/golden/policies/kyverno/kyverno/02_deployment-kyverno.yaml
@@ -1,0 +1,137 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: kyverno
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: syn
+  name: kyverno
+  namespace: syn-kyverno
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: kyverno
+      app.kubernetes.io/name: kyverno
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 40%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: kyverno
+        app.kubernetes.io/name: kyverno
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - kyverno
+              topologyKey: kubernetes.io/hostname
+      containers:
+        - args: []
+          env:
+            - name: INIT_CONFIG
+              value: kyverno
+            - name: METRICS_CONFIG
+              value: kyverno-metrics
+            - name: KYVERNO_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: KYVERNO_SVC
+              value: kyverno-svc
+            - name: TUF_ROOT
+              value: /.sigstore
+          image: ghcr.io/kyverno/kyverno:v1.6.2
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 2
+            httpGet:
+              path: /health/liveness
+              port: 9443
+              scheme: HTTPS
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 5
+          name: kyverno
+          ports:
+            - containerPort: 9443
+              name: https
+              protocol: TCP
+            - containerPort: 8000
+              name: metrics-port
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 4
+            httpGet:
+              path: /health/readiness
+              port: 9443
+              scheme: HTTPS
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          resources:
+            limits:
+              memory: 512Mi
+            requests:
+              cpu: 100m
+              memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          volumeMounts:
+            - mountPath: /.sigstore
+              name: sigstore
+      initContainers:
+        - env:
+            - name: METRICS_CONFIG
+              value: kyverno-metrics
+            - name: KYVERNO_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          image: ghcr.io/kyverno/kyvernopre:v1.6.2
+          imagePullPolicy: IfNotPresent
+          name: kyverno-pre
+          resources:
+            limits:
+              cpu: 100m
+              memory: 256Mi
+            requests:
+              cpu: 10m
+              memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+      nodeSelector:
+        node-role.kubernetes.io/master: ''
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: kyverno-service-account
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+          operator: Exists
+      volumes:
+        - emptyDir: {}
+          name: sigstore

--- a/tests/golden/policies/kyverno/kyverno/02_poddisruptionbudget-kyverno.yaml
+++ b/tests/golden/policies/kyverno/kyverno/02_poddisruptionbudget-kyverno.yaml
@@ -1,0 +1,17 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: syn
+    name: kyverno
+  name: kyverno
+  namespace: syn-kyverno
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: kyverno
+      app.kubernetes.io/name: kyverno

--- a/tests/golden/policies/kyverno/kyverno/02_role-kyverno-leaderelection.yaml
+++ b/tests/golden/policies/kyverno/kyverno/02_role-kyverno-leaderelection.yaml
@@ -1,0 +1,31 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: kyverno
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: syn
+  name: kyverno:leaderelection
+  namespace: syn-kyverno
+rules:
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - delete
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch

--- a/tests/golden/policies/kyverno/kyverno/02_rolebinding-kyverno-leaderelection.yaml
+++ b/tests/golden/policies/kyverno/kyverno/02_rolebinding-kyverno-leaderelection.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: kyverno
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: syn
+  name: kyverno:leaderelection
+  namespace: syn-kyverno
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kyverno:leaderelection
+subjects:
+  - kind: ServiceAccount
+    name: kyverno-service-account
+    namespace: syn-kyverno

--- a/tests/golden/policies/kyverno/kyverno/02_service-kyverno-svc-metrics.yaml
+++ b/tests/golden/policies/kyverno/kyverno/02_service-kyverno-svc-metrics.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: kyverno
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: syn
+  name: kyverno-svc-metrics
+  namespace: syn-kyverno
+spec:
+  ports:
+    - name: metrics-port
+      port: 8000
+      targetPort: metrics-port
+  selector:
+    app: kyverno
+    app.kubernetes.io/name: kyverno

--- a/tests/golden/policies/kyverno/kyverno/02_service-kyverno-svc.yaml
+++ b/tests/golden/policies/kyverno/kyverno/02_service-kyverno-svc.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: kyverno
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: syn
+  name: kyverno-svc
+  namespace: syn-kyverno
+spec:
+  ports:
+    - name: https
+      port: 443
+      targetPort: https
+  selector:
+    app: kyverno
+    app.kubernetes.io/name: kyverno

--- a/tests/golden/policies/kyverno/kyverno/02_serviceaccount-kyverno-service-account.yaml
+++ b/tests/golden/policies/kyverno/kyverno/02_serviceaccount-kyverno-service-account.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: kyverno
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: syn
+  name: kyverno-service-account
+  namespace: syn-kyverno

--- a/tests/golden/policies/kyverno/kyverno/10_monitoring/00_servicemonitor-kyverno.yaml
+++ b/tests/golden/policies/kyverno/kyverno/10_monitoring/00_servicemonitor-kyverno.yaml
@@ -1,0 +1,22 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: syn
+    name: kyverno
+  name: kyverno
+  namespace: syn-kyverno
+spec:
+  endpoints:
+    - port: metrics-port
+  namespaceSelector:
+    matchNames:
+      - syn-kyverno
+  selector:
+    matchLabels:
+      app.kubernetes.io/managed-by: commodore
+      app.kubernetes.io/name: kyverno
+      app.kubernetes.io/part-of: syn

--- a/tests/golden/policies/kyverno/kyverno/10_monitoring/10_prometheusrule_kyverno-alerts.yaml
+++ b/tests/golden/policies/kyverno/kyverno/10_monitoring/10_prometheusrule_kyverno-alerts.yaml
@@ -1,0 +1,47 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: syn
+    name: kyverno-alerts
+  name: kyverno-alerts
+  namespace: syn-kyverno
+spec:
+  groups:
+    - name: kyverno-alerts
+      rules:
+        - alert: KyvernoAdmissionLatencyReachedWebhookTimeout
+          annotations:
+            description: Kyverno admission latency for {{$labels.resouce_kind}}/{{$labels.resource_namespace}}
+              higher than Kubernetes webhook timeout (10s).
+            message: Kyverno admission latency higher than Kubernetes webhook timeout
+              (10s).
+            runbook_url: https://hub.syn.tools/kyverno/runbooks/KyvernoAdmissionLatencyReachedWebhookTimeout.html
+            summary: Kyverno admission too slow.
+          expr: "(\n  sum by(resource_kind, resource_namespace) (increase(kyverno_admission_review_duration_seconds_bucket{le=\"\
+            +Inf\"}[10m]))\n-\n  sum by(resource_kind, resource_namespace) (increase(kyverno_admission_review_duration_seconds_bucket{le=\"\
+            10\"}[10m]))\n) > 0\n"
+          for: 5m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: kyverno
+        - alert: KyvernoAverageAdmissionLatencyHigh
+          annotations:
+            description: Kyverno average admission latency for {{$labels.resouce_kind}}
+              reached 5 seconds.
+            message: Kyverno average admission latency for {{$labels.resouce_kind}}
+              reached 5 seconds in the last 10 minutes.
+            runbook_url: https://hub.syn.tools/kyverno/runbooks/KyvernoAverageAdmissionLatencyHigh.html
+            summary: Kyverno admission is slowing down.
+          expr: "(\n  sum by (job,resource_kind) (rate(kyverno_admission_review_duration_seconds_sum[5m]))\n\
+            /\n  sum by (job,resource_kind) (rate(kyverno_admission_review_duration_seconds_count[5m]))\n\
+            ) > 5\n"
+          for: 10m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: kyverno

--- a/tests/golden/policies/kyverno/kyverno/80_policies.yaml
+++ b/tests/golden/policies/kyverno/kyverno/80_policies.yaml
@@ -1,0 +1,28 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: syn
+    name: another-policy
+  name: another-policy
+spec:
+  foo: bar
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  annotations:
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/title: Example Policy
+  labels:
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: syn
+    name: test-policy
+  name: test-policy
+  spec:
+    background: true
+    validationFailureAction: enforce

--- a/tests/policies.yml
+++ b/tests/policies.yml
@@ -1,0 +1,22 @@
+---
+parameters:
+  kyverno:
+    clusterpolicies:
+      test-policy:
+        metadata:
+          annotations:
+            policies.kyverno.io/title: Example Policy
+            policies.kyverno.io/subject: Pod
+          spec:
+            validationFailureAction: enforce
+            background: true
+      another-policy:
+        spec:
+          foo: bar
+
+  # Required for the tests to run
+  kapitan:
+    dependencies:
+      - type: https
+        source: https://raw.githubusercontent.com/appuio/component-openshift4-monitoring/v1.9.2/lib/prom.libsonnet
+        output_path: vendor/lib/prom.libsonnet

--- a/tests/unit/validate_test.go
+++ b/tests/unit/validate_test.go
@@ -19,6 +19,7 @@ func skipValidation(path string) bool {
 	ignore := []string{
 		fmt.Sprintf("%s/00_crds", testPath),
 		fmt.Sprintf("%s/10_monitoring", testPath),
+		fmt.Sprintf("%s/80_policies.yaml", testPath),
 	}
 	for _, iv := range ignore {
 		if iv == path {


### PR DESCRIPTION
This change introduces the option to define ClusterPolicies to be managed by Syn via this component. Currently, they are managed as ad-hoc manifests, which has many drawbacks.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] ~~Link this PR to related issues or PRs.~~
