### PR TITLE
Add parameter which allows customizing container security context 

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,13 +1,13 @@
 {
   "template": "https://github.com/projectsyn/commodore-component-template.git",
-  "commit": "0f8aa8baef803c2f09d710c717f26f7eff145407",
+  "commit": "86f54285090cc7ef5372a32b752f8bcdc562b338",
   "checkout": "main",
   "context": {
     "cookiecutter": {
       "name": "kyverno",
       "slug": "kyverno",
       "parameter_key": "kyverno",
-      "test_cases": "defaults policies",
+      "test_cases": "defaults policies openshift-4.10",
       "add_lib": "y",
       "add_pp": "n",
       "add_golden": "y",

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,6 +34,7 @@ jobs:
         instance:
           - defaults
           - policies
+          - openshift-4.10
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}
@@ -61,6 +62,7 @@ jobs:
         instance:
           - defaults
           - policies
+          - openshift-4.10
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}

--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -57,4 +57,4 @@ KUBENT_IMAGE    ?= ghcr.io/doitintl/kube-no-trouble:latest
 KUBENT_DOCKER   ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) --entrypoint=/app/kubent $(KUBENT_IMAGE)
 
 instance ?= defaults
-test_instances = tests/defaults.yml tests/policies.yml
+test_instances = tests/defaults.yml tests/policies.yml tests/openshift-4.10.yml

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -121,3 +121,7 @@ parameters:
     generateSuccessEvents: 'false'
     # Pass extra args to the kyverno container
     extraArgs: []
+    # Configure custom security context for the kyverno containers.
+    # Setting the parameter to null will clear the security context for
+    # OpenShift <= 4.10.
+    containerSecurityContext: {}

--- a/component/kyverno.jsonnet
+++ b/component/kyverno.jsonnet
@@ -89,6 +89,7 @@ com.Kustomization(
               {
                 name: 'kyverno-pre',
                 resources: params.resources.pre,
+                securityContext: params.containerSecurityContext,
               },
             ],
             containers: [
@@ -96,6 +97,7 @@ com.Kustomization(
                 name: 'kyverno',
                 resources: params.resources.kyverno,
                 args: params.extraArgs,
+                securityContext: params.containerSecurityContext,
               },
             ],
           },

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -103,6 +103,19 @@ extraArgs:
 
 Allows passing extra arguments to Kyverno.
 
+== `containerSecurityContext`
+
+[horizontal]
+type:: dict
+default:: `{}`
+
+This parameter allows customizing the container security context for the Kyverno deployment's containers (both init containers, and regular containers).
+By default, the security contexts present in the upstream Kustomization are used.
+
+On OpenShift 4.10 or older, where the upstream security context isn't compatible with the restricted SCC, you can provide `containerSecurityContext: null` to completely drop the upstream container security context.
+
+If a dict is provided, it's merged with the upstream security context using a standard Kustomize strategic merge patch.
+
 == `additionalClusterRoles`
 
 [horizontal]

--- a/tests/golden/defaults/kyverno/kyverno/10_pod-disruption-budget.yaml
+++ b/tests/golden/defaults/kyverno/kyverno/10_pod-disruption-budget.yaml
@@ -1,4 +1,4 @@
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   annotations: {}

--- a/tests/golden/openshift-4.10/kyverno/kyverno/10_monitoring/00_servicemonitor-kyverno.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/10_monitoring/00_servicemonitor-kyverno.yaml
@@ -1,0 +1,22 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: syn
+    name: kyverno
+  name: kyverno
+  namespace: syn-kyverno
+spec:
+  endpoints:
+    - port: metrics-port
+  namespaceSelector:
+    matchNames:
+      - syn-kyverno
+  selector:
+    matchLabels:
+      app.kubernetes.io/managed-by: commodore
+      app.kubernetes.io/name: kyverno
+      app.kubernetes.io/part-of: syn

--- a/tests/golden/openshift-4.10/kyverno/kyverno/10_monitoring/10_prometheusrule_kyverno-alerts.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/10_monitoring/10_prometheusrule_kyverno-alerts.yaml
@@ -1,0 +1,47 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: syn
+    name: kyverno-alerts
+  name: kyverno-alerts
+  namespace: syn-kyverno
+spec:
+  groups:
+    - name: kyverno-alerts
+      rules:
+        - alert: KyvernoAdmissionLatencyReachedWebhookTimeout
+          annotations:
+            description: Kyverno admission latency for {{$labels.resouce_kind}}/{{$labels.resource_namespace}}
+              higher than Kubernetes webhook timeout (10s).
+            message: Kyverno admission latency higher than Kubernetes webhook timeout
+              (10s).
+            runbook_url: https://hub.syn.tools/kyverno/runbooks/KyvernoAdmissionLatencyReachedWebhookTimeout.html
+            summary: Kyverno admission too slow.
+          expr: "(\n  sum by(resource_kind, resource_namespace) (increase(kyverno_admission_review_duration_seconds_bucket{le=\"\
+            +Inf\"}[10m]))\n-\n  sum by(resource_kind, resource_namespace) (increase(kyverno_admission_review_duration_seconds_bucket{le=\"\
+            10\"}[10m]))\n) > 0\n"
+          for: 5m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: kyverno
+        - alert: KyvernoAverageAdmissionLatencyHigh
+          annotations:
+            description: Kyverno average admission latency for {{$labels.resouce_kind}}
+              reached 5 seconds.
+            message: Kyverno average admission latency for {{$labels.resouce_kind}}
+              reached 5 seconds in the last 10 minutes.
+            runbook_url: https://hub.syn.tools/kyverno/runbooks/KyvernoAverageAdmissionLatencyHigh.html
+            summary: Kyverno admission is slowing down.
+          expr: "(\n  sum by (job,resource_kind) (rate(kyverno_admission_review_duration_seconds_sum[5m]))\n\
+            /\n  sum by (job,resource_kind) (rate(kyverno_admission_review_duration_seconds_count[5m]))\n\
+            ) > 5\n"
+          for: 10m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: kyverno

--- a/tests/golden/openshift-4.10/kyverno/kyverno/10_pod-disruption-budget.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/10_pod-disruption-budget.yaml
@@ -1,0 +1,17 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: syn
+    name: kyverno
+  name: kyverno
+  namespace: syn-kyverno
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: kyverno
+      app.kubernetes.io/name: kyverno

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_admissionreports.kyverno.io.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_admissionreports.kyverno.io.yaml
@@ -1,0 +1,341 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Replace=true
+    controller-gen.kubebuilder.io/version: v0.10.0
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: kyverno
+    app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/version: v1.8.1
+  name: admissionreports.kyverno.io
+spec:
+  group: kyverno.io
+  names:
+    kind: AdmissionReport
+    listKind: AdmissionReportList
+    plural: admissionreports
+    shortNames:
+    - admr
+    singular: admissionreport
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.ownerReferences[0].apiVersion
+      name: ApiVersion
+      priority: 1
+      type: string
+    - jsonPath: .metadata.ownerReferences[0].kind
+      name: Kind
+      priority: 1
+      type: string
+    - jsonPath: .metadata.ownerReferences[0].name
+      name: Subject
+      priority: 1
+      type: string
+    - jsonPath: .spec.summary.pass
+      name: Pass
+      type: integer
+    - jsonPath: .spec.summary.fail
+      name: Fail
+      type: integer
+    - jsonPath: .spec.summary.warn
+      name: Warn
+      type: integer
+    - jsonPath: .spec.summary.error
+      name: Error
+      type: integer
+    - jsonPath: .spec.summary.skip
+      name: Skip
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .metadata.labels['audit\.kyverno\.io/resource\.hash']
+      name: Hash
+      priority: 1
+      type: string
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: AdmissionReport is the Schema for the AdmissionReports API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              owner:
+                description: Owner is a reference to the report owner (e.g. a Deployment,
+                  Namespace, or Node)
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  blockOwnerDeletion:
+                    description: If true, AND if the owner has the "foregroundDeletion"
+                      finalizer, then the owner cannot be deleted from the key-value
+                      store until this reference is removed. See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion
+                      for how the garbage collector interacts with this field and
+                      enforces the foreground deletion. Defaults to false. To set
+                      this field, a user needs "delete" permission of the owner, otherwise
+                      422 (Unprocessable Entity) will be returned.
+                    type: boolean
+                  controller:
+                    description: If true, this reference points to the managing controller.
+                    type: boolean
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                - name
+                - uid
+                type: object
+                x-kubernetes-map-type: atomic
+              results:
+                description: PolicyReportResult provides result details
+                items:
+                  description: PolicyReportResult provides the result for an individual
+                    policy
+                  properties:
+                    category:
+                      description: Category indicates policy category
+                      type: string
+                    message:
+                      description: Description is a short user friendly message for
+                        the policy rule
+                      type: string
+                    policy:
+                      description: Policy is the name or identifier of the policy
+                      type: string
+                    properties:
+                      additionalProperties:
+                        type: string
+                      description: Properties provides additional information for
+                        the policy rule
+                      type: object
+                    resourceSelector:
+                      description: SubjectSelector is an optional label selector for
+                        checked Kubernetes resources. For example, a policy result
+                        may apply to all pods that match a label. Either a Subject
+                        or a SubjectSelector can be specified. If neither are provided,
+                        the result is assumed to be for the policy report scope.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector
+                              that contains values, a key, and an operator that relates
+                              the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship
+                                  to a set of values. Valid operators are In, NotIn,
+                                  Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values.
+                                  If the operator is In or NotIn, the values array
+                                  must be non-empty. If the operator is Exists or
+                                  DoesNotExist, the values array must be empty. This
+                                  array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: matchLabels is a map of {key,value} pairs.
+                            A single {key,value} in the matchLabels map is equivalent
+                            to an element of matchExpressions, whose key field is
+                            "key", the operator is "In", and the values array contains
+                            only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    resources:
+                      description: Subjects is an optional reference to the checked
+                        Kubernetes resources
+                      items:
+                        description: "ObjectReference contains enough information
+                          to let you inspect or modify the referred object. --- New
+                          uses of this type are discouraged because of difficulty
+                          describing its usage when embedded in APIs. 1. Ignored fields.
+                          \ It includes many fields which are not generally honored.
+                          \ For instance, ResourceVersion and FieldPath are both very
+                          rarely valid in actual usage. 2. Invalid usage help.  It
+                          is impossible to add specific help for individual usage.
+                          \ In most embedded usages, there are particular restrictions
+                          like, \"must refer only to types A and B\" or \"UID not
+                          honored\" or \"name must be restricted\". Those cannot be
+                          well described when embedded. 3. Inconsistent validation.
+                          \ Because the usages are different, the validation rules
+                          are different by usage, which makes it hard for users to
+                          predict what will happen. 4. The fields are both imprecise
+                          and overly precise.  Kind is not a precise mapping to a
+                          URL. This can produce ambiguity during interpretation and
+                          require a REST mapping.  In most cases, the dependency is
+                          on the group,resource tuple and the version of the actual
+                          struct is irrelevant. 5. We cannot easily change it.  Because
+                          this type is embedded in many locations, updates to this
+                          type will affect numerous schemas.  Don't make new APIs
+                          embed an underspecified API type they do not control. \n
+                          Instead of using this type, create a locally provided and
+                          used type that is well-focused on your reference. For example,
+                          ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                          ."
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: 'If referring to a piece of an object instead
+                              of an entire object, this string should contain a valid
+                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container
+                              within a pod, this would take on a value like: "spec.containers{name}"
+                              (where "name" refers to the name of the container that
+                              triggered the event) or if no container name is specified
+                              "spec.containers[2]" (container with index 2 in this
+                              pod). This syntax is chosen only to have some well-defined
+                              way of referencing a part of an object. TODO: this design
+                              is not final and this field is subject to change in
+                              the future.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                          resourceVersion:
+                            description: 'Specific resourceVersion to which this reference
+                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            type: string
+                          uid:
+                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      type: array
+                    result:
+                      description: Result indicates the outcome of the policy rule
+                        execution
+                      enum:
+                      - pass
+                      - fail
+                      - warn
+                      - error
+                      - skip
+                      type: string
+                    rule:
+                      description: Rule is the name or identifier of the rule within
+                        the policy
+                      type: string
+                    scored:
+                      description: Scored indicates if this result is scored
+                      type: boolean
+                    severity:
+                      description: Severity indicates policy check result criticality
+                      enum:
+                      - critical
+                      - high
+                      - low
+                      - medium
+                      - info
+                      type: string
+                    source:
+                      description: Source is an identifier for the policy engine that
+                        manages this report
+                      type: string
+                    timestamp:
+                      description: Timestamp indicates the time the result was found
+                      properties:
+                        nanos:
+                          description: Non-negative fractions of a second at nanosecond
+                            resolution. Negative second values with fractions must
+                            still have non-negative nanos values that count forward
+                            in time. Must be from 0 to 999,999,999 inclusive. This
+                            field may be limited in precision depending on context.
+                          format: int32
+                          type: integer
+                        seconds:
+                          description: Represents seconds of UTC time since Unix epoch
+                            1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z
+                            to 9999-12-31T23:59:59Z inclusive.
+                          format: int64
+                          type: integer
+                      required:
+                      - nanos
+                      - seconds
+                      type: object
+                  required:
+                  - policy
+                  type: object
+                type: array
+              summary:
+                description: PolicyReportSummary provides a summary of results
+                properties:
+                  error:
+                    description: Error provides the count of policies that could not
+                      be evaluated
+                    type: integer
+                  fail:
+                    description: Fail provides the count of policies whose requirements
+                      were not met
+                    type: integer
+                  pass:
+                    description: Pass provides the count of policies whose requirements
+                      were met
+                    type: integer
+                  skip:
+                    description: Skip indicates the count of policies that were not
+                      selected for evaluation
+                    type: integer
+                  warn:
+                    description: Warn provides the count of non-scored policies whose
+                      requirements were not met
+                    type: integer
+                type: object
+            required:
+            - owner
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_backgroundscanreports.kyverno.io.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_backgroundscanreports.kyverno.io.yaml
@@ -1,0 +1,305 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Replace=true
+    controller-gen.kubebuilder.io/version: v0.10.0
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: kyverno
+    app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/version: v1.8.1
+  name: backgroundscanreports.kyverno.io
+spec:
+  group: kyverno.io
+  names:
+    kind: BackgroundScanReport
+    listKind: BackgroundScanReportList
+    plural: backgroundscanreports
+    shortNames:
+    - bgscanr
+    singular: backgroundscanreport
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.ownerReferences[0].apiVersion
+      name: ApiVersion
+      priority: 1
+      type: string
+    - jsonPath: .metadata.ownerReferences[0].kind
+      name: Kind
+      priority: 1
+      type: string
+    - jsonPath: .metadata.ownerReferences[0].name
+      name: Subject
+      priority: 1
+      type: string
+    - jsonPath: .spec.summary.pass
+      name: Pass
+      type: integer
+    - jsonPath: .spec.summary.fail
+      name: Fail
+      type: integer
+    - jsonPath: .spec.summary.warn
+      name: Warn
+      type: integer
+    - jsonPath: .spec.summary.error
+      name: Error
+      type: integer
+    - jsonPath: .spec.summary.skip
+      name: Skip
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .metadata.labels['audit\.kyverno\.io/resource\.hash']
+      name: Hash
+      priority: 1
+      type: string
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: BackgroundScanReport is the Schema for the BackgroundScanReports
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              results:
+                description: PolicyReportResult provides result details
+                items:
+                  description: PolicyReportResult provides the result for an individual
+                    policy
+                  properties:
+                    category:
+                      description: Category indicates policy category
+                      type: string
+                    message:
+                      description: Description is a short user friendly message for
+                        the policy rule
+                      type: string
+                    policy:
+                      description: Policy is the name or identifier of the policy
+                      type: string
+                    properties:
+                      additionalProperties:
+                        type: string
+                      description: Properties provides additional information for
+                        the policy rule
+                      type: object
+                    resourceSelector:
+                      description: SubjectSelector is an optional label selector for
+                        checked Kubernetes resources. For example, a policy result
+                        may apply to all pods that match a label. Either a Subject
+                        or a SubjectSelector can be specified. If neither are provided,
+                        the result is assumed to be for the policy report scope.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector
+                              that contains values, a key, and an operator that relates
+                              the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship
+                                  to a set of values. Valid operators are In, NotIn,
+                                  Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values.
+                                  If the operator is In or NotIn, the values array
+                                  must be non-empty. If the operator is Exists or
+                                  DoesNotExist, the values array must be empty. This
+                                  array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: matchLabels is a map of {key,value} pairs.
+                            A single {key,value} in the matchLabels map is equivalent
+                            to an element of matchExpressions, whose key field is
+                            "key", the operator is "In", and the values array contains
+                            only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    resources:
+                      description: Subjects is an optional reference to the checked
+                        Kubernetes resources
+                      items:
+                        description: "ObjectReference contains enough information
+                          to let you inspect or modify the referred object. --- New
+                          uses of this type are discouraged because of difficulty
+                          describing its usage when embedded in APIs. 1. Ignored fields.
+                          \ It includes many fields which are not generally honored.
+                          \ For instance, ResourceVersion and FieldPath are both very
+                          rarely valid in actual usage. 2. Invalid usage help.  It
+                          is impossible to add specific help for individual usage.
+                          \ In most embedded usages, there are particular restrictions
+                          like, \"must refer only to types A and B\" or \"UID not
+                          honored\" or \"name must be restricted\". Those cannot be
+                          well described when embedded. 3. Inconsistent validation.
+                          \ Because the usages are different, the validation rules
+                          are different by usage, which makes it hard for users to
+                          predict what will happen. 4. The fields are both imprecise
+                          and overly precise.  Kind is not a precise mapping to a
+                          URL. This can produce ambiguity during interpretation and
+                          require a REST mapping.  In most cases, the dependency is
+                          on the group,resource tuple and the version of the actual
+                          struct is irrelevant. 5. We cannot easily change it.  Because
+                          this type is embedded in many locations, updates to this
+                          type will affect numerous schemas.  Don't make new APIs
+                          embed an underspecified API type they do not control. \n
+                          Instead of using this type, create a locally provided and
+                          used type that is well-focused on your reference. For example,
+                          ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                          ."
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: 'If referring to a piece of an object instead
+                              of an entire object, this string should contain a valid
+                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container
+                              within a pod, this would take on a value like: "spec.containers{name}"
+                              (where "name" refers to the name of the container that
+                              triggered the event) or if no container name is specified
+                              "spec.containers[2]" (container with index 2 in this
+                              pod). This syntax is chosen only to have some well-defined
+                              way of referencing a part of an object. TODO: this design
+                              is not final and this field is subject to change in
+                              the future.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                          resourceVersion:
+                            description: 'Specific resourceVersion to which this reference
+                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            type: string
+                          uid:
+                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      type: array
+                    result:
+                      description: Result indicates the outcome of the policy rule
+                        execution
+                      enum:
+                      - pass
+                      - fail
+                      - warn
+                      - error
+                      - skip
+                      type: string
+                    rule:
+                      description: Rule is the name or identifier of the rule within
+                        the policy
+                      type: string
+                    scored:
+                      description: Scored indicates if this result is scored
+                      type: boolean
+                    severity:
+                      description: Severity indicates policy check result criticality
+                      enum:
+                      - critical
+                      - high
+                      - low
+                      - medium
+                      - info
+                      type: string
+                    source:
+                      description: Source is an identifier for the policy engine that
+                        manages this report
+                      type: string
+                    timestamp:
+                      description: Timestamp indicates the time the result was found
+                      properties:
+                        nanos:
+                          description: Non-negative fractions of a second at nanosecond
+                            resolution. Negative second values with fractions must
+                            still have non-negative nanos values that count forward
+                            in time. Must be from 0 to 999,999,999 inclusive. This
+                            field may be limited in precision depending on context.
+                          format: int32
+                          type: integer
+                        seconds:
+                          description: Represents seconds of UTC time since Unix epoch
+                            1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z
+                            to 9999-12-31T23:59:59Z inclusive.
+                          format: int64
+                          type: integer
+                      required:
+                      - nanos
+                      - seconds
+                      type: object
+                  required:
+                  - policy
+                  type: object
+                type: array
+              summary:
+                description: PolicyReportSummary provides a summary of results
+                properties:
+                  error:
+                    description: Error provides the count of policies that could not
+                      be evaluated
+                    type: integer
+                  fail:
+                    description: Fail provides the count of policies whose requirements
+                      were not met
+                    type: integer
+                  pass:
+                    description: Pass provides the count of policies whose requirements
+                      were met
+                    type: integer
+                  skip:
+                    description: Skip indicates the count of policies that were not
+                      selected for evaluation
+                    type: integer
+                  warn:
+                    description: Warn provides the count of non-scored policies whose
+                      requirements were not met
+                    type: integer
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clusteradmissionreports.kyverno.io.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clusteradmissionreports.kyverno.io.yaml
@@ -1,0 +1,342 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Replace=true
+    controller-gen.kubebuilder.io/version: v0.10.0
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: kyverno
+    app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/version: v1.8.1
+  name: clusteradmissionreports.kyverno.io
+spec:
+  group: kyverno.io
+  names:
+    kind: ClusterAdmissionReport
+    listKind: ClusterAdmissionReportList
+    plural: clusteradmissionreports
+    shortNames:
+    - cadmr
+    singular: clusteradmissionreport
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.ownerReferences[0].apiVersion
+      name: ApiVersion
+      priority: 1
+      type: string
+    - jsonPath: .metadata.ownerReferences[0].kind
+      name: Kind
+      priority: 1
+      type: string
+    - jsonPath: .metadata.ownerReferences[0].name
+      name: Subject
+      priority: 1
+      type: string
+    - jsonPath: .spec.summary.pass
+      name: Pass
+      type: integer
+    - jsonPath: .spec.summary.fail
+      name: Fail
+      type: integer
+    - jsonPath: .spec.summary.warn
+      name: Warn
+      type: integer
+    - jsonPath: .spec.summary.error
+      name: Error
+      type: integer
+    - jsonPath: .spec.summary.skip
+      name: Skip
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .metadata.labels['audit\.kyverno\.io/resource\.hash']
+      name: Hash
+      priority: 1
+      type: string
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: ClusterAdmissionReport is the Schema for the ClusterAdmissionReports
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              owner:
+                description: Owner is a reference to the report owner (e.g. a Deployment,
+                  Namespace, or Node)
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  blockOwnerDeletion:
+                    description: If true, AND if the owner has the "foregroundDeletion"
+                      finalizer, then the owner cannot be deleted from the key-value
+                      store until this reference is removed. See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion
+                      for how the garbage collector interacts with this field and
+                      enforces the foreground deletion. Defaults to false. To set
+                      this field, a user needs "delete" permission of the owner, otherwise
+                      422 (Unprocessable Entity) will be returned.
+                    type: boolean
+                  controller:
+                    description: If true, this reference points to the managing controller.
+                    type: boolean
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                - name
+                - uid
+                type: object
+                x-kubernetes-map-type: atomic
+              results:
+                description: PolicyReportResult provides result details
+                items:
+                  description: PolicyReportResult provides the result for an individual
+                    policy
+                  properties:
+                    category:
+                      description: Category indicates policy category
+                      type: string
+                    message:
+                      description: Description is a short user friendly message for
+                        the policy rule
+                      type: string
+                    policy:
+                      description: Policy is the name or identifier of the policy
+                      type: string
+                    properties:
+                      additionalProperties:
+                        type: string
+                      description: Properties provides additional information for
+                        the policy rule
+                      type: object
+                    resourceSelector:
+                      description: SubjectSelector is an optional label selector for
+                        checked Kubernetes resources. For example, a policy result
+                        may apply to all pods that match a label. Either a Subject
+                        or a SubjectSelector can be specified. If neither are provided,
+                        the result is assumed to be for the policy report scope.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector
+                              that contains values, a key, and an operator that relates
+                              the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship
+                                  to a set of values. Valid operators are In, NotIn,
+                                  Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values.
+                                  If the operator is In or NotIn, the values array
+                                  must be non-empty. If the operator is Exists or
+                                  DoesNotExist, the values array must be empty. This
+                                  array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: matchLabels is a map of {key,value} pairs.
+                            A single {key,value} in the matchLabels map is equivalent
+                            to an element of matchExpressions, whose key field is
+                            "key", the operator is "In", and the values array contains
+                            only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    resources:
+                      description: Subjects is an optional reference to the checked
+                        Kubernetes resources
+                      items:
+                        description: "ObjectReference contains enough information
+                          to let you inspect or modify the referred object. --- New
+                          uses of this type are discouraged because of difficulty
+                          describing its usage when embedded in APIs. 1. Ignored fields.
+                          \ It includes many fields which are not generally honored.
+                          \ For instance, ResourceVersion and FieldPath are both very
+                          rarely valid in actual usage. 2. Invalid usage help.  It
+                          is impossible to add specific help for individual usage.
+                          \ In most embedded usages, there are particular restrictions
+                          like, \"must refer only to types A and B\" or \"UID not
+                          honored\" or \"name must be restricted\". Those cannot be
+                          well described when embedded. 3. Inconsistent validation.
+                          \ Because the usages are different, the validation rules
+                          are different by usage, which makes it hard for users to
+                          predict what will happen. 4. The fields are both imprecise
+                          and overly precise.  Kind is not a precise mapping to a
+                          URL. This can produce ambiguity during interpretation and
+                          require a REST mapping.  In most cases, the dependency is
+                          on the group,resource tuple and the version of the actual
+                          struct is irrelevant. 5. We cannot easily change it.  Because
+                          this type is embedded in many locations, updates to this
+                          type will affect numerous schemas.  Don't make new APIs
+                          embed an underspecified API type they do not control. \n
+                          Instead of using this type, create a locally provided and
+                          used type that is well-focused on your reference. For example,
+                          ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                          ."
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: 'If referring to a piece of an object instead
+                              of an entire object, this string should contain a valid
+                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container
+                              within a pod, this would take on a value like: "spec.containers{name}"
+                              (where "name" refers to the name of the container that
+                              triggered the event) or if no container name is specified
+                              "spec.containers[2]" (container with index 2 in this
+                              pod). This syntax is chosen only to have some well-defined
+                              way of referencing a part of an object. TODO: this design
+                              is not final and this field is subject to change in
+                              the future.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                          resourceVersion:
+                            description: 'Specific resourceVersion to which this reference
+                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            type: string
+                          uid:
+                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      type: array
+                    result:
+                      description: Result indicates the outcome of the policy rule
+                        execution
+                      enum:
+                      - pass
+                      - fail
+                      - warn
+                      - error
+                      - skip
+                      type: string
+                    rule:
+                      description: Rule is the name or identifier of the rule within
+                        the policy
+                      type: string
+                    scored:
+                      description: Scored indicates if this result is scored
+                      type: boolean
+                    severity:
+                      description: Severity indicates policy check result criticality
+                      enum:
+                      - critical
+                      - high
+                      - low
+                      - medium
+                      - info
+                      type: string
+                    source:
+                      description: Source is an identifier for the policy engine that
+                        manages this report
+                      type: string
+                    timestamp:
+                      description: Timestamp indicates the time the result was found
+                      properties:
+                        nanos:
+                          description: Non-negative fractions of a second at nanosecond
+                            resolution. Negative second values with fractions must
+                            still have non-negative nanos values that count forward
+                            in time. Must be from 0 to 999,999,999 inclusive. This
+                            field may be limited in precision depending on context.
+                          format: int32
+                          type: integer
+                        seconds:
+                          description: Represents seconds of UTC time since Unix epoch
+                            1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z
+                            to 9999-12-31T23:59:59Z inclusive.
+                          format: int64
+                          type: integer
+                      required:
+                      - nanos
+                      - seconds
+                      type: object
+                  required:
+                  - policy
+                  type: object
+                type: array
+              summary:
+                description: PolicyReportSummary provides a summary of results
+                properties:
+                  error:
+                    description: Error provides the count of policies that could not
+                      be evaluated
+                    type: integer
+                  fail:
+                    description: Fail provides the count of policies whose requirements
+                      were not met
+                    type: integer
+                  pass:
+                    description: Pass provides the count of policies whose requirements
+                      were met
+                    type: integer
+                  skip:
+                    description: Skip indicates the count of policies that were not
+                      selected for evaluation
+                    type: integer
+                  warn:
+                    description: Warn provides the count of non-scored policies whose
+                      requirements were not met
+                    type: integer
+                type: object
+            required:
+            - owner
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clusterbackgroundscanreports.kyverno.io.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clusterbackgroundscanreports.kyverno.io.yaml
@@ -1,0 +1,305 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Replace=true
+    controller-gen.kubebuilder.io/version: v0.10.0
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: kyverno
+    app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/version: v1.8.1
+  name: clusterbackgroundscanreports.kyverno.io
+spec:
+  group: kyverno.io
+  names:
+    kind: ClusterBackgroundScanReport
+    listKind: ClusterBackgroundScanReportList
+    plural: clusterbackgroundscanreports
+    shortNames:
+    - cbgscanr
+    singular: clusterbackgroundscanreport
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.ownerReferences[0].apiVersion
+      name: ApiVersion
+      priority: 1
+      type: string
+    - jsonPath: .metadata.ownerReferences[0].kind
+      name: Kind
+      priority: 1
+      type: string
+    - jsonPath: .metadata.ownerReferences[0].name
+      name: Subject
+      priority: 1
+      type: string
+    - jsonPath: .spec.summary.pass
+      name: Pass
+      type: integer
+    - jsonPath: .spec.summary.fail
+      name: Fail
+      type: integer
+    - jsonPath: .spec.summary.warn
+      name: Warn
+      type: integer
+    - jsonPath: .spec.summary.error
+      name: Error
+      type: integer
+    - jsonPath: .spec.summary.skip
+      name: Skip
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .metadata.labels['audit\.kyverno\.io/resource\.hash']
+      name: Hash
+      priority: 1
+      type: string
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: ClusterBackgroundScanReport is the Schema for the ClusterBackgroundScanReports
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              results:
+                description: PolicyReportResult provides result details
+                items:
+                  description: PolicyReportResult provides the result for an individual
+                    policy
+                  properties:
+                    category:
+                      description: Category indicates policy category
+                      type: string
+                    message:
+                      description: Description is a short user friendly message for
+                        the policy rule
+                      type: string
+                    policy:
+                      description: Policy is the name or identifier of the policy
+                      type: string
+                    properties:
+                      additionalProperties:
+                        type: string
+                      description: Properties provides additional information for
+                        the policy rule
+                      type: object
+                    resourceSelector:
+                      description: SubjectSelector is an optional label selector for
+                        checked Kubernetes resources. For example, a policy result
+                        may apply to all pods that match a label. Either a Subject
+                        or a SubjectSelector can be specified. If neither are provided,
+                        the result is assumed to be for the policy report scope.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector
+                              that contains values, a key, and an operator that relates
+                              the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship
+                                  to a set of values. Valid operators are In, NotIn,
+                                  Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values.
+                                  If the operator is In or NotIn, the values array
+                                  must be non-empty. If the operator is Exists or
+                                  DoesNotExist, the values array must be empty. This
+                                  array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: matchLabels is a map of {key,value} pairs.
+                            A single {key,value} in the matchLabels map is equivalent
+                            to an element of matchExpressions, whose key field is
+                            "key", the operator is "In", and the values array contains
+                            only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    resources:
+                      description: Subjects is an optional reference to the checked
+                        Kubernetes resources
+                      items:
+                        description: "ObjectReference contains enough information
+                          to let you inspect or modify the referred object. --- New
+                          uses of this type are discouraged because of difficulty
+                          describing its usage when embedded in APIs. 1. Ignored fields.
+                          \ It includes many fields which are not generally honored.
+                          \ For instance, ResourceVersion and FieldPath are both very
+                          rarely valid in actual usage. 2. Invalid usage help.  It
+                          is impossible to add specific help for individual usage.
+                          \ In most embedded usages, there are particular restrictions
+                          like, \"must refer only to types A and B\" or \"UID not
+                          honored\" or \"name must be restricted\". Those cannot be
+                          well described when embedded. 3. Inconsistent validation.
+                          \ Because the usages are different, the validation rules
+                          are different by usage, which makes it hard for users to
+                          predict what will happen. 4. The fields are both imprecise
+                          and overly precise.  Kind is not a precise mapping to a
+                          URL. This can produce ambiguity during interpretation and
+                          require a REST mapping.  In most cases, the dependency is
+                          on the group,resource tuple and the version of the actual
+                          struct is irrelevant. 5. We cannot easily change it.  Because
+                          this type is embedded in many locations, updates to this
+                          type will affect numerous schemas.  Don't make new APIs
+                          embed an underspecified API type they do not control. \n
+                          Instead of using this type, create a locally provided and
+                          used type that is well-focused on your reference. For example,
+                          ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                          ."
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: 'If referring to a piece of an object instead
+                              of an entire object, this string should contain a valid
+                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container
+                              within a pod, this would take on a value like: "spec.containers{name}"
+                              (where "name" refers to the name of the container that
+                              triggered the event) or if no container name is specified
+                              "spec.containers[2]" (container with index 2 in this
+                              pod). This syntax is chosen only to have some well-defined
+                              way of referencing a part of an object. TODO: this design
+                              is not final and this field is subject to change in
+                              the future.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                          resourceVersion:
+                            description: 'Specific resourceVersion to which this reference
+                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            type: string
+                          uid:
+                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      type: array
+                    result:
+                      description: Result indicates the outcome of the policy rule
+                        execution
+                      enum:
+                      - pass
+                      - fail
+                      - warn
+                      - error
+                      - skip
+                      type: string
+                    rule:
+                      description: Rule is the name or identifier of the rule within
+                        the policy
+                      type: string
+                    scored:
+                      description: Scored indicates if this result is scored
+                      type: boolean
+                    severity:
+                      description: Severity indicates policy check result criticality
+                      enum:
+                      - critical
+                      - high
+                      - low
+                      - medium
+                      - info
+                      type: string
+                    source:
+                      description: Source is an identifier for the policy engine that
+                        manages this report
+                      type: string
+                    timestamp:
+                      description: Timestamp indicates the time the result was found
+                      properties:
+                        nanos:
+                          description: Non-negative fractions of a second at nanosecond
+                            resolution. Negative second values with fractions must
+                            still have non-negative nanos values that count forward
+                            in time. Must be from 0 to 999,999,999 inclusive. This
+                            field may be limited in precision depending on context.
+                          format: int32
+                          type: integer
+                        seconds:
+                          description: Represents seconds of UTC time since Unix epoch
+                            1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z
+                            to 9999-12-31T23:59:59Z inclusive.
+                          format: int64
+                          type: integer
+                      required:
+                      - nanos
+                      - seconds
+                      type: object
+                  required:
+                  - policy
+                  type: object
+                type: array
+              summary:
+                description: PolicyReportSummary provides a summary of results
+                properties:
+                  error:
+                    description: Error provides the count of policies that could not
+                      be evaluated
+                    type: integer
+                  fail:
+                    description: Fail provides the count of policies whose requirements
+                      were not met
+                    type: integer
+                  pass:
+                    description: Pass provides the count of policies whose requirements
+                      were met
+                    type: integer
+                  skip:
+                    description: Skip indicates the count of policies that were not
+                      selected for evaluation
+                    type: integer
+                  warn:
+                    description: Warn provides the count of non-scored policies whose
+                      requirements were not met
+                    type: integer
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clusterpolicies.kyverno.io.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clusterpolicies.kyverno.io.yaml
@@ -1,0 +1,11239 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Replace=true
+    controller-gen.kubebuilder.io/version: v0.10.0
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: kyverno
+    app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/version: v1.8.1
+  name: clusterpolicies.kyverno.io
+spec:
+  group: kyverno.io
+  names:
+    kind: ClusterPolicy
+    listKind: ClusterPolicyList
+    plural: clusterpolicies
+    shortNames:
+    - cpol
+    singular: clusterpolicy
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.background
+      name: Background
+      type: boolean
+    - jsonPath: .spec.validationFailureAction
+      name: Validate Action
+      type: string
+    - jsonPath: .spec.failurePolicy
+      name: Failure Policy
+      priority: 1
+      type: string
+    - jsonPath: .status.ready
+      name: Ready
+      type: boolean
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: ClusterPolicy declares validation, mutation, and generation behaviors
+          for matching resources.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec declares policy behaviors.
+            properties:
+              applyRules:
+                description: ApplyRules controls how rules in a policy are applied.
+                  Rule are processed in the order of declaration. When set to `One`
+                  processing stops after a rule has been applied i.e. the rule matches
+                  and results in a pass, fail, or error. When set to `All` all rules
+                  in the policy are processed. The default is `All`.
+                enum:
+                - All
+                - One
+                type: string
+              background:
+                default: true
+                description: Background controls if rules are applied to existing
+                  resources during a background scan. Optional. Default value is "true".
+                  The value must be set to "false" if the policy rule uses variables
+                  that are only available in the admission review request (e.g. user
+                  name).
+                type: boolean
+              failurePolicy:
+                description: FailurePolicy defines how unexpected policy errors and
+                  webhook response timeout errors are handled. Rules within the same
+                  policy share the same failure behavior. Allowed values are Ignore
+                  or Fail. Defaults to Fail.
+                enum:
+                - Ignore
+                - Fail
+                type: string
+              generateExistingOnPolicyUpdate:
+                description: GenerateExistingOnPolicyUpdate controls whether to trigger
+                  generate rule in existing resources If is set to "true" generate
+                  rule will be triggered and applied to existing matched resources.
+                  Defaults to "false" if not specified.
+                type: boolean
+              mutateExistingOnPolicyUpdate:
+                description: MutateExistingOnPolicyUpdate controls if a mutateExisting
+                  policy is applied on policy events. Default value is "false".
+                type: boolean
+              rules:
+                description: Rules is a list of Rule instances. A Policy contains
+                  multiple rules and each rule can validate, mutate, or generate resources.
+                items:
+                  description: Rule defines a validation, mutation, or generation
+                    control for matching resources. Each rules contains a match declaration
+                    to select resources, and an optional exclude declaration to specify
+                    which resources to exclude.
+                  properties:
+                    context:
+                      description: Context defines variables and data sources that
+                        can be used during rule execution.
+                      items:
+                        description: ContextEntry adds variables and data sources
+                          to a rule Context. Either a ConfigMap reference or a APILookup
+                          must be provided.
+                        properties:
+                          apiCall:
+                            description: APICall defines an HTTP request to the Kubernetes
+                              API server. The JSON data retrieved is stored in the
+                              context.
+                            properties:
+                              jmesPath:
+                                description: JMESPath is an optional JSON Match Expression
+                                  that can be used to transform the JSON response
+                                  returned from the API server. For example a JMESPath
+                                  of "items | length(@)" applied to the API server
+                                  response to the URLPath "/apis/apps/v1/deployments"
+                                  will return the total count of deployments across
+                                  all namespaces.
+                                type: string
+                              urlPath:
+                                description: URLPath is the URL path to be used in
+                                  the HTTP GET request to the Kubernetes API server
+                                  (e.g. "/api/v1/namespaces" or  "/apis/apps/v1/deployments").
+                                  The format required is the same format used by the
+                                  `kubectl get --raw` command.
+                                type: string
+                            required:
+                            - urlPath
+                            type: object
+                          configMap:
+                            description: ConfigMap is the ConfigMap reference.
+                            properties:
+                              name:
+                                description: Name is the ConfigMap name.
+                                type: string
+                              namespace:
+                                description: Namespace is the ConfigMap namespace.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          imageRegistry:
+                            description: ImageRegistry defines requests to an OCI/Docker
+                              V2 registry to fetch image details.
+                            properties:
+                              jmesPath:
+                                description: JMESPath is an optional JSON Match Expression
+                                  that can be used to transform the ImageData struct
+                                  returned as a result of processing the image reference.
+                                type: string
+                              reference:
+                                description: 'Reference is image reference to a container
+                                  image in the registry. Example: ghcr.io/kyverno/kyverno:latest'
+                                type: string
+                            required:
+                            - reference
+                            type: object
+                          name:
+                            description: Name is the variable name.
+                            type: string
+                          variable:
+                            description: Variable defines an arbitrary JMESPath context
+                              variable that can be defined inline.
+                            properties:
+                              default:
+                                description: Default is an optional arbitrary JSON
+                                  object that the variable may take if the JMESPath
+                                  expression evaluates to nil
+                                x-kubernetes-preserve-unknown-fields: true
+                              jmesPath:
+                                description: JMESPath is an optional JMESPath Expression
+                                  that can be used to transform the variable.
+                                type: string
+                              value:
+                                description: Value is any arbitrary JSON object representable
+                                  in YAML or JSON form.
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                        type: object
+                      type: array
+                    exclude:
+                      description: ExcludeResources defines when this policy rule
+                        should not be applied. The exclude criteria can include resource
+                        information (e.g. kind, name, namespace, labels) and admission
+                        review request information like the name or role.
+                      properties:
+                        all:
+                          description: All allows specifying resources which will
+                            be ANDed
+                          items:
+                            description: ResourceFilter allow users to "AND" or "OR"
+                              between resources
+                            properties:
+                              clusterRoles:
+                                description: ClusterRoles is the list of cluster-wide
+                                  role names for the user.
+                                items:
+                                  type: string
+                                type: array
+                              resources:
+                                description: ResourceDescription contains information
+                                  about the resource being created or modified.
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations is a  map of annotations
+                                      (key-value pairs of type string). Annotation
+                                      keys and values support the wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (matches at least one character).
+                                    type: object
+                                  kinds:
+                                    description: Kinds is a list of resource kinds.
+                                    items:
+                                      type: string
+                                    type: array
+                                  name:
+                                    description: 'Name is the name of the resource.
+                                      The name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character). NOTE: "Name" is being deprecated
+                                      in favor of "Names".'
+                                    type: string
+                                  names:
+                                    description: Names are the names of the resources.
+                                      Each name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character).
+                                    items:
+                                      type: string
+                                    type: array
+                                  namespaceSelector:
+                                    description: 'NamespaceSelector is a label selector
+                                      for the resource namespace. Label keys and values
+                                      in `matchLabels` support the wildcard characters
+                                      `*` (matches zero or many characters) and `?`
+                                      (matches one character).Wildcards allows writing
+                                      label selectors like ["storage.k8s.io/*": "*"].
+                                      Note that using ["*" : "*"] matches any key
+                                      and value but does not match an empty label
+                                      set.'
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaces:
+                                    description: Namespaces is a list of namespaces
+                                      names. Each name supports wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (at least one character).
+                                    items:
+                                      type: string
+                                    type: array
+                                  selector:
+                                    description: 'Selector is a label selector. Label
+                                      keys and values in `matchLabels` support the
+                                      wildcard characters `*` (matches zero or many
+                                      characters) and `?` (matches one character).
+                                      Wildcards allows writing label selectors like
+                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                      : "*"] matches any key and value but does not
+                                      match an empty label set.'
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              roles:
+                                description: Roles is the list of namespaced role
+                                  names for the user.
+                                items:
+                                  type: string
+                                type: array
+                              subjects:
+                                description: Subjects is the list of subject names
+                                  like users, user groups, and service accounts.
+                                items:
+                                  description: Subject contains a reference to the
+                                    object or user identities a role binding applies
+                                    to.  This can either hold a direct API object
+                                    reference, or a value for non-objects such as
+                                    user and group names.
+                                  properties:
+                                    apiGroup:
+                                      description: APIGroup holds the API group of
+                                        the referenced subject. Defaults to "" for
+                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
+                                        for User and Group subjects.
+                                      type: string
+                                    kind:
+                                      description: Kind of object being referenced.
+                                        Values defined by this API group are "User",
+                                        "Group", and "ServiceAccount". If the Authorizer
+                                        does not recognized the kind value, the Authorizer
+                                        should report an error.
+                                      type: string
+                                    name:
+                                      description: Name of the object being referenced.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the referenced object.  If
+                                        the object kind is non-namespace, such as
+                                        "User" or "Group", and this value is not empty
+                                        the Authorizer should report an error.
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                type: array
+                            type: object
+                          type: array
+                        any:
+                          description: Any allows specifying resources which will
+                            be ORed
+                          items:
+                            description: ResourceFilter allow users to "AND" or "OR"
+                              between resources
+                            properties:
+                              clusterRoles:
+                                description: ClusterRoles is the list of cluster-wide
+                                  role names for the user.
+                                items:
+                                  type: string
+                                type: array
+                              resources:
+                                description: ResourceDescription contains information
+                                  about the resource being created or modified.
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations is a  map of annotations
+                                      (key-value pairs of type string). Annotation
+                                      keys and values support the wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (matches at least one character).
+                                    type: object
+                                  kinds:
+                                    description: Kinds is a list of resource kinds.
+                                    items:
+                                      type: string
+                                    type: array
+                                  name:
+                                    description: 'Name is the name of the resource.
+                                      The name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character). NOTE: "Name" is being deprecated
+                                      in favor of "Names".'
+                                    type: string
+                                  names:
+                                    description: Names are the names of the resources.
+                                      Each name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character).
+                                    items:
+                                      type: string
+                                    type: array
+                                  namespaceSelector:
+                                    description: 'NamespaceSelector is a label selector
+                                      for the resource namespace. Label keys and values
+                                      in `matchLabels` support the wildcard characters
+                                      `*` (matches zero or many characters) and `?`
+                                      (matches one character).Wildcards allows writing
+                                      label selectors like ["storage.k8s.io/*": "*"].
+                                      Note that using ["*" : "*"] matches any key
+                                      and value but does not match an empty label
+                                      set.'
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaces:
+                                    description: Namespaces is a list of namespaces
+                                      names. Each name supports wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (at least one character).
+                                    items:
+                                      type: string
+                                    type: array
+                                  selector:
+                                    description: 'Selector is a label selector. Label
+                                      keys and values in `matchLabels` support the
+                                      wildcard characters `*` (matches zero or many
+                                      characters) and `?` (matches one character).
+                                      Wildcards allows writing label selectors like
+                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                      : "*"] matches any key and value but does not
+                                      match an empty label set.'
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              roles:
+                                description: Roles is the list of namespaced role
+                                  names for the user.
+                                items:
+                                  type: string
+                                type: array
+                              subjects:
+                                description: Subjects is the list of subject names
+                                  like users, user groups, and service accounts.
+                                items:
+                                  description: Subject contains a reference to the
+                                    object or user identities a role binding applies
+                                    to.  This can either hold a direct API object
+                                    reference, or a value for non-objects such as
+                                    user and group names.
+                                  properties:
+                                    apiGroup:
+                                      description: APIGroup holds the API group of
+                                        the referenced subject. Defaults to "" for
+                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
+                                        for User and Group subjects.
+                                      type: string
+                                    kind:
+                                      description: Kind of object being referenced.
+                                        Values defined by this API group are "User",
+                                        "Group", and "ServiceAccount". If the Authorizer
+                                        does not recognized the kind value, the Authorizer
+                                        should report an error.
+                                      type: string
+                                    name:
+                                      description: Name of the object being referenced.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the referenced object.  If
+                                        the object kind is non-namespace, such as
+                                        "User" or "Group", and this value is not empty
+                                        the Authorizer should report an error.
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                type: array
+                            type: object
+                          type: array
+                        clusterRoles:
+                          description: ClusterRoles is the list of cluster-wide role
+                            names for the user.
+                          items:
+                            type: string
+                          type: array
+                        resources:
+                          description: ResourceDescription contains information about
+                            the resource being created or modified. Requires at least
+                            one tag to be specified when under MatchResources. Specifying
+                            ResourceDescription directly under match is being deprecated.
+                            Please specify under "any" or "all" instead.
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a  map of annotations (key-value
+                                pairs of type string). Annotation keys and values
+                                support the wildcard characters "*" (matches zero
+                                or many characters) and "?" (matches at least one
+                                character).
+                              type: object
+                            kinds:
+                              description: Kinds is a list of resource kinds.
+                              items:
+                                type: string
+                              type: array
+                            name:
+                              description: 'Name is the name of the resource. The
+                                name supports wildcard characters "*" (matches zero
+                                or many characters) and "?" (at least one character).
+                                NOTE: "Name" is being deprecated in favor of "Names".'
+                              type: string
+                            names:
+                              description: Names are the names of the resources. Each
+                                name supports wildcard characters "*" (matches zero
+                                or many characters) and "?" (at least one character).
+                              items:
+                                type: string
+                              type: array
+                            namespaceSelector:
+                              description: 'NamespaceSelector is a label selector
+                                for the resource namespace. Label keys and values
+                                in `matchLabels` support the wildcard characters `*`
+                                (matches zero or many characters) and `?` (matches
+                                one character).Wildcards allows writing label selectors
+                                like ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                : "*"] matches any key and value but does not match
+                                an empty label set.'
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            namespaces:
+                              description: Namespaces is a list of namespaces names.
+                                Each name supports wildcard characters "*" (matches
+                                zero or many characters) and "?" (at least one character).
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: 'Selector is a label selector. Label keys
+                                and values in `matchLabels` support the wildcard characters
+                                `*` (matches zero or many characters) and `?` (matches
+                                one character). Wildcards allows writing label selectors
+                                like ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                : "*"] matches any key and value but does not match
+                                an empty label set.'
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        roles:
+                          description: Roles is the list of namespaced role names
+                            for the user.
+                          items:
+                            type: string
+                          type: array
+                        subjects:
+                          description: Subjects is the list of subject names like
+                            users, user groups, and service accounts.
+                          items:
+                            description: Subject contains a reference to the object
+                              or user identities a role binding applies to.  This
+                              can either hold a direct API object reference, or a
+                              value for non-objects such as user and group names.
+                            properties:
+                              apiGroup:
+                                description: APIGroup holds the API group of the referenced
+                                  subject. Defaults to "" for ServiceAccount subjects.
+                                  Defaults to "rbac.authorization.k8s.io" for User
+                                  and Group subjects.
+                                type: string
+                              kind:
+                                description: Kind of object being referenced. Values
+                                  defined by this API group are "User", "Group", and
+                                  "ServiceAccount". If the Authorizer does not recognized
+                                  the kind value, the Authorizer should report an
+                                  error.
+                                type: string
+                              name:
+                                description: Name of the object being referenced.
+                                type: string
+                              namespace:
+                                description: Namespace of the referenced object.  If
+                                  the object kind is non-namespace, such as "User"
+                                  or "Group", and this value is not empty the Authorizer
+                                  should report an error.
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          type: array
+                      type: object
+                    generate:
+                      description: Generation is used to create new resources.
+                      properties:
+                        apiVersion:
+                          description: APIVersion specifies resource apiVersion.
+                          type: string
+                        clone:
+                          description: Clone specifies the source resource used to
+                            populate each generated resource. At most one of Data
+                            or Clone can be specified. If neither are provided, the
+                            generated resource will be created with default data only.
+                          properties:
+                            name:
+                              description: Name specifies name of the resource.
+                              type: string
+                            namespace:
+                              description: Namespace specifies source resource namespace.
+                              type: string
+                          type: object
+                        cloneList:
+                          description: CloneList specifies the list of source resource
+                            used to populate each generated resource.
+                          properties:
+                            kinds:
+                              description: Kinds is a list of resource kinds.
+                              items:
+                                type: string
+                              type: array
+                            namespace:
+                              description: Namespace specifies source resource namespace.
+                              type: string
+                            selector:
+                              description: Selector is a label selector. Label keys
+                                and values in `matchLabels`. wildcard characters are
+                                not supported.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        data:
+                          description: Data provides the resource declaration used
+                            to populate each generated resource. At most one of Data
+                            or Clone must be specified. If neither are provided, the
+                            generated resource will be created with default data only.
+                          x-kubernetes-preserve-unknown-fields: true
+                        kind:
+                          description: Kind specifies resource kind.
+                          type: string
+                        name:
+                          description: Name specifies the resource name.
+                          type: string
+                        namespace:
+                          description: Namespace specifies resource namespace.
+                          type: string
+                        synchronize:
+                          description: Synchronize controls if generated resources
+                            should be kept in-sync with their source resource. If
+                            Synchronize is set to "true" changes to generated resources
+                            will be overwritten with resource data from Data or the
+                            resource specified in the Clone declaration. Optional.
+                            Defaults to "false" if not specified.
+                          type: boolean
+                      type: object
+                    imageExtractors:
+                      additionalProperties:
+                        items:
+                          properties:
+                            key:
+                              description: Key is an optional name of the field within
+                                'path' that will be used to uniquely identify an image.
+                                Note - this field MUST be unique.
+                              type: string
+                            name:
+                              description: Name is the entry the image will be available
+                                under 'images.<name>' in the context. If this field
+                                is not defined, image entries will appear under 'images.custom'.
+                              type: string
+                            path:
+                              description: Path is the path to the object containing
+                                the image field in a custom resource. It should be
+                                slash-separated. Each slash-separated key must be
+                                a valid YAML key or a wildcard '*'. Wildcard keys
+                                are expanded in case of arrays or objects.
+                              type: string
+                            value:
+                              description: Value is an optional name of the field
+                                within 'path' that points to the image URI. This is
+                                useful when a custom 'key' is also defined.
+                              type: string
+                          required:
+                          - path
+                          type: object
+                        type: array
+                      description: ImageExtractors defines a mapping from kinds to
+                        ImageExtractorConfigs. This config is only valid for verifyImages
+                        rules.
+                      type: object
+                    match:
+                      description: MatchResources defines when this policy rule should
+                        be applied. The match criteria can include resource information
+                        (e.g. kind, name, namespace, labels) and admission review
+                        request information like the user name or role. At least one
+                        kind is required.
+                      properties:
+                        all:
+                          description: All allows specifying resources which will
+                            be ANDed
+                          items:
+                            description: ResourceFilter allow users to "AND" or "OR"
+                              between resources
+                            properties:
+                              clusterRoles:
+                                description: ClusterRoles is the list of cluster-wide
+                                  role names for the user.
+                                items:
+                                  type: string
+                                type: array
+                              resources:
+                                description: ResourceDescription contains information
+                                  about the resource being created or modified.
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations is a  map of annotations
+                                      (key-value pairs of type string). Annotation
+                                      keys and values support the wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (matches at least one character).
+                                    type: object
+                                  kinds:
+                                    description: Kinds is a list of resource kinds.
+                                    items:
+                                      type: string
+                                    type: array
+                                  name:
+                                    description: 'Name is the name of the resource.
+                                      The name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character). NOTE: "Name" is being deprecated
+                                      in favor of "Names".'
+                                    type: string
+                                  names:
+                                    description: Names are the names of the resources.
+                                      Each name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character).
+                                    items:
+                                      type: string
+                                    type: array
+                                  namespaceSelector:
+                                    description: 'NamespaceSelector is a label selector
+                                      for the resource namespace. Label keys and values
+                                      in `matchLabels` support the wildcard characters
+                                      `*` (matches zero or many characters) and `?`
+                                      (matches one character).Wildcards allows writing
+                                      label selectors like ["storage.k8s.io/*": "*"].
+                                      Note that using ["*" : "*"] matches any key
+                                      and value but does not match an empty label
+                                      set.'
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaces:
+                                    description: Namespaces is a list of namespaces
+                                      names. Each name supports wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (at least one character).
+                                    items:
+                                      type: string
+                                    type: array
+                                  selector:
+                                    description: 'Selector is a label selector. Label
+                                      keys and values in `matchLabels` support the
+                                      wildcard characters `*` (matches zero or many
+                                      characters) and `?` (matches one character).
+                                      Wildcards allows writing label selectors like
+                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                      : "*"] matches any key and value but does not
+                                      match an empty label set.'
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              roles:
+                                description: Roles is the list of namespaced role
+                                  names for the user.
+                                items:
+                                  type: string
+                                type: array
+                              subjects:
+                                description: Subjects is the list of subject names
+                                  like users, user groups, and service accounts.
+                                items:
+                                  description: Subject contains a reference to the
+                                    object or user identities a role binding applies
+                                    to.  This can either hold a direct API object
+                                    reference, or a value for non-objects such as
+                                    user and group names.
+                                  properties:
+                                    apiGroup:
+                                      description: APIGroup holds the API group of
+                                        the referenced subject. Defaults to "" for
+                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
+                                        for User and Group subjects.
+                                      type: string
+                                    kind:
+                                      description: Kind of object being referenced.
+                                        Values defined by this API group are "User",
+                                        "Group", and "ServiceAccount". If the Authorizer
+                                        does not recognized the kind value, the Authorizer
+                                        should report an error.
+                                      type: string
+                                    name:
+                                      description: Name of the object being referenced.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the referenced object.  If
+                                        the object kind is non-namespace, such as
+                                        "User" or "Group", and this value is not empty
+                                        the Authorizer should report an error.
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                type: array
+                            type: object
+                          type: array
+                        any:
+                          description: Any allows specifying resources which will
+                            be ORed
+                          items:
+                            description: ResourceFilter allow users to "AND" or "OR"
+                              between resources
+                            properties:
+                              clusterRoles:
+                                description: ClusterRoles is the list of cluster-wide
+                                  role names for the user.
+                                items:
+                                  type: string
+                                type: array
+                              resources:
+                                description: ResourceDescription contains information
+                                  about the resource being created or modified.
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations is a  map of annotations
+                                      (key-value pairs of type string). Annotation
+                                      keys and values support the wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (matches at least one character).
+                                    type: object
+                                  kinds:
+                                    description: Kinds is a list of resource kinds.
+                                    items:
+                                      type: string
+                                    type: array
+                                  name:
+                                    description: 'Name is the name of the resource.
+                                      The name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character). NOTE: "Name" is being deprecated
+                                      in favor of "Names".'
+                                    type: string
+                                  names:
+                                    description: Names are the names of the resources.
+                                      Each name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character).
+                                    items:
+                                      type: string
+                                    type: array
+                                  namespaceSelector:
+                                    description: 'NamespaceSelector is a label selector
+                                      for the resource namespace. Label keys and values
+                                      in `matchLabels` support the wildcard characters
+                                      `*` (matches zero or many characters) and `?`
+                                      (matches one character).Wildcards allows writing
+                                      label selectors like ["storage.k8s.io/*": "*"].
+                                      Note that using ["*" : "*"] matches any key
+                                      and value but does not match an empty label
+                                      set.'
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaces:
+                                    description: Namespaces is a list of namespaces
+                                      names. Each name supports wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (at least one character).
+                                    items:
+                                      type: string
+                                    type: array
+                                  selector:
+                                    description: 'Selector is a label selector. Label
+                                      keys and values in `matchLabels` support the
+                                      wildcard characters `*` (matches zero or many
+                                      characters) and `?` (matches one character).
+                                      Wildcards allows writing label selectors like
+                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                      : "*"] matches any key and value but does not
+                                      match an empty label set.'
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              roles:
+                                description: Roles is the list of namespaced role
+                                  names for the user.
+                                items:
+                                  type: string
+                                type: array
+                              subjects:
+                                description: Subjects is the list of subject names
+                                  like users, user groups, and service accounts.
+                                items:
+                                  description: Subject contains a reference to the
+                                    object or user identities a role binding applies
+                                    to.  This can either hold a direct API object
+                                    reference, or a value for non-objects such as
+                                    user and group names.
+                                  properties:
+                                    apiGroup:
+                                      description: APIGroup holds the API group of
+                                        the referenced subject. Defaults to "" for
+                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
+                                        for User and Group subjects.
+                                      type: string
+                                    kind:
+                                      description: Kind of object being referenced.
+                                        Values defined by this API group are "User",
+                                        "Group", and "ServiceAccount". If the Authorizer
+                                        does not recognized the kind value, the Authorizer
+                                        should report an error.
+                                      type: string
+                                    name:
+                                      description: Name of the object being referenced.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the referenced object.  If
+                                        the object kind is non-namespace, such as
+                                        "User" or "Group", and this value is not empty
+                                        the Authorizer should report an error.
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                type: array
+                            type: object
+                          type: array
+                        clusterRoles:
+                          description: ClusterRoles is the list of cluster-wide role
+                            names for the user.
+                          items:
+                            type: string
+                          type: array
+                        resources:
+                          description: ResourceDescription contains information about
+                            the resource being created or modified. Requires at least
+                            one tag to be specified when under MatchResources. Specifying
+                            ResourceDescription directly under match is being deprecated.
+                            Please specify under "any" or "all" instead.
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a  map of annotations (key-value
+                                pairs of type string). Annotation keys and values
+                                support the wildcard characters "*" (matches zero
+                                or many characters) and "?" (matches at least one
+                                character).
+                              type: object
+                            kinds:
+                              description: Kinds is a list of resource kinds.
+                              items:
+                                type: string
+                              type: array
+                            name:
+                              description: 'Name is the name of the resource. The
+                                name supports wildcard characters "*" (matches zero
+                                or many characters) and "?" (at least one character).
+                                NOTE: "Name" is being deprecated in favor of "Names".'
+                              type: string
+                            names:
+                              description: Names are the names of the resources. Each
+                                name supports wildcard characters "*" (matches zero
+                                or many characters) and "?" (at least one character).
+                              items:
+                                type: string
+                              type: array
+                            namespaceSelector:
+                              description: 'NamespaceSelector is a label selector
+                                for the resource namespace. Label keys and values
+                                in `matchLabels` support the wildcard characters `*`
+                                (matches zero or many characters) and `?` (matches
+                                one character).Wildcards allows writing label selectors
+                                like ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                : "*"] matches any key and value but does not match
+                                an empty label set.'
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            namespaces:
+                              description: Namespaces is a list of namespaces names.
+                                Each name supports wildcard characters "*" (matches
+                                zero or many characters) and "?" (at least one character).
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: 'Selector is a label selector. Label keys
+                                and values in `matchLabels` support the wildcard characters
+                                `*` (matches zero or many characters) and `?` (matches
+                                one character). Wildcards allows writing label selectors
+                                like ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                : "*"] matches any key and value but does not match
+                                an empty label set.'
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        roles:
+                          description: Roles is the list of namespaced role names
+                            for the user.
+                          items:
+                            type: string
+                          type: array
+                        subjects:
+                          description: Subjects is the list of subject names like
+                            users, user groups, and service accounts.
+                          items:
+                            description: Subject contains a reference to the object
+                              or user identities a role binding applies to.  This
+                              can either hold a direct API object reference, or a
+                              value for non-objects such as user and group names.
+                            properties:
+                              apiGroup:
+                                description: APIGroup holds the API group of the referenced
+                                  subject. Defaults to "" for ServiceAccount subjects.
+                                  Defaults to "rbac.authorization.k8s.io" for User
+                                  and Group subjects.
+                                type: string
+                              kind:
+                                description: Kind of object being referenced. Values
+                                  defined by this API group are "User", "Group", and
+                                  "ServiceAccount". If the Authorizer does not recognized
+                                  the kind value, the Authorizer should report an
+                                  error.
+                                type: string
+                              name:
+                                description: Name of the object being referenced.
+                                type: string
+                              namespace:
+                                description: Namespace of the referenced object.  If
+                                  the object kind is non-namespace, such as "User"
+                                  or "Group", and this value is not empty the Authorizer
+                                  should report an error.
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          type: array
+                      type: object
+                    mutate:
+                      description: Mutation is used to modify matching resources.
+                      properties:
+                        foreach:
+                          description: ForEach applies mutation rules to a list of
+                            sub-elements by creating a context for each entry in the
+                            list and looping over it to apply the specified logic.
+                          items:
+                            description: ForEach applies mutation rules to a list
+                              of sub-elements by creating a context for each entry
+                              in the list and looping over it to apply the specified
+                              logic.
+                            properties:
+                              context:
+                                description: Context defines variables and data sources
+                                  that can be used during rule execution.
+                                items:
+                                  description: ContextEntry adds variables and data
+                                    sources to a rule Context. Either a ConfigMap
+                                    reference or a APILookup must be provided.
+                                  properties:
+                                    apiCall:
+                                      description: APICall defines an HTTP request
+                                        to the Kubernetes API server. The JSON data
+                                        retrieved is stored in the context.
+                                      properties:
+                                        jmesPath:
+                                          description: JMESPath is an optional JSON
+                                            Match Expression that can be used to transform
+                                            the JSON response returned from the API
+                                            server. For example a JMESPath of "items
+                                            | length(@)" applied to the API server
+                                            response to the URLPath "/apis/apps/v1/deployments"
+                                            will return the total count of deployments
+                                            across all namespaces.
+                                          type: string
+                                        urlPath:
+                                          description: URLPath is the URL path to
+                                            be used in the HTTP GET request to the
+                                            Kubernetes API server (e.g. "/api/v1/namespaces"
+                                            or  "/apis/apps/v1/deployments"). The
+                                            format required is the same format used
+                                            by the `kubectl get --raw` command.
+                                          type: string
+                                      required:
+                                      - urlPath
+                                      type: object
+                                    configMap:
+                                      description: ConfigMap is the ConfigMap reference.
+                                      properties:
+                                        name:
+                                          description: Name is the ConfigMap name.
+                                          type: string
+                                        namespace:
+                                          description: Namespace is the ConfigMap
+                                            namespace.
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    imageRegistry:
+                                      description: ImageRegistry defines requests
+                                        to an OCI/Docker V2 registry to fetch image
+                                        details.
+                                      properties:
+                                        jmesPath:
+                                          description: JMESPath is an optional JSON
+                                            Match Expression that can be used to transform
+                                            the ImageData struct returned as a result
+                                            of processing the image reference.
+                                          type: string
+                                        reference:
+                                          description: 'Reference is image reference
+                                            to a container image in the registry.
+                                            Example: ghcr.io/kyverno/kyverno:latest'
+                                          type: string
+                                      required:
+                                      - reference
+                                      type: object
+                                    name:
+                                      description: Name is the variable name.
+                                      type: string
+                                    variable:
+                                      description: Variable defines an arbitrary JMESPath
+                                        context variable that can be defined inline.
+                                      properties:
+                                        default:
+                                          description: Default is an optional arbitrary
+                                            JSON object that the variable may take
+                                            if the JMESPath expression evaluates to
+                                            nil
+                                          x-kubernetes-preserve-unknown-fields: true
+                                        jmesPath:
+                                          description: JMESPath is an optional JMESPath
+                                            Expression that can be used to transform
+                                            the variable.
+                                          type: string
+                                        value:
+                                          description: Value is any arbitrary JSON
+                                            object representable in YAML or JSON form.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                  type: object
+                                type: array
+                              list:
+                                description: List specifies a JMESPath expression
+                                  that results in one or more elements to which the
+                                  validation logic is applied.
+                                type: string
+                              patchStrategicMerge:
+                                description: PatchStrategicMerge is a strategic merge
+                                  patch used to modify resources. See https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/
+                                  and https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.
+                                x-kubernetes-preserve-unknown-fields: true
+                              patchesJson6902:
+                                description: PatchesJSON6902 is a list of RFC 6902
+                                  JSON Patch declarations used to modify resources.
+                                  See https://tools.ietf.org/html/rfc6902 and https://kubectl.docs.kubernetes.io/references/kustomize/patchesjson6902/.
+                                type: string
+                              preconditions:
+                                description: 'AnyAllConditions are used to determine
+                                  if a policy rule should be applied by evaluating
+                                  a set of conditions. The declaration can contain
+                                  nested `any` or `all` statements. See: https://kyverno.io/docs/writing-policies/preconditions/'
+                                properties:
+                                  all:
+                                    description: AllConditions enable variable-based
+                                      conditional rule execution. This is useful for
+                                      finer control of when an rule is applied. A
+                                      condition can reference object data using JMESPath
+                                      notation. Here, all of the conditions need to
+                                      pass
+                                    items:
+                                      description: Condition defines variable-based
+                                        conditional criteria for rule execution.
+                                      properties:
+                                        key:
+                                          description: Key is the context entry (using
+                                            JMESPath) for conditional rule evaluation.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                        operator:
+                                          description: 'Operator is the conditional
+                                            operation to perform. Valid operators
+                                            are: Equals, NotEquals, In, AnyIn, AllIn,
+                                            NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,
+                                            GreaterThan, LessThanOrEquals, LessThan,
+                                            DurationGreaterThanOrEquals, DurationGreaterThan,
+                                            DurationLessThanOrEquals, DurationLessThan'
+                                          enum:
+                                          - Equals
+                                          - NotEquals
+                                          - In
+                                          - AnyIn
+                                          - AllIn
+                                          - NotIn
+                                          - AnyNotIn
+                                          - AllNotIn
+                                          - GreaterThanOrEquals
+                                          - GreaterThan
+                                          - LessThanOrEquals
+                                          - LessThan
+                                          - DurationGreaterThanOrEquals
+                                          - DurationGreaterThan
+                                          - DurationLessThanOrEquals
+                                          - DurationLessThan
+                                          type: string
+                                        value:
+                                          description: Value is the conditional value,
+                                            or set of values. The values can be fixed
+                                            set or can be variables declared using
+                                            JMESPath.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                    type: array
+                                  any:
+                                    description: AnyConditions enable variable-based
+                                      conditional rule execution. This is useful for
+                                      finer control of when an rule is applied. A
+                                      condition can reference object data using JMESPath
+                                      notation. Here, at least one of the conditions
+                                      need to pass
+                                    items:
+                                      description: Condition defines variable-based
+                                        conditional criteria for rule execution.
+                                      properties:
+                                        key:
+                                          description: Key is the context entry (using
+                                            JMESPath) for conditional rule evaluation.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                        operator:
+                                          description: 'Operator is the conditional
+                                            operation to perform. Valid operators
+                                            are: Equals, NotEquals, In, AnyIn, AllIn,
+                                            NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,
+                                            GreaterThan, LessThanOrEquals, LessThan,
+                                            DurationGreaterThanOrEquals, DurationGreaterThan,
+                                            DurationLessThanOrEquals, DurationLessThan'
+                                          enum:
+                                          - Equals
+                                          - NotEquals
+                                          - In
+                                          - AnyIn
+                                          - AllIn
+                                          - NotIn
+                                          - AnyNotIn
+                                          - AllNotIn
+                                          - GreaterThanOrEquals
+                                          - GreaterThan
+                                          - LessThanOrEquals
+                                          - LessThan
+                                          - DurationGreaterThanOrEquals
+                                          - DurationGreaterThan
+                                          - DurationLessThanOrEquals
+                                          - DurationLessThan
+                                          type: string
+                                        value:
+                                          description: Value is the conditional value,
+                                            or set of values. The values can be fixed
+                                            set or can be variables declared using
+                                            JMESPath.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                    type: array
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          type: array
+                        patchStrategicMerge:
+                          description: PatchStrategicMerge is a strategic merge patch
+                            used to modify resources. See https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/
+                            and https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.
+                          x-kubernetes-preserve-unknown-fields: true
+                        patchesJson6902:
+                          description: PatchesJSON6902 is a list of RFC 6902 JSON
+                            Patch declarations used to modify resources. See https://tools.ietf.org/html/rfc6902
+                            and https://kubectl.docs.kubernetes.io/references/kustomize/patchesjson6902/.
+                          type: string
+                        targets:
+                          description: Targets defines the target resources to be
+                            mutated.
+                          items:
+                            properties:
+                              apiVersion:
+                                description: APIVersion specifies resource apiVersion.
+                                type: string
+                              kind:
+                                description: Kind specifies resource kind.
+                                type: string
+                              name:
+                                description: Name specifies the resource name.
+                                type: string
+                              namespace:
+                                description: Namespace specifies resource namespace.
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    name:
+                      description: Name is a label to identify the rule, It must be
+                        unique within the policy.
+                      maxLength: 63
+                      type: string
+                    preconditions:
+                      description: 'Preconditions are used to determine if a policy
+                        rule should be applied by evaluating a set of conditions.
+                        The declaration can contain nested `any` or `all` statements.
+                        A direct list of conditions (without `any` or `all` statements
+                        is supported for backwards compatibility but will be deprecated
+                        in the next major release. See: https://kyverno.io/docs/writing-policies/preconditions/'
+                      x-kubernetes-preserve-unknown-fields: true
+                    validate:
+                      description: Validation is used to validate matching resources.
+                      properties:
+                        anyPattern:
+                          description: AnyPattern specifies list of validation patterns.
+                            At least one of the patterns must be satisfied for the
+                            validation rule to succeed.
+                          x-kubernetes-preserve-unknown-fields: true
+                        deny:
+                          description: Deny defines conditions used to pass or fail
+                            a validation rule.
+                          properties:
+                            conditions:
+                              description: 'Multiple conditions can be declared under
+                                an `any` or `all` statement. A direct list of conditions
+                                (without `any` or `all` statements) is also supported
+                                for backwards compatibility but will be deprecated
+                                in the next major release. See: https://kyverno.io/docs/writing-policies/validate/#deny-rules'
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                        foreach:
+                          description: ForEach applies validate rules to a list of
+                            sub-elements by creating a context for each entry in the
+                            list and looping over it to apply the specified logic.
+                          items:
+                            description: ForEach applies validate rules to a list
+                              of sub-elements by creating a context for each entry
+                              in the list and looping over it to apply the specified
+                              logic.
+                            properties:
+                              anyPattern:
+                                description: AnyPattern specifies list of validation
+                                  patterns. At least one of the patterns must be satisfied
+                                  for the validation rule to succeed.
+                                x-kubernetes-preserve-unknown-fields: true
+                              context:
+                                description: Context defines variables and data sources
+                                  that can be used during rule execution.
+                                items:
+                                  description: ContextEntry adds variables and data
+                                    sources to a rule Context. Either a ConfigMap
+                                    reference or a APILookup must be provided.
+                                  properties:
+                                    apiCall:
+                                      description: APICall defines an HTTP request
+                                        to the Kubernetes API server. The JSON data
+                                        retrieved is stored in the context.
+                                      properties:
+                                        jmesPath:
+                                          description: JMESPath is an optional JSON
+                                            Match Expression that can be used to transform
+                                            the JSON response returned from the API
+                                            server. For example a JMESPath of "items
+                                            | length(@)" applied to the API server
+                                            response to the URLPath "/apis/apps/v1/deployments"
+                                            will return the total count of deployments
+                                            across all namespaces.
+                                          type: string
+                                        urlPath:
+                                          description: URLPath is the URL path to
+                                            be used in the HTTP GET request to the
+                                            Kubernetes API server (e.g. "/api/v1/namespaces"
+                                            or  "/apis/apps/v1/deployments"). The
+                                            format required is the same format used
+                                            by the `kubectl get --raw` command.
+                                          type: string
+                                      required:
+                                      - urlPath
+                                      type: object
+                                    configMap:
+                                      description: ConfigMap is the ConfigMap reference.
+                                      properties:
+                                        name:
+                                          description: Name is the ConfigMap name.
+                                          type: string
+                                        namespace:
+                                          description: Namespace is the ConfigMap
+                                            namespace.
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    imageRegistry:
+                                      description: ImageRegistry defines requests
+                                        to an OCI/Docker V2 registry to fetch image
+                                        details.
+                                      properties:
+                                        jmesPath:
+                                          description: JMESPath is an optional JSON
+                                            Match Expression that can be used to transform
+                                            the ImageData struct returned as a result
+                                            of processing the image reference.
+                                          type: string
+                                        reference:
+                                          description: 'Reference is image reference
+                                            to a container image in the registry.
+                                            Example: ghcr.io/kyverno/kyverno:latest'
+                                          type: string
+                                      required:
+                                      - reference
+                                      type: object
+                                    name:
+                                      description: Name is the variable name.
+                                      type: string
+                                    variable:
+                                      description: Variable defines an arbitrary JMESPath
+                                        context variable that can be defined inline.
+                                      properties:
+                                        default:
+                                          description: Default is an optional arbitrary
+                                            JSON object that the variable may take
+                                            if the JMESPath expression evaluates to
+                                            nil
+                                          x-kubernetes-preserve-unknown-fields: true
+                                        jmesPath:
+                                          description: JMESPath is an optional JMESPath
+                                            Expression that can be used to transform
+                                            the variable.
+                                          type: string
+                                        value:
+                                          description: Value is any arbitrary JSON
+                                            object representable in YAML or JSON form.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                  type: object
+                                type: array
+                              deny:
+                                description: Deny defines conditions used to pass
+                                  or fail a validation rule.
+                                properties:
+                                  conditions:
+                                    description: 'Multiple conditions can be declared
+                                      under an `any` or `all` statement. A direct
+                                      list of conditions (without `any` or `all` statements)
+                                      is also supported for backwards compatibility
+                                      but will be deprecated in the next major release.
+                                      See: https://kyverno.io/docs/writing-policies/validate/#deny-rules'
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              elementScope:
+                                description: ElementScope specifies whether to use
+                                  the current list element as the scope for validation.
+                                  Defaults to "true" if not specified. When set to
+                                  "false", "request.object" is used as the validation
+                                  scope within the foreach block to allow referencing
+                                  other elements in the subtree.
+                                type: boolean
+                              list:
+                                description: List specifies a JMESPath expression
+                                  that results in one or more elements to which the
+                                  validation logic is applied.
+                                type: string
+                              pattern:
+                                description: Pattern specifies an overlay-style pattern
+                                  used to check resources.
+                                x-kubernetes-preserve-unknown-fields: true
+                              preconditions:
+                                description: 'AnyAllConditions are used to determine
+                                  if a policy rule should be applied by evaluating
+                                  a set of conditions. The declaration can contain
+                                  nested `any` or `all` statements. See: https://kyverno.io/docs/writing-policies/preconditions/'
+                                properties:
+                                  all:
+                                    description: AllConditions enable variable-based
+                                      conditional rule execution. This is useful for
+                                      finer control of when an rule is applied. A
+                                      condition can reference object data using JMESPath
+                                      notation. Here, all of the conditions need to
+                                      pass
+                                    items:
+                                      description: Condition defines variable-based
+                                        conditional criteria for rule execution.
+                                      properties:
+                                        key:
+                                          description: Key is the context entry (using
+                                            JMESPath) for conditional rule evaluation.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                        operator:
+                                          description: 'Operator is the conditional
+                                            operation to perform. Valid operators
+                                            are: Equals, NotEquals, In, AnyIn, AllIn,
+                                            NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,
+                                            GreaterThan, LessThanOrEquals, LessThan,
+                                            DurationGreaterThanOrEquals, DurationGreaterThan,
+                                            DurationLessThanOrEquals, DurationLessThan'
+                                          enum:
+                                          - Equals
+                                          - NotEquals
+                                          - In
+                                          - AnyIn
+                                          - AllIn
+                                          - NotIn
+                                          - AnyNotIn
+                                          - AllNotIn
+                                          - GreaterThanOrEquals
+                                          - GreaterThan
+                                          - LessThanOrEquals
+                                          - LessThan
+                                          - DurationGreaterThanOrEquals
+                                          - DurationGreaterThan
+                                          - DurationLessThanOrEquals
+                                          - DurationLessThan
+                                          type: string
+                                        value:
+                                          description: Value is the conditional value,
+                                            or set of values. The values can be fixed
+                                            set or can be variables declared using
+                                            JMESPath.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                    type: array
+                                  any:
+                                    description: AnyConditions enable variable-based
+                                      conditional rule execution. This is useful for
+                                      finer control of when an rule is applied. A
+                                      condition can reference object data using JMESPath
+                                      notation. Here, at least one of the conditions
+                                      need to pass
+                                    items:
+                                      description: Condition defines variable-based
+                                        conditional criteria for rule execution.
+                                      properties:
+                                        key:
+                                          description: Key is the context entry (using
+                                            JMESPath) for conditional rule evaluation.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                        operator:
+                                          description: 'Operator is the conditional
+                                            operation to perform. Valid operators
+                                            are: Equals, NotEquals, In, AnyIn, AllIn,
+                                            NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,
+                                            GreaterThan, LessThanOrEquals, LessThan,
+                                            DurationGreaterThanOrEquals, DurationGreaterThan,
+                                            DurationLessThanOrEquals, DurationLessThan'
+                                          enum:
+                                          - Equals
+                                          - NotEquals
+                                          - In
+                                          - AnyIn
+                                          - AllIn
+                                          - NotIn
+                                          - AnyNotIn
+                                          - AllNotIn
+                                          - GreaterThanOrEquals
+                                          - GreaterThan
+                                          - LessThanOrEquals
+                                          - LessThan
+                                          - DurationGreaterThanOrEquals
+                                          - DurationGreaterThan
+                                          - DurationLessThanOrEquals
+                                          - DurationLessThan
+                                          type: string
+                                        value:
+                                          description: Value is the conditional value,
+                                            or set of values. The values can be fixed
+                                            set or can be variables declared using
+                                            JMESPath.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                    type: array
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          type: array
+                        manifests:
+                          description: Manifest specifies conditions for manifest
+                            verification
+                          properties:
+                            annotationDomain:
+                              description: AnnotationDomain is custom domain of annotation
+                                for message and signature. Default is "cosign.sigstore.dev".
+                              type: string
+                            attestors:
+                              description: Attestors specified the required attestors
+                                (i.e. authorities)
+                              items:
+                                properties:
+                                  count:
+                                    description: Count specifies the required number
+                                      of entries that must match. If the count is
+                                      null, all entries must match (a logical AND).
+                                      If the count is 1, at least one entry must match
+                                      (a logical OR). If the count contains a value
+                                      N, then N must be less than or equal to the
+                                      size of entries, and at least N entries must
+                                      match.
+                                    minimum: 1
+                                    type: integer
+                                  entries:
+                                    description: Entries contains the available attestors.
+                                      An attestor can be a static key, attributes
+                                      for keyless verification, or a nested attestor
+                                      declaration.
+                                    items:
+                                      properties:
+                                        annotations:
+                                          additionalProperties:
+                                            type: string
+                                          description: Annotations are used for image
+                                            verification. Every specified key-value
+                                            pair must exist and match in the verified
+                                            payload. The payload may contain other
+                                            key-value pairs.
+                                          type: object
+                                        attestor:
+                                          description: Attestor is a nested AttestorSet
+                                            used to specify a more complex set of
+                                            match authorities
+                                          x-kubernetes-preserve-unknown-fields: true
+                                        certificates:
+                                          description: Certificates specifies one
+                                            or more certificates
+                                          properties:
+                                            cert:
+                                              description: Certificate is an optional
+                                                PEM encoded public certificate.
+                                              type: string
+                                            certChain:
+                                              description: CertificateChain is an
+                                                optional PEM encoded set of certificates
+                                                used to verify
+                                              type: string
+                                            rekor:
+                                              description: Rekor provides configuration
+                                                for the Rekor transparency log service.
+                                                If the value is nil, Rekor is not
+                                                checked. If an empty object is provided
+                                                the public instance of Rekor (https://rekor.sigstore.dev)
+                                                is used.
+                                              properties:
+                                                url:
+                                                  description: URL is the address
+                                                    of the transparency log. Defaults
+                                                    to the public log https://rekor.sigstore.dev.
+                                                  type: string
+                                              required:
+                                              - url
+                                              type: object
+                                          type: object
+                                        keyless:
+                                          description: Keyless is a set of attribute
+                                            used to verify a Sigstore keyless attestor.
+                                            See https://github.com/sigstore/cosign/blob/main/KEYLESS.md.
+                                          properties:
+                                            additionalExtensions:
+                                              additionalProperties:
+                                                type: string
+                                              description: AdditionalExtensions are
+                                                certificate-extensions used for keyless
+                                                signing.
+                                              type: object
+                                            issuer:
+                                              description: Issuer is the certificate
+                                                issuer used for keyless signing.
+                                              type: string
+                                            rekor:
+                                              description: Rekor provides configuration
+                                                for the Rekor transparency log service.
+                                                If the value is nil, Rekor is not
+                                                checked and a root certificate chain
+                                                is expected instead. If an empty object
+                                                is provided the public instance of
+                                                Rekor (https://rekor.sigstore.dev)
+                                                is used.
+                                              properties:
+                                                url:
+                                                  description: URL is the address
+                                                    of the transparency log. Defaults
+                                                    to the public log https://rekor.sigstore.dev.
+                                                  type: string
+                                              required:
+                                              - url
+                                              type: object
+                                            roots:
+                                              description: Roots is an optional set
+                                                of PEM encoded trusted root certificates.
+                                                If not provided, the system roots
+                                                are used.
+                                              type: string
+                                            subject:
+                                              description: Subject is the verified
+                                                identity used for keyless signing,
+                                                for example the email address
+                                              type: string
+                                          type: object
+                                        keys:
+                                          description: Keys specifies one or more
+                                            public keys
+                                          properties:
+                                            publicKeys:
+                                              description: Keys is a set of X.509
+                                                public keys used to verify image signatures.
+                                                The keys can be directly specified
+                                                or can be a variable reference to
+                                                a key specified in a ConfigMap (see
+                                                https://kyverno.io/docs/writing-policies/variables/).
+                                                When multiple keys are specified each
+                                                key is processed as a separate staticKey
+                                                entry (.attestors[*].entries.keys)
+                                                within the set of attestors and the
+                                                count is applied across the keys.
+                                              type: string
+                                            rekor:
+                                              description: Rekor provides configuration
+                                                for the Rekor transparency log service.
+                                                If the value is nil, Rekor is not
+                                                checked. If an empty object is provided
+                                                the public instance of Rekor (https://rekor.sigstore.dev)
+                                                is used.
+                                              properties:
+                                                url:
+                                                  description: URL is the address
+                                                    of the transparency log. Defaults
+                                                    to the public log https://rekor.sigstore.dev.
+                                                  type: string
+                                              required:
+                                              - url
+                                              type: object
+                                          type: object
+                                        repository:
+                                          description: Repository is an optional alternate
+                                            OCI repository to use for signatures and
+                                            attestations that match this rule. If
+                                            specified Repository will override other
+                                            OCI image repository locations for this
+                                            Attestor.
+                                          type: string
+                                      type: object
+                                    type: array
+                                type: object
+                              type: array
+                            dryRun:
+                              description: DryRun configuration
+                              properties:
+                                enable:
+                                  type: boolean
+                                namespace:
+                                  type: string
+                              type: object
+                            ignoreFields:
+                              description: Fields which will be ignored while comparing
+                                manifests.
+                              items:
+                                properties:
+                                  fields:
+                                    items:
+                                      type: string
+                                    type: array
+                                  objects:
+                                    items:
+                                      properties:
+                                        group:
+                                          type: string
+                                        kind:
+                                          type: string
+                                        name:
+                                          type: string
+                                        namespace:
+                                          type: string
+                                        version:
+                                          type: string
+                                      type: object
+                                    type: array
+                                type: object
+                              type: array
+                            repository:
+                              description: Repository is an optional alternate OCI
+                                repository to use for resource bundle reference. The
+                                repository can be overridden per Attestor or Attestation.
+                              type: string
+                          type: object
+                        message:
+                          description: Message specifies a custom message to be displayed
+                            on failure.
+                          type: string
+                        pattern:
+                          description: Pattern specifies an overlay-style pattern
+                            used to check resources.
+                          x-kubernetes-preserve-unknown-fields: true
+                        podSecurity:
+                          description: PodSecurity applies exemptions for Kubernetes
+                            Pod Security admission by specifying exclusions for Pod
+                            Security Standards controls.
+                          properties:
+                            exclude:
+                              description: Exclude specifies the Pod Security Standard
+                                controls to be excluded.
+                              items:
+                                description: PodSecurityStandard specifies the Pod
+                                  Security Standard controls to be excluded.
+                                properties:
+                                  controlName:
+                                    description: 'ControlName specifies the name of
+                                      the Pod Security Standard control. See: https://kubernetes.io/docs/concepts/security/pod-security-standards/'
+                                    enum:
+                                    - HostProcess
+                                    - Host Namespaces
+                                    - Privileged Containers
+                                    - Capabilities
+                                    - HostPath Volumes
+                                    - Host Ports
+                                    - AppArmor
+                                    - SELinux
+                                    - /proc Mount Type
+                                    - Seccomp
+                                    - Sysctls
+                                    - Volume Types
+                                    - Privilege Escalation
+                                    - Running as Non-root
+                                    - Running as Non-root user
+                                    type: string
+                                  images:
+                                    description: 'Images selects matching containers
+                                      and applies the container level PSS. Each image
+                                      is the image name consisting of the registry
+                                      address, repository, image, and tag. Empty list
+                                      matches no containers, PSS checks are applied
+                                      at the pod level only. Wildcards (''*'' and
+                                      ''?'') are allowed. See: https://kubernetes.io/docs/concepts/containers/images.'
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - controlName
+                                type: object
+                              type: array
+                            level:
+                              description: Level defines the Pod Security Standard
+                                level to be applied to workloads. Allowed values are
+                                privileged, baseline, and restricted.
+                              enum:
+                              - privileged
+                              - baseline
+                              - restricted
+                              type: string
+                            version:
+                              description: Version defines the Pod Security Standard
+                                versions that Kubernetes supports. Allowed values
+                                are v1.19, v1.20, v1.21, v1.22, v1.23, v1.24, v1.25,
+                                latest. Defaults to latest.
+                              enum:
+                              - v1.19
+                              - v1.20
+                              - v1.21
+                              - v1.22
+                              - v1.23
+                              - v1.24
+                              - v1.25
+                              - latest
+                              type: string
+                          type: object
+                      type: object
+                    verifyImages:
+                      description: VerifyImages is used to verify image signatures
+                        and mutate them to add a digest
+                      items:
+                        description: ImageVerification validates that images that
+                          match the specified pattern are signed with the supplied
+                          public key. Once the image is verified it is mutated to
+                          include the SHA digest retrieved during the registration.
+                        properties:
+                          additionalExtensions:
+                            additionalProperties:
+                              type: string
+                            description: AdditionalExtensions are certificate-extensions
+                              used for keyless signing. Deprecated.
+                            type: object
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: Annotations are used for image verification.
+                              Every specified key-value pair must exist and match
+                              in the verified payload. The payload may contain other
+                              key-value pairs. Deprecated. Use annotations per Attestor
+                              instead.
+                            type: object
+                          attestations:
+                            description: Attestations are optional checks for signed
+                              in-toto Statements used to verify the image. See https://github.com/in-toto/attestation.
+                              Kyverno fetches signed attestations from the OCI registry
+                              and decodes them into a list of Statement declarations.
+                            items:
+                              description: Attestation are checks for signed in-toto
+                                Statements that are used to verify the image. See
+                                https://github.com/in-toto/attestation. Kyverno fetches
+                                signed attestations from the OCI registry and decodes
+                                them into a list of Statements.
+                              properties:
+                                conditions:
+                                  description: Conditions are used to verify attributes
+                                    within a Predicate. If no Conditions are specified
+                                    the attestation check is satisfied as long there
+                                    are predicates that match the predicate type.
+                                  items:
+                                    description: AnyAllConditions consists of conditions
+                                      wrapped denoting a logical criteria to be fulfilled.
+                                      AnyConditions get fulfilled when at least one
+                                      of its sub-conditions passes. AllConditions
+                                      get fulfilled only when all of its sub-conditions
+                                      pass.
+                                    properties:
+                                      all:
+                                        description: AllConditions enable variable-based
+                                          conditional rule execution. This is useful
+                                          for finer control of when an rule is applied.
+                                          A condition can reference object data using
+                                          JMESPath notation. Here, all of the conditions
+                                          need to pass
+                                        items:
+                                          description: Condition defines variable-based
+                                            conditional criteria for rule execution.
+                                          properties:
+                                            key:
+                                              description: Key is the context entry
+                                                (using JMESPath) for conditional rule
+                                                evaluation.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            operator:
+                                              description: 'Operator is the conditional
+                                                operation to perform. Valid operators
+                                                are: Equals, NotEquals, In, AnyIn,
+                                                AllIn, NotIn, AnyNotIn, AllNotIn,
+                                                GreaterThanOrEquals, GreaterThan,
+                                                LessThanOrEquals, LessThan, DurationGreaterThanOrEquals,
+                                                DurationGreaterThan, DurationLessThanOrEquals,
+                                                DurationLessThan'
+                                              enum:
+                                              - Equals
+                                              - NotEquals
+                                              - In
+                                              - AnyIn
+                                              - AllIn
+                                              - NotIn
+                                              - AnyNotIn
+                                              - AllNotIn
+                                              - GreaterThanOrEquals
+                                              - GreaterThan
+                                              - LessThanOrEquals
+                                              - LessThan
+                                              - DurationGreaterThanOrEquals
+                                              - DurationGreaterThan
+                                              - DurationLessThanOrEquals
+                                              - DurationLessThan
+                                              type: string
+                                            value:
+                                              description: Value is the conditional
+                                                value, or set of values. The values
+                                                can be fixed set or can be variables
+                                                declared using JMESPath.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                        type: array
+                                      any:
+                                        description: AnyConditions enable variable-based
+                                          conditional rule execution. This is useful
+                                          for finer control of when an rule is applied.
+                                          A condition can reference object data using
+                                          JMESPath notation. Here, at least one of
+                                          the conditions need to pass
+                                        items:
+                                          description: Condition defines variable-based
+                                            conditional criteria for rule execution.
+                                          properties:
+                                            key:
+                                              description: Key is the context entry
+                                                (using JMESPath) for conditional rule
+                                                evaluation.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            operator:
+                                              description: 'Operator is the conditional
+                                                operation to perform. Valid operators
+                                                are: Equals, NotEquals, In, AnyIn,
+                                                AllIn, NotIn, AnyNotIn, AllNotIn,
+                                                GreaterThanOrEquals, GreaterThan,
+                                                LessThanOrEquals, LessThan, DurationGreaterThanOrEquals,
+                                                DurationGreaterThan, DurationLessThanOrEquals,
+                                                DurationLessThan'
+                                              enum:
+                                              - Equals
+                                              - NotEquals
+                                              - In
+                                              - AnyIn
+                                              - AllIn
+                                              - NotIn
+                                              - AnyNotIn
+                                              - AllNotIn
+                                              - GreaterThanOrEquals
+                                              - GreaterThan
+                                              - LessThanOrEquals
+                                              - LessThan
+                                              - DurationGreaterThanOrEquals
+                                              - DurationGreaterThan
+                                              - DurationLessThanOrEquals
+                                              - DurationLessThan
+                                              type: string
+                                            value:
+                                              description: Value is the conditional
+                                                value, or set of values. The values
+                                                can be fixed set or can be variables
+                                                declared using JMESPath.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                        type: array
+                                    type: object
+                                  type: array
+                                predicateType:
+                                  description: PredicateType defines the type of Predicate
+                                    contained within the Statement.
+                                  type: string
+                              type: object
+                            type: array
+                          attestors:
+                            description: Attestors specified the required attestors
+                              (i.e. authorities)
+                            items:
+                              properties:
+                                count:
+                                  description: Count specifies the required number
+                                    of entries that must match. If the count is null,
+                                    all entries must match (a logical AND). If the
+                                    count is 1, at least one entry must match (a logical
+                                    OR). If the count contains a value N, then N must
+                                    be less than or equal to the size of entries,
+                                    and at least N entries must match.
+                                  minimum: 1
+                                  type: integer
+                                entries:
+                                  description: Entries contains the available attestors.
+                                    An attestor can be a static key, attributes for
+                                    keyless verification, or a nested attestor declaration.
+                                  items:
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations are used for image
+                                          verification. Every specified key-value
+                                          pair must exist and match in the verified
+                                          payload. The payload may contain other key-value
+                                          pairs.
+                                        type: object
+                                      attestor:
+                                        description: Attestor is a nested AttestorSet
+                                          used to specify a more complex set of match
+                                          authorities
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      certificates:
+                                        description: Certificates specifies one or
+                                          more certificates
+                                        properties:
+                                          cert:
+                                            description: Certificate is an optional
+                                              PEM encoded public certificate.
+                                            type: string
+                                          certChain:
+                                            description: CertificateChain is an optional
+                                              PEM encoded set of certificates used
+                                              to verify
+                                            type: string
+                                          rekor:
+                                            description: Rekor provides configuration
+                                              for the Rekor transparency log service.
+                                              If the value is nil, Rekor is not checked.
+                                              If an empty object is provided the public
+                                              instance of Rekor (https://rekor.sigstore.dev)
+                                              is used.
+                                            properties:
+                                              url:
+                                                description: URL is the address of
+                                                  the transparency log. Defaults to
+                                                  the public log https://rekor.sigstore.dev.
+                                                type: string
+                                            required:
+                                            - url
+                                            type: object
+                                        type: object
+                                      keyless:
+                                        description: Keyless is a set of attribute
+                                          used to verify a Sigstore keyless attestor.
+                                          See https://github.com/sigstore/cosign/blob/main/KEYLESS.md.
+                                        properties:
+                                          additionalExtensions:
+                                            additionalProperties:
+                                              type: string
+                                            description: AdditionalExtensions are
+                                              certificate-extensions used for keyless
+                                              signing.
+                                            type: object
+                                          issuer:
+                                            description: Issuer is the certificate
+                                              issuer used for keyless signing.
+                                            type: string
+                                          rekor:
+                                            description: Rekor provides configuration
+                                              for the Rekor transparency log service.
+                                              If the value is nil, Rekor is not checked
+                                              and a root certificate chain is expected
+                                              instead. If an empty object is provided
+                                              the public instance of Rekor (https://rekor.sigstore.dev)
+                                              is used.
+                                            properties:
+                                              url:
+                                                description: URL is the address of
+                                                  the transparency log. Defaults to
+                                                  the public log https://rekor.sigstore.dev.
+                                                type: string
+                                            required:
+                                            - url
+                                            type: object
+                                          roots:
+                                            description: Roots is an optional set
+                                              of PEM encoded trusted root certificates.
+                                              If not provided, the system roots are
+                                              used.
+                                            type: string
+                                          subject:
+                                            description: Subject is the verified identity
+                                              used for keyless signing, for example
+                                              the email address
+                                            type: string
+                                        type: object
+                                      keys:
+                                        description: Keys specifies one or more public
+                                          keys
+                                        properties:
+                                          publicKeys:
+                                            description: Keys is a set of X.509 public
+                                              keys used to verify image signatures.
+                                              The keys can be directly specified or
+                                              can be a variable reference to a key
+                                              specified in a ConfigMap (see https://kyverno.io/docs/writing-policies/variables/).
+                                              When multiple keys are specified each
+                                              key is processed as a separate staticKey
+                                              entry (.attestors[*].entries.keys) within
+                                              the set of attestors and the count is
+                                              applied across the keys.
+                                            type: string
+                                          rekor:
+                                            description: Rekor provides configuration
+                                              for the Rekor transparency log service.
+                                              If the value is nil, Rekor is not checked.
+                                              If an empty object is provided the public
+                                              instance of Rekor (https://rekor.sigstore.dev)
+                                              is used.
+                                            properties:
+                                              url:
+                                                description: URL is the address of
+                                                  the transparency log. Defaults to
+                                                  the public log https://rekor.sigstore.dev.
+                                                type: string
+                                            required:
+                                            - url
+                                            type: object
+                                        type: object
+                                      repository:
+                                        description: Repository is an optional alternate
+                                          OCI repository to use for signatures and
+                                          attestations that match this rule. If specified
+                                          Repository will override other OCI image
+                                          repository locations for this Attestor.
+                                        type: string
+                                    type: object
+                                  type: array
+                              type: object
+                            type: array
+                          image:
+                            description: 'Image is the image name consisting of the
+                              registry address, repository, image, and tag. Wildcards
+                              (''*'' and ''?'') are allowed. See: https://kubernetes.io/docs/concepts/containers/images.
+                              Deprecated. Use ImageReferences instead.'
+                            type: string
+                          imageReferences:
+                            description: 'ImageReferences is a list of matching image
+                              reference patterns. At least one pattern in the list
+                              must match the image for the rule to apply. Each image
+                              reference consists of a registry address (defaults to
+                              docker.io), repository, image, and tag (defaults to
+                              latest). Wildcards (''*'' and ''?'') are allowed. See:
+                              https://kubernetes.io/docs/concepts/containers/images.'
+                            items:
+                              type: string
+                            type: array
+                          issuer:
+                            description: Issuer is the certificate issuer used for
+                              keyless signing. Deprecated. Use KeylessAttestor instead.
+                            type: string
+                          key:
+                            description: Key is the PEM encoded public key that the
+                              image or attestation is signed with. Deprecated. Use
+                              StaticKeyAttestor instead.
+                            type: string
+                          mutateDigest:
+                            default: true
+                            description: MutateDigest enables replacement of image
+                              tags with digests. Defaults to true.
+                            type: boolean
+                          repository:
+                            description: Repository is an optional alternate OCI repository
+                              to use for image signatures and attestations that match
+                              this rule. If specified Repository will override the
+                              default OCI image repository configured for the installation.
+                              The repository can also be overridden per Attestor or
+                              Attestation.
+                            type: string
+                          required:
+                            default: true
+                            description: Required validates that images are verified
+                              i.e. have matched passed a signature or attestation
+                              check.
+                            type: boolean
+                          roots:
+                            description: Roots is the PEM encoded Root certificate
+                              chain used for keyless signing Deprecated. Use KeylessAttestor
+                              instead.
+                            type: string
+                          subject:
+                            description: Subject is the identity used for keyless
+                              signing, for example an email address Deprecated. Use
+                              KeylessAttestor instead.
+                            type: string
+                          verifyDigest:
+                            default: true
+                            description: VerifyDigest validates that images have a
+                              digest.
+                            type: boolean
+                        type: object
+                      type: array
+                  type: object
+                type: array
+              schemaValidation:
+                description: SchemaValidation skips policy validation checks. Optional.
+                  The default value is set to "true", it must be set to "false" to
+                  disable the validation checks.
+                type: boolean
+              validationFailureAction:
+                default: audit
+                description: ValidationFailureAction defines if a validation policy
+                  rule violation should block the admission review request (enforce),
+                  or allow (audit) the admission review request and report an error
+                  in a policy report. Optional. Allowed values are audit or enforce.
+                  The default value is "audit".
+                enum:
+                - audit
+                - enforce
+                type: string
+              validationFailureActionOverrides:
+                description: ValidationFailureActionOverrides is a Cluster Policy
+                  attribute that specifies ValidationFailureAction namespace-wise.
+                  It overrides ValidationFailureAction for the specified namespaces.
+                items:
+                  properties:
+                    action:
+                      description: ValidationFailureAction defines the policy validation
+                        failure action
+                      enum:
+                      - audit
+                      - enforce
+                      type: string
+                    namespaces:
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                type: array
+              webhookTimeoutSeconds:
+                description: WebhookTimeoutSeconds specifies the maximum time in seconds
+                  allowed to apply this policy. After the configured time expires,
+                  the admission request may fail, or may simply ignore the policy
+                  results, based on the failure policy. The default timeout is 10s,
+                  the value must be between 1 and 30 seconds.
+                format: int32
+                type: integer
+            type: object
+          status:
+            description: Status contains policy runtime data.
+            properties:
+              autogen:
+                description: Autogen contains autogen status information
+                properties:
+                  rules:
+                    description: Rules is a list of Rule instances. It contains auto
+                      generated rules added for pod controllers
+                    items:
+                      description: Rule defines a validation, mutation, or generation
+                        control for matching resources. Each rules contains a match
+                        declaration to select resources, and an optional exclude declaration
+                        to specify which resources to exclude.
+                      properties:
+                        context:
+                          description: Context defines variables and data sources
+                            that can be used during rule execution.
+                          items:
+                            description: ContextEntry adds variables and data sources
+                              to a rule Context. Either a ConfigMap reference or a
+                              APILookup must be provided.
+                            properties:
+                              apiCall:
+                                description: APICall defines an HTTP request to the
+                                  Kubernetes API server. The JSON data retrieved is
+                                  stored in the context.
+                                properties:
+                                  jmesPath:
+                                    description: JMESPath is an optional JSON Match
+                                      Expression that can be used to transform the
+                                      JSON response returned from the API server.
+                                      For example a JMESPath of "items | length(@)"
+                                      applied to the API server response to the URLPath
+                                      "/apis/apps/v1/deployments" will return the
+                                      total count of deployments across all namespaces.
+                                    type: string
+                                  urlPath:
+                                    description: URLPath is the URL path to be used
+                                      in the HTTP GET request to the Kubernetes API
+                                      server (e.g. "/api/v1/namespaces" or  "/apis/apps/v1/deployments").
+                                      The format required is the same format used
+                                      by the `kubectl get --raw` command.
+                                    type: string
+                                required:
+                                - urlPath
+                                type: object
+                              configMap:
+                                description: ConfigMap is the ConfigMap reference.
+                                properties:
+                                  name:
+                                    description: Name is the ConfigMap name.
+                                    type: string
+                                  namespace:
+                                    description: Namespace is the ConfigMap namespace.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              imageRegistry:
+                                description: ImageRegistry defines requests to an
+                                  OCI/Docker V2 registry to fetch image details.
+                                properties:
+                                  jmesPath:
+                                    description: JMESPath is an optional JSON Match
+                                      Expression that can be used to transform the
+                                      ImageData struct returned as a result of processing
+                                      the image reference.
+                                    type: string
+                                  reference:
+                                    description: 'Reference is image reference to
+                                      a container image in the registry. Example:
+                                      ghcr.io/kyverno/kyverno:latest'
+                                    type: string
+                                required:
+                                - reference
+                                type: object
+                              name:
+                                description: Name is the variable name.
+                                type: string
+                              variable:
+                                description: Variable defines an arbitrary JMESPath
+                                  context variable that can be defined inline.
+                                properties:
+                                  default:
+                                    description: Default is an optional arbitrary
+                                      JSON object that the variable may take if the
+                                      JMESPath expression evaluates to nil
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  jmesPath:
+                                    description: JMESPath is an optional JMESPath
+                                      Expression that can be used to transform the
+                                      variable.
+                                    type: string
+                                  value:
+                                    description: Value is any arbitrary JSON object
+                                      representable in YAML or JSON form.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                            type: object
+                          type: array
+                        exclude:
+                          description: ExcludeResources defines when this policy rule
+                            should not be applied. The exclude criteria can include
+                            resource information (e.g. kind, name, namespace, labels)
+                            and admission review request information like the name
+                            or role.
+                          properties:
+                            all:
+                              description: All allows specifying resources which will
+                                be ANDed
+                              items:
+                                description: ResourceFilter allow users to "AND" or
+                                  "OR" between resources
+                                properties:
+                                  clusterRoles:
+                                    description: ClusterRoles is the list of cluster-wide
+                                      role names for the user.
+                                    items:
+                                      type: string
+                                    type: array
+                                  resources:
+                                    description: ResourceDescription contains information
+                                      about the resource being created or modified.
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations is a  map of annotations
+                                          (key-value pairs of type string). Annotation
+                                          keys and values support the wildcard characters
+                                          "*" (matches zero or many characters) and
+                                          "?" (matches at least one character).
+                                        type: object
+                                      kinds:
+                                        description: Kinds is a list of resource kinds.
+                                        items:
+                                          type: string
+                                        type: array
+                                      name:
+                                        description: 'Name is the name of the resource.
+                                          The name supports wildcard characters "*"
+                                          (matches zero or many characters) and "?"
+                                          (at least one character). NOTE: "Name" is
+                                          being deprecated in favor of "Names".'
+                                        type: string
+                                      names:
+                                        description: Names are the names of the resources.
+                                          Each name supports wildcard characters "*"
+                                          (matches zero or many characters) and "?"
+                                          (at least one character).
+                                        items:
+                                          type: string
+                                        type: array
+                                      namespaceSelector:
+                                        description: 'NamespaceSelector is a label
+                                          selector for the resource namespace. Label
+                                          keys and values in `matchLabels` support
+                                          the wildcard characters `*` (matches zero
+                                          or many characters) and `?` (matches one
+                                          character).Wildcards allows writing label
+                                          selectors like ["storage.k8s.io/*": "*"].
+                                          Note that using ["*" : "*"] matches any
+                                          key and value but does not match an empty
+                                          label set.'
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      namespaces:
+                                        description: Namespaces is a list of namespaces
+                                          names. Each name supports wildcard characters
+                                          "*" (matches zero or many characters) and
+                                          "?" (at least one character).
+                                        items:
+                                          type: string
+                                        type: array
+                                      selector:
+                                        description: 'Selector is a label selector.
+                                          Label keys and values in `matchLabels` support
+                                          the wildcard characters `*` (matches zero
+                                          or many characters) and `?` (matches one
+                                          character). Wildcards allows writing label
+                                          selectors like ["storage.k8s.io/*": "*"].
+                                          Note that using ["*" : "*"] matches any
+                                          key and value but does not match an empty
+                                          label set.'
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  roles:
+                                    description: Roles is the list of namespaced role
+                                      names for the user.
+                                    items:
+                                      type: string
+                                    type: array
+                                  subjects:
+                                    description: Subjects is the list of subject names
+                                      like users, user groups, and service accounts.
+                                    items:
+                                      description: Subject contains a reference to
+                                        the object or user identities a role binding
+                                        applies to.  This can either hold a direct
+                                        API object reference, or a value for non-objects
+                                        such as user and group names.
+                                      properties:
+                                        apiGroup:
+                                          description: APIGroup holds the API group
+                                            of the referenced subject. Defaults to
+                                            "" for ServiceAccount subjects. Defaults
+                                            to "rbac.authorization.k8s.io" for User
+                                            and Group subjects.
+                                          type: string
+                                        kind:
+                                          description: Kind of object being referenced.
+                                            Values defined by this API group are "User",
+                                            "Group", and "ServiceAccount". If the
+                                            Authorizer does not recognized the kind
+                                            value, the Authorizer should report an
+                                            error.
+                                          type: string
+                                        name:
+                                          description: Name of the object being referenced.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the referenced
+                                            object.  If the object kind is non-namespace,
+                                            such as "User" or "Group", and this value
+                                            is not empty the Authorizer should report
+                                            an error.
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    type: array
+                                type: object
+                              type: array
+                            any:
+                              description: Any allows specifying resources which will
+                                be ORed
+                              items:
+                                description: ResourceFilter allow users to "AND" or
+                                  "OR" between resources
+                                properties:
+                                  clusterRoles:
+                                    description: ClusterRoles is the list of cluster-wide
+                                      role names for the user.
+                                    items:
+                                      type: string
+                                    type: array
+                                  resources:
+                                    description: ResourceDescription contains information
+                                      about the resource being created or modified.
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations is a  map of annotations
+                                          (key-value pairs of type string). Annotation
+                                          keys and values support the wildcard characters
+                                          "*" (matches zero or many characters) and
+                                          "?" (matches at least one character).
+                                        type: object
+                                      kinds:
+                                        description: Kinds is a list of resource kinds.
+                                        items:
+                                          type: string
+                                        type: array
+                                      name:
+                                        description: 'Name is the name of the resource.
+                                          The name supports wildcard characters "*"
+                                          (matches zero or many characters) and "?"
+                                          (at least one character). NOTE: "Name" is
+                                          being deprecated in favor of "Names".'
+                                        type: string
+                                      names:
+                                        description: Names are the names of the resources.
+                                          Each name supports wildcard characters "*"
+                                          (matches zero or many characters) and "?"
+                                          (at least one character).
+                                        items:
+                                          type: string
+                                        type: array
+                                      namespaceSelector:
+                                        description: 'NamespaceSelector is a label
+                                          selector for the resource namespace. Label
+                                          keys and values in `matchLabels` support
+                                          the wildcard characters `*` (matches zero
+                                          or many characters) and `?` (matches one
+                                          character).Wildcards allows writing label
+                                          selectors like ["storage.k8s.io/*": "*"].
+                                          Note that using ["*" : "*"] matches any
+                                          key and value but does not match an empty
+                                          label set.'
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      namespaces:
+                                        description: Namespaces is a list of namespaces
+                                          names. Each name supports wildcard characters
+                                          "*" (matches zero or many characters) and
+                                          "?" (at least one character).
+                                        items:
+                                          type: string
+                                        type: array
+                                      selector:
+                                        description: 'Selector is a label selector.
+                                          Label keys and values in `matchLabels` support
+                                          the wildcard characters `*` (matches zero
+                                          or many characters) and `?` (matches one
+                                          character). Wildcards allows writing label
+                                          selectors like ["storage.k8s.io/*": "*"].
+                                          Note that using ["*" : "*"] matches any
+                                          key and value but does not match an empty
+                                          label set.'
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  roles:
+                                    description: Roles is the list of namespaced role
+                                      names for the user.
+                                    items:
+                                      type: string
+                                    type: array
+                                  subjects:
+                                    description: Subjects is the list of subject names
+                                      like users, user groups, and service accounts.
+                                    items:
+                                      description: Subject contains a reference to
+                                        the object or user identities a role binding
+                                        applies to.  This can either hold a direct
+                                        API object reference, or a value for non-objects
+                                        such as user and group names.
+                                      properties:
+                                        apiGroup:
+                                          description: APIGroup holds the API group
+                                            of the referenced subject. Defaults to
+                                            "" for ServiceAccount subjects. Defaults
+                                            to "rbac.authorization.k8s.io" for User
+                                            and Group subjects.
+                                          type: string
+                                        kind:
+                                          description: Kind of object being referenced.
+                                            Values defined by this API group are "User",
+                                            "Group", and "ServiceAccount". If the
+                                            Authorizer does not recognized the kind
+                                            value, the Authorizer should report an
+                                            error.
+                                          type: string
+                                        name:
+                                          description: Name of the object being referenced.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the referenced
+                                            object.  If the object kind is non-namespace,
+                                            such as "User" or "Group", and this value
+                                            is not empty the Authorizer should report
+                                            an error.
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    type: array
+                                type: object
+                              type: array
+                            clusterRoles:
+                              description: ClusterRoles is the list of cluster-wide
+                                role names for the user.
+                              items:
+                                type: string
+                              type: array
+                            resources:
+                              description: ResourceDescription contains information
+                                about the resource being created or modified. Requires
+                                at least one tag to be specified when under MatchResources.
+                                Specifying ResourceDescription directly under match
+                                is being deprecated. Please specify under "any" or
+                                "all" instead.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  description: Annotations is a  map of annotations
+                                    (key-value pairs of type string). Annotation keys
+                                    and values support the wildcard characters "*"
+                                    (matches zero or many characters) and "?" (matches
+                                    at least one character).
+                                  type: object
+                                kinds:
+                                  description: Kinds is a list of resource kinds.
+                                  items:
+                                    type: string
+                                  type: array
+                                name:
+                                  description: 'Name is the name of the resource.
+                                    The name supports wildcard characters "*" (matches
+                                    zero or many characters) and "?" (at least one
+                                    character). NOTE: "Name" is being deprecated in
+                                    favor of "Names".'
+                                  type: string
+                                names:
+                                  description: Names are the names of the resources.
+                                    Each name supports wildcard characters "*" (matches
+                                    zero or many characters) and "?" (at least one
+                                    character).
+                                  items:
+                                    type: string
+                                  type: array
+                                namespaceSelector:
+                                  description: 'NamespaceSelector is a label selector
+                                    for the resource namespace. Label keys and values
+                                    in `matchLabels` support the wildcard characters
+                                    `*` (matches zero or many characters) and `?`
+                                    (matches one character).Wildcards allows writing
+                                    label selectors like ["storage.k8s.io/*": "*"].
+                                    Note that using ["*" : "*"] matches any key and
+                                    value but does not match an empty label set.'
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: Namespaces is a list of namespaces
+                                    names. Each name supports wildcard characters
+                                    "*" (matches zero or many characters) and "?"
+                                    (at least one character).
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: 'Selector is a label selector. Label
+                                    keys and values in `matchLabels` support the wildcard
+                                    characters `*` (matches zero or many characters)
+                                    and `?` (matches one character). Wildcards allows
+                                    writing label selectors like ["storage.k8s.io/*":
+                                    "*"]. Note that using ["*" : "*"] matches any
+                                    key and value but does not match an empty label
+                                    set.'
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            roles:
+                              description: Roles is the list of namespaced role names
+                                for the user.
+                              items:
+                                type: string
+                              type: array
+                            subjects:
+                              description: Subjects is the list of subject names like
+                                users, user groups, and service accounts.
+                              items:
+                                description: Subject contains a reference to the object
+                                  or user identities a role binding applies to.  This
+                                  can either hold a direct API object reference, or
+                                  a value for non-objects such as user and group names.
+                                properties:
+                                  apiGroup:
+                                    description: APIGroup holds the API group of the
+                                      referenced subject. Defaults to "" for ServiceAccount
+                                      subjects. Defaults to "rbac.authorization.k8s.io"
+                                      for User and Group subjects.
+                                    type: string
+                                  kind:
+                                    description: Kind of object being referenced.
+                                      Values defined by this API group are "User",
+                                      "Group", and "ServiceAccount". If the Authorizer
+                                      does not recognized the kind value, the Authorizer
+                                      should report an error.
+                                    type: string
+                                  name:
+                                    description: Name of the object being referenced.
+                                    type: string
+                                  namespace:
+                                    description: Namespace of the referenced object.  If
+                                      the object kind is non-namespace, such as "User"
+                                      or "Group", and this value is not empty the
+                                      Authorizer should report an error.
+                                    type: string
+                                required:
+                                - kind
+                                - name
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              type: array
+                          type: object
+                        generate:
+                          description: Generation is used to create new resources.
+                          properties:
+                            apiVersion:
+                              description: APIVersion specifies resource apiVersion.
+                              type: string
+                            clone:
+                              description: Clone specifies the source resource used
+                                to populate each generated resource. At most one of
+                                Data or Clone can be specified. If neither are provided,
+                                the generated resource will be created with default
+                                data only.
+                              properties:
+                                name:
+                                  description: Name specifies name of the resource.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies source resource
+                                    namespace.
+                                  type: string
+                              type: object
+                            cloneList:
+                              description: CloneList specifies the list of source
+                                resource used to populate each generated resource.
+                              properties:
+                                kinds:
+                                  description: Kinds is a list of resource kinds.
+                                  items:
+                                    type: string
+                                  type: array
+                                namespace:
+                                  description: Namespace specifies source resource
+                                    namespace.
+                                  type: string
+                                selector:
+                                  description: Selector is a label selector. Label
+                                    keys and values in `matchLabels`. wildcard characters
+                                    are not supported.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            data:
+                              description: Data provides the resource declaration
+                                used to populate each generated resource. At most
+                                one of Data or Clone must be specified. If neither
+                                are provided, the generated resource will be created
+                                with default data only.
+                              x-kubernetes-preserve-unknown-fields: true
+                            kind:
+                              description: Kind specifies resource kind.
+                              type: string
+                            name:
+                              description: Name specifies the resource name.
+                              type: string
+                            namespace:
+                              description: Namespace specifies resource namespace.
+                              type: string
+                            synchronize:
+                              description: Synchronize controls if generated resources
+                                should be kept in-sync with their source resource.
+                                If Synchronize is set to "true" changes to generated
+                                resources will be overwritten with resource data from
+                                Data or the resource specified in the Clone declaration.
+                                Optional. Defaults to "false" if not specified.
+                              type: boolean
+                          type: object
+                        imageExtractors:
+                          additionalProperties:
+                            items:
+                              properties:
+                                key:
+                                  description: Key is an optional name of the field
+                                    within 'path' that will be used to uniquely identify
+                                    an image. Note - this field MUST be unique.
+                                  type: string
+                                name:
+                                  description: Name is the entry the image will be
+                                    available under 'images.<name>' in the context.
+                                    If this field is not defined, image entries will
+                                    appear under 'images.custom'.
+                                  type: string
+                                path:
+                                  description: Path is the path to the object containing
+                                    the image field in a custom resource. It should
+                                    be slash-separated. Each slash-separated key must
+                                    be a valid YAML key or a wildcard '*'. Wildcard
+                                    keys are expanded in case of arrays or objects.
+                                  type: string
+                                value:
+                                  description: Value is an optional name of the field
+                                    within 'path' that points to the image URI. This
+                                    is useful when a custom 'key' is also defined.
+                                  type: string
+                              required:
+                              - path
+                              type: object
+                            type: array
+                          description: ImageExtractors defines a mapping from kinds
+                            to ImageExtractorConfigs. This config is only valid for
+                            verifyImages rules.
+                          type: object
+                        match:
+                          description: MatchResources defines when this policy rule
+                            should be applied. The match criteria can include resource
+                            information (e.g. kind, name, namespace, labels) and admission
+                            review request information like the user name or role.
+                            At least one kind is required.
+                          properties:
+                            all:
+                              description: All allows specifying resources which will
+                                be ANDed
+                              items:
+                                description: ResourceFilter allow users to "AND" or
+                                  "OR" between resources
+                                properties:
+                                  clusterRoles:
+                                    description: ClusterRoles is the list of cluster-wide
+                                      role names for the user.
+                                    items:
+                                      type: string
+                                    type: array
+                                  resources:
+                                    description: ResourceDescription contains information
+                                      about the resource being created or modified.
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations is a  map of annotations
+                                          (key-value pairs of type string). Annotation
+                                          keys and values support the wildcard characters
+                                          "*" (matches zero or many characters) and
+                                          "?" (matches at least one character).
+                                        type: object
+                                      kinds:
+                                        description: Kinds is a list of resource kinds.
+                                        items:
+                                          type: string
+                                        type: array
+                                      name:
+                                        description: 'Name is the name of the resource.
+                                          The name supports wildcard characters "*"
+                                          (matches zero or many characters) and "?"
+                                          (at least one character). NOTE: "Name" is
+                                          being deprecated in favor of "Names".'
+                                        type: string
+                                      names:
+                                        description: Names are the names of the resources.
+                                          Each name supports wildcard characters "*"
+                                          (matches zero or many characters) and "?"
+                                          (at least one character).
+                                        items:
+                                          type: string
+                                        type: array
+                                      namespaceSelector:
+                                        description: 'NamespaceSelector is a label
+                                          selector for the resource namespace. Label
+                                          keys and values in `matchLabels` support
+                                          the wildcard characters `*` (matches zero
+                                          or many characters) and `?` (matches one
+                                          character).Wildcards allows writing label
+                                          selectors like ["storage.k8s.io/*": "*"].
+                                          Note that using ["*" : "*"] matches any
+                                          key and value but does not match an empty
+                                          label set.'
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      namespaces:
+                                        description: Namespaces is a list of namespaces
+                                          names. Each name supports wildcard characters
+                                          "*" (matches zero or many characters) and
+                                          "?" (at least one character).
+                                        items:
+                                          type: string
+                                        type: array
+                                      selector:
+                                        description: 'Selector is a label selector.
+                                          Label keys and values in `matchLabels` support
+                                          the wildcard characters `*` (matches zero
+                                          or many characters) and `?` (matches one
+                                          character). Wildcards allows writing label
+                                          selectors like ["storage.k8s.io/*": "*"].
+                                          Note that using ["*" : "*"] matches any
+                                          key and value but does not match an empty
+                                          label set.'
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  roles:
+                                    description: Roles is the list of namespaced role
+                                      names for the user.
+                                    items:
+                                      type: string
+                                    type: array
+                                  subjects:
+                                    description: Subjects is the list of subject names
+                                      like users, user groups, and service accounts.
+                                    items:
+                                      description: Subject contains a reference to
+                                        the object or user identities a role binding
+                                        applies to.  This can either hold a direct
+                                        API object reference, or a value for non-objects
+                                        such as user and group names.
+                                      properties:
+                                        apiGroup:
+                                          description: APIGroup holds the API group
+                                            of the referenced subject. Defaults to
+                                            "" for ServiceAccount subjects. Defaults
+                                            to "rbac.authorization.k8s.io" for User
+                                            and Group subjects.
+                                          type: string
+                                        kind:
+                                          description: Kind of object being referenced.
+                                            Values defined by this API group are "User",
+                                            "Group", and "ServiceAccount". If the
+                                            Authorizer does not recognized the kind
+                                            value, the Authorizer should report an
+                                            error.
+                                          type: string
+                                        name:
+                                          description: Name of the object being referenced.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the referenced
+                                            object.  If the object kind is non-namespace,
+                                            such as "User" or "Group", and this value
+                                            is not empty the Authorizer should report
+                                            an error.
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    type: array
+                                type: object
+                              type: array
+                            any:
+                              description: Any allows specifying resources which will
+                                be ORed
+                              items:
+                                description: ResourceFilter allow users to "AND" or
+                                  "OR" between resources
+                                properties:
+                                  clusterRoles:
+                                    description: ClusterRoles is the list of cluster-wide
+                                      role names for the user.
+                                    items:
+                                      type: string
+                                    type: array
+                                  resources:
+                                    description: ResourceDescription contains information
+                                      about the resource being created or modified.
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations is a  map of annotations
+                                          (key-value pairs of type string). Annotation
+                                          keys and values support the wildcard characters
+                                          "*" (matches zero or many characters) and
+                                          "?" (matches at least one character).
+                                        type: object
+                                      kinds:
+                                        description: Kinds is a list of resource kinds.
+                                        items:
+                                          type: string
+                                        type: array
+                                      name:
+                                        description: 'Name is the name of the resource.
+                                          The name supports wildcard characters "*"
+                                          (matches zero or many characters) and "?"
+                                          (at least one character). NOTE: "Name" is
+                                          being deprecated in favor of "Names".'
+                                        type: string
+                                      names:
+                                        description: Names are the names of the resources.
+                                          Each name supports wildcard characters "*"
+                                          (matches zero or many characters) and "?"
+                                          (at least one character).
+                                        items:
+                                          type: string
+                                        type: array
+                                      namespaceSelector:
+                                        description: 'NamespaceSelector is a label
+                                          selector for the resource namespace. Label
+                                          keys and values in `matchLabels` support
+                                          the wildcard characters `*` (matches zero
+                                          or many characters) and `?` (matches one
+                                          character).Wildcards allows writing label
+                                          selectors like ["storage.k8s.io/*": "*"].
+                                          Note that using ["*" : "*"] matches any
+                                          key and value but does not match an empty
+                                          label set.'
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      namespaces:
+                                        description: Namespaces is a list of namespaces
+                                          names. Each name supports wildcard characters
+                                          "*" (matches zero or many characters) and
+                                          "?" (at least one character).
+                                        items:
+                                          type: string
+                                        type: array
+                                      selector:
+                                        description: 'Selector is a label selector.
+                                          Label keys and values in `matchLabels` support
+                                          the wildcard characters `*` (matches zero
+                                          or many characters) and `?` (matches one
+                                          character). Wildcards allows writing label
+                                          selectors like ["storage.k8s.io/*": "*"].
+                                          Note that using ["*" : "*"] matches any
+                                          key and value but does not match an empty
+                                          label set.'
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  roles:
+                                    description: Roles is the list of namespaced role
+                                      names for the user.
+                                    items:
+                                      type: string
+                                    type: array
+                                  subjects:
+                                    description: Subjects is the list of subject names
+                                      like users, user groups, and service accounts.
+                                    items:
+                                      description: Subject contains a reference to
+                                        the object or user identities a role binding
+                                        applies to.  This can either hold a direct
+                                        API object reference, or a value for non-objects
+                                        such as user and group names.
+                                      properties:
+                                        apiGroup:
+                                          description: APIGroup holds the API group
+                                            of the referenced subject. Defaults to
+                                            "" for ServiceAccount subjects. Defaults
+                                            to "rbac.authorization.k8s.io" for User
+                                            and Group subjects.
+                                          type: string
+                                        kind:
+                                          description: Kind of object being referenced.
+                                            Values defined by this API group are "User",
+                                            "Group", and "ServiceAccount". If the
+                                            Authorizer does not recognized the kind
+                                            value, the Authorizer should report an
+                                            error.
+                                          type: string
+                                        name:
+                                          description: Name of the object being referenced.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the referenced
+                                            object.  If the object kind is non-namespace,
+                                            such as "User" or "Group", and this value
+                                            is not empty the Authorizer should report
+                                            an error.
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    type: array
+                                type: object
+                              type: array
+                            clusterRoles:
+                              description: ClusterRoles is the list of cluster-wide
+                                role names for the user.
+                              items:
+                                type: string
+                              type: array
+                            resources:
+                              description: ResourceDescription contains information
+                                about the resource being created or modified. Requires
+                                at least one tag to be specified when under MatchResources.
+                                Specifying ResourceDescription directly under match
+                                is being deprecated. Please specify under "any" or
+                                "all" instead.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  description: Annotations is a  map of annotations
+                                    (key-value pairs of type string). Annotation keys
+                                    and values support the wildcard characters "*"
+                                    (matches zero or many characters) and "?" (matches
+                                    at least one character).
+                                  type: object
+                                kinds:
+                                  description: Kinds is a list of resource kinds.
+                                  items:
+                                    type: string
+                                  type: array
+                                name:
+                                  description: 'Name is the name of the resource.
+                                    The name supports wildcard characters "*" (matches
+                                    zero or many characters) and "?" (at least one
+                                    character). NOTE: "Name" is being deprecated in
+                                    favor of "Names".'
+                                  type: string
+                                names:
+                                  description: Names are the names of the resources.
+                                    Each name supports wildcard characters "*" (matches
+                                    zero or many characters) and "?" (at least one
+                                    character).
+                                  items:
+                                    type: string
+                                  type: array
+                                namespaceSelector:
+                                  description: 'NamespaceSelector is a label selector
+                                    for the resource namespace. Label keys and values
+                                    in `matchLabels` support the wildcard characters
+                                    `*` (matches zero or many characters) and `?`
+                                    (matches one character).Wildcards allows writing
+                                    label selectors like ["storage.k8s.io/*": "*"].
+                                    Note that using ["*" : "*"] matches any key and
+                                    value but does not match an empty label set.'
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: Namespaces is a list of namespaces
+                                    names. Each name supports wildcard characters
+                                    "*" (matches zero or many characters) and "?"
+                                    (at least one character).
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: 'Selector is a label selector. Label
+                                    keys and values in `matchLabels` support the wildcard
+                                    characters `*` (matches zero or many characters)
+                                    and `?` (matches one character). Wildcards allows
+                                    writing label selectors like ["storage.k8s.io/*":
+                                    "*"]. Note that using ["*" : "*"] matches any
+                                    key and value but does not match an empty label
+                                    set.'
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            roles:
+                              description: Roles is the list of namespaced role names
+                                for the user.
+                              items:
+                                type: string
+                              type: array
+                            subjects:
+                              description: Subjects is the list of subject names like
+                                users, user groups, and service accounts.
+                              items:
+                                description: Subject contains a reference to the object
+                                  or user identities a role binding applies to.  This
+                                  can either hold a direct API object reference, or
+                                  a value for non-objects such as user and group names.
+                                properties:
+                                  apiGroup:
+                                    description: APIGroup holds the API group of the
+                                      referenced subject. Defaults to "" for ServiceAccount
+                                      subjects. Defaults to "rbac.authorization.k8s.io"
+                                      for User and Group subjects.
+                                    type: string
+                                  kind:
+                                    description: Kind of object being referenced.
+                                      Values defined by this API group are "User",
+                                      "Group", and "ServiceAccount". If the Authorizer
+                                      does not recognized the kind value, the Authorizer
+                                      should report an error.
+                                    type: string
+                                  name:
+                                    description: Name of the object being referenced.
+                                    type: string
+                                  namespace:
+                                    description: Namespace of the referenced object.  If
+                                      the object kind is non-namespace, such as "User"
+                                      or "Group", and this value is not empty the
+                                      Authorizer should report an error.
+                                    type: string
+                                required:
+                                - kind
+                                - name
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              type: array
+                          type: object
+                        mutate:
+                          description: Mutation is used to modify matching resources.
+                          properties:
+                            foreach:
+                              description: ForEach applies mutation rules to a list
+                                of sub-elements by creating a context for each entry
+                                in the list and looping over it to apply the specified
+                                logic.
+                              items:
+                                description: ForEach applies mutation rules to a list
+                                  of sub-elements by creating a context for each entry
+                                  in the list and looping over it to apply the specified
+                                  logic.
+                                properties:
+                                  context:
+                                    description: Context defines variables and data
+                                      sources that can be used during rule execution.
+                                    items:
+                                      description: ContextEntry adds variables and
+                                        data sources to a rule Context. Either a ConfigMap
+                                        reference or a APILookup must be provided.
+                                      properties:
+                                        apiCall:
+                                          description: APICall defines an HTTP request
+                                            to the Kubernetes API server. The JSON
+                                            data retrieved is stored in the context.
+                                          properties:
+                                            jmesPath:
+                                              description: JMESPath is an optional
+                                                JSON Match Expression that can be
+                                                used to transform the JSON response
+                                                returned from the API server. For
+                                                example a JMESPath of "items | length(@)"
+                                                applied to the API server response
+                                                to the URLPath "/apis/apps/v1/deployments"
+                                                will return the total count of deployments
+                                                across all namespaces.
+                                              type: string
+                                            urlPath:
+                                              description: URLPath is the URL path
+                                                to be used in the HTTP GET request
+                                                to the Kubernetes API server (e.g.
+                                                "/api/v1/namespaces" or  "/apis/apps/v1/deployments").
+                                                The format required is the same format
+                                                used by the `kubectl get --raw` command.
+                                              type: string
+                                          required:
+                                          - urlPath
+                                          type: object
+                                        configMap:
+                                          description: ConfigMap is the ConfigMap
+                                            reference.
+                                          properties:
+                                            name:
+                                              description: Name is the ConfigMap name.
+                                              type: string
+                                            namespace:
+                                              description: Namespace is the ConfigMap
+                                                namespace.
+                                              type: string
+                                          required:
+                                          - name
+                                          type: object
+                                        imageRegistry:
+                                          description: ImageRegistry defines requests
+                                            to an OCI/Docker V2 registry to fetch
+                                            image details.
+                                          properties:
+                                            jmesPath:
+                                              description: JMESPath is an optional
+                                                JSON Match Expression that can be
+                                                used to transform the ImageData struct
+                                                returned as a result of processing
+                                                the image reference.
+                                              type: string
+                                            reference:
+                                              description: 'Reference is image reference
+                                                to a container image in the registry.
+                                                Example: ghcr.io/kyverno/kyverno:latest'
+                                              type: string
+                                          required:
+                                          - reference
+                                          type: object
+                                        name:
+                                          description: Name is the variable name.
+                                          type: string
+                                        variable:
+                                          description: Variable defines an arbitrary
+                                            JMESPath context variable that can be
+                                            defined inline.
+                                          properties:
+                                            default:
+                                              description: Default is an optional
+                                                arbitrary JSON object that the variable
+                                                may take if the JMESPath expression
+                                                evaluates to nil
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            jmesPath:
+                                              description: JMESPath is an optional
+                                                JMESPath Expression that can be used
+                                                to transform the variable.
+                                              type: string
+                                            value:
+                                              description: Value is any arbitrary
+                                                JSON object representable in YAML
+                                                or JSON form.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                      type: object
+                                    type: array
+                                  list:
+                                    description: List specifies a JMESPath expression
+                                      that results in one or more elements to which
+                                      the validation logic is applied.
+                                    type: string
+                                  patchStrategicMerge:
+                                    description: PatchStrategicMerge is a strategic
+                                      merge patch used to modify resources. See https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/
+                                      and https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  patchesJson6902:
+                                    description: PatchesJSON6902 is a list of RFC
+                                      6902 JSON Patch declarations used to modify
+                                      resources. See https://tools.ietf.org/html/rfc6902
+                                      and https://kubectl.docs.kubernetes.io/references/kustomize/patchesjson6902/.
+                                    type: string
+                                  preconditions:
+                                    description: 'AnyAllConditions are used to determine
+                                      if a policy rule should be applied by evaluating
+                                      a set of conditions. The declaration can contain
+                                      nested `any` or `all` statements. See: https://kyverno.io/docs/writing-policies/preconditions/'
+                                    properties:
+                                      all:
+                                        description: AllConditions enable variable-based
+                                          conditional rule execution. This is useful
+                                          for finer control of when an rule is applied.
+                                          A condition can reference object data using
+                                          JMESPath notation. Here, all of the conditions
+                                          need to pass
+                                        items:
+                                          description: Condition defines variable-based
+                                            conditional criteria for rule execution.
+                                          properties:
+                                            key:
+                                              description: Key is the context entry
+                                                (using JMESPath) for conditional rule
+                                                evaluation.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            operator:
+                                              description: 'Operator is the conditional
+                                                operation to perform. Valid operators
+                                                are: Equals, NotEquals, In, AnyIn,
+                                                AllIn, NotIn, AnyNotIn, AllNotIn,
+                                                GreaterThanOrEquals, GreaterThan,
+                                                LessThanOrEquals, LessThan, DurationGreaterThanOrEquals,
+                                                DurationGreaterThan, DurationLessThanOrEquals,
+                                                DurationLessThan'
+                                              enum:
+                                              - Equals
+                                              - NotEquals
+                                              - In
+                                              - AnyIn
+                                              - AllIn
+                                              - NotIn
+                                              - AnyNotIn
+                                              - AllNotIn
+                                              - GreaterThanOrEquals
+                                              - GreaterThan
+                                              - LessThanOrEquals
+                                              - LessThan
+                                              - DurationGreaterThanOrEquals
+                                              - DurationGreaterThan
+                                              - DurationLessThanOrEquals
+                                              - DurationLessThan
+                                              type: string
+                                            value:
+                                              description: Value is the conditional
+                                                value, or set of values. The values
+                                                can be fixed set or can be variables
+                                                declared using JMESPath.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                        type: array
+                                      any:
+                                        description: AnyConditions enable variable-based
+                                          conditional rule execution. This is useful
+                                          for finer control of when an rule is applied.
+                                          A condition can reference object data using
+                                          JMESPath notation. Here, at least one of
+                                          the conditions need to pass
+                                        items:
+                                          description: Condition defines variable-based
+                                            conditional criteria for rule execution.
+                                          properties:
+                                            key:
+                                              description: Key is the context entry
+                                                (using JMESPath) for conditional rule
+                                                evaluation.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            operator:
+                                              description: 'Operator is the conditional
+                                                operation to perform. Valid operators
+                                                are: Equals, NotEquals, In, AnyIn,
+                                                AllIn, NotIn, AnyNotIn, AllNotIn,
+                                                GreaterThanOrEquals, GreaterThan,
+                                                LessThanOrEquals, LessThan, DurationGreaterThanOrEquals,
+                                                DurationGreaterThan, DurationLessThanOrEquals,
+                                                DurationLessThan'
+                                              enum:
+                                              - Equals
+                                              - NotEquals
+                                              - In
+                                              - AnyIn
+                                              - AllIn
+                                              - NotIn
+                                              - AnyNotIn
+                                              - AllNotIn
+                                              - GreaterThanOrEquals
+                                              - GreaterThan
+                                              - LessThanOrEquals
+                                              - LessThan
+                                              - DurationGreaterThanOrEquals
+                                              - DurationGreaterThan
+                                              - DurationLessThanOrEquals
+                                              - DurationLessThan
+                                              type: string
+                                            value:
+                                              description: Value is the conditional
+                                                value, or set of values. The values
+                                                can be fixed set or can be variables
+                                                declared using JMESPath.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                        type: array
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              type: array
+                            patchStrategicMerge:
+                              description: PatchStrategicMerge is a strategic merge
+                                patch used to modify resources. See https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/
+                                and https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.
+                              x-kubernetes-preserve-unknown-fields: true
+                            patchesJson6902:
+                              description: PatchesJSON6902 is a list of RFC 6902 JSON
+                                Patch declarations used to modify resources. See https://tools.ietf.org/html/rfc6902
+                                and https://kubectl.docs.kubernetes.io/references/kustomize/patchesjson6902/.
+                              type: string
+                            targets:
+                              description: Targets defines the target resources to
+                                be mutated.
+                              items:
+                                properties:
+                                  apiVersion:
+                                    description: APIVersion specifies resource apiVersion.
+                                    type: string
+                                  kind:
+                                    description: Kind specifies resource kind.
+                                    type: string
+                                  name:
+                                    description: Name specifies the resource name.
+                                    type: string
+                                  namespace:
+                                    description: Namespace specifies resource namespace.
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        name:
+                          description: Name is a label to identify the rule, It must
+                            be unique within the policy.
+                          maxLength: 63
+                          type: string
+                        preconditions:
+                          description: 'Preconditions are used to determine if a policy
+                            rule should be applied by evaluating a set of conditions.
+                            The declaration can contain nested `any` or `all` statements.
+                            A direct list of conditions (without `any` or `all` statements
+                            is supported for backwards compatibility but will be deprecated
+                            in the next major release. See: https://kyverno.io/docs/writing-policies/preconditions/'
+                          x-kubernetes-preserve-unknown-fields: true
+                        validate:
+                          description: Validation is used to validate matching resources.
+                          properties:
+                            anyPattern:
+                              description: AnyPattern specifies list of validation
+                                patterns. At least one of the patterns must be satisfied
+                                for the validation rule to succeed.
+                              x-kubernetes-preserve-unknown-fields: true
+                            deny:
+                              description: Deny defines conditions used to pass or
+                                fail a validation rule.
+                              properties:
+                                conditions:
+                                  description: 'Multiple conditions can be declared
+                                    under an `any` or `all` statement. A direct list
+                                    of conditions (without `any` or `all` statements)
+                                    is also supported for backwards compatibility
+                                    but will be deprecated in the next major release.
+                                    See: https://kyverno.io/docs/writing-policies/validate/#deny-rules'
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            foreach:
+                              description: ForEach applies validate rules to a list
+                                of sub-elements by creating a context for each entry
+                                in the list and looping over it to apply the specified
+                                logic.
+                              items:
+                                description: ForEach applies validate rules to a list
+                                  of sub-elements by creating a context for each entry
+                                  in the list and looping over it to apply the specified
+                                  logic.
+                                properties:
+                                  anyPattern:
+                                    description: AnyPattern specifies list of validation
+                                      patterns. At least one of the patterns must
+                                      be satisfied for the validation rule to succeed.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  context:
+                                    description: Context defines variables and data
+                                      sources that can be used during rule execution.
+                                    items:
+                                      description: ContextEntry adds variables and
+                                        data sources to a rule Context. Either a ConfigMap
+                                        reference or a APILookup must be provided.
+                                      properties:
+                                        apiCall:
+                                          description: APICall defines an HTTP request
+                                            to the Kubernetes API server. The JSON
+                                            data retrieved is stored in the context.
+                                          properties:
+                                            jmesPath:
+                                              description: JMESPath is an optional
+                                                JSON Match Expression that can be
+                                                used to transform the JSON response
+                                                returned from the API server. For
+                                                example a JMESPath of "items | length(@)"
+                                                applied to the API server response
+                                                to the URLPath "/apis/apps/v1/deployments"
+                                                will return the total count of deployments
+                                                across all namespaces.
+                                              type: string
+                                            urlPath:
+                                              description: URLPath is the URL path
+                                                to be used in the HTTP GET request
+                                                to the Kubernetes API server (e.g.
+                                                "/api/v1/namespaces" or  "/apis/apps/v1/deployments").
+                                                The format required is the same format
+                                                used by the `kubectl get --raw` command.
+                                              type: string
+                                          required:
+                                          - urlPath
+                                          type: object
+                                        configMap:
+                                          description: ConfigMap is the ConfigMap
+                                            reference.
+                                          properties:
+                                            name:
+                                              description: Name is the ConfigMap name.
+                                              type: string
+                                            namespace:
+                                              description: Namespace is the ConfigMap
+                                                namespace.
+                                              type: string
+                                          required:
+                                          - name
+                                          type: object
+                                        imageRegistry:
+                                          description: ImageRegistry defines requests
+                                            to an OCI/Docker V2 registry to fetch
+                                            image details.
+                                          properties:
+                                            jmesPath:
+                                              description: JMESPath is an optional
+                                                JSON Match Expression that can be
+                                                used to transform the ImageData struct
+                                                returned as a result of processing
+                                                the image reference.
+                                              type: string
+                                            reference:
+                                              description: 'Reference is image reference
+                                                to a container image in the registry.
+                                                Example: ghcr.io/kyverno/kyverno:latest'
+                                              type: string
+                                          required:
+                                          - reference
+                                          type: object
+                                        name:
+                                          description: Name is the variable name.
+                                          type: string
+                                        variable:
+                                          description: Variable defines an arbitrary
+                                            JMESPath context variable that can be
+                                            defined inline.
+                                          properties:
+                                            default:
+                                              description: Default is an optional
+                                                arbitrary JSON object that the variable
+                                                may take if the JMESPath expression
+                                                evaluates to nil
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            jmesPath:
+                                              description: JMESPath is an optional
+                                                JMESPath Expression that can be used
+                                                to transform the variable.
+                                              type: string
+                                            value:
+                                              description: Value is any arbitrary
+                                                JSON object representable in YAML
+                                                or JSON form.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                      type: object
+                                    type: array
+                                  deny:
+                                    description: Deny defines conditions used to pass
+                                      or fail a validation rule.
+                                    properties:
+                                      conditions:
+                                        description: 'Multiple conditions can be declared
+                                          under an `any` or `all` statement. A direct
+                                          list of conditions (without `any` or `all`
+                                          statements) is also supported for backwards
+                                          compatibility but will be deprecated in
+                                          the next major release. See: https://kyverno.io/docs/writing-policies/validate/#deny-rules'
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                  elementScope:
+                                    description: ElementScope specifies whether to
+                                      use the current list element as the scope for
+                                      validation. Defaults to "true" if not specified.
+                                      When set to "false", "request.object" is used
+                                      as the validation scope within the foreach block
+                                      to allow referencing other elements in the subtree.
+                                    type: boolean
+                                  list:
+                                    description: List specifies a JMESPath expression
+                                      that results in one or more elements to which
+                                      the validation logic is applied.
+                                    type: string
+                                  pattern:
+                                    description: Pattern specifies an overlay-style
+                                      pattern used to check resources.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  preconditions:
+                                    description: 'AnyAllConditions are used to determine
+                                      if a policy rule should be applied by evaluating
+                                      a set of conditions. The declaration can contain
+                                      nested `any` or `all` statements. See: https://kyverno.io/docs/writing-policies/preconditions/'
+                                    properties:
+                                      all:
+                                        description: AllConditions enable variable-based
+                                          conditional rule execution. This is useful
+                                          for finer control of when an rule is applied.
+                                          A condition can reference object data using
+                                          JMESPath notation. Here, all of the conditions
+                                          need to pass
+                                        items:
+                                          description: Condition defines variable-based
+                                            conditional criteria for rule execution.
+                                          properties:
+                                            key:
+                                              description: Key is the context entry
+                                                (using JMESPath) for conditional rule
+                                                evaluation.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            operator:
+                                              description: 'Operator is the conditional
+                                                operation to perform. Valid operators
+                                                are: Equals, NotEquals, In, AnyIn,
+                                                AllIn, NotIn, AnyNotIn, AllNotIn,
+                                                GreaterThanOrEquals, GreaterThan,
+                                                LessThanOrEquals, LessThan, DurationGreaterThanOrEquals,
+                                                DurationGreaterThan, DurationLessThanOrEquals,
+                                                DurationLessThan'
+                                              enum:
+                                              - Equals
+                                              - NotEquals
+                                              - In
+                                              - AnyIn
+                                              - AllIn
+                                              - NotIn
+                                              - AnyNotIn
+                                              - AllNotIn
+                                              - GreaterThanOrEquals
+                                              - GreaterThan
+                                              - LessThanOrEquals
+                                              - LessThan
+                                              - DurationGreaterThanOrEquals
+                                              - DurationGreaterThan
+                                              - DurationLessThanOrEquals
+                                              - DurationLessThan
+                                              type: string
+                                            value:
+                                              description: Value is the conditional
+                                                value, or set of values. The values
+                                                can be fixed set or can be variables
+                                                declared using JMESPath.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                        type: array
+                                      any:
+                                        description: AnyConditions enable variable-based
+                                          conditional rule execution. This is useful
+                                          for finer control of when an rule is applied.
+                                          A condition can reference object data using
+                                          JMESPath notation. Here, at least one of
+                                          the conditions need to pass
+                                        items:
+                                          description: Condition defines variable-based
+                                            conditional criteria for rule execution.
+                                          properties:
+                                            key:
+                                              description: Key is the context entry
+                                                (using JMESPath) for conditional rule
+                                                evaluation.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            operator:
+                                              description: 'Operator is the conditional
+                                                operation to perform. Valid operators
+                                                are: Equals, NotEquals, In, AnyIn,
+                                                AllIn, NotIn, AnyNotIn, AllNotIn,
+                                                GreaterThanOrEquals, GreaterThan,
+                                                LessThanOrEquals, LessThan, DurationGreaterThanOrEquals,
+                                                DurationGreaterThan, DurationLessThanOrEquals,
+                                                DurationLessThan'
+                                              enum:
+                                              - Equals
+                                              - NotEquals
+                                              - In
+                                              - AnyIn
+                                              - AllIn
+                                              - NotIn
+                                              - AnyNotIn
+                                              - AllNotIn
+                                              - GreaterThanOrEquals
+                                              - GreaterThan
+                                              - LessThanOrEquals
+                                              - LessThan
+                                              - DurationGreaterThanOrEquals
+                                              - DurationGreaterThan
+                                              - DurationLessThanOrEquals
+                                              - DurationLessThan
+                                              type: string
+                                            value:
+                                              description: Value is the conditional
+                                                value, or set of values. The values
+                                                can be fixed set or can be variables
+                                                declared using JMESPath.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                        type: array
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              type: array
+                            manifests:
+                              description: Manifest specifies conditions for manifest
+                                verification
+                              properties:
+                                annotationDomain:
+                                  description: AnnotationDomain is custom domain of
+                                    annotation for message and signature. Default
+                                    is "cosign.sigstore.dev".
+                                  type: string
+                                attestors:
+                                  description: Attestors specified the required attestors
+                                    (i.e. authorities)
+                                  items:
+                                    properties:
+                                      count:
+                                        description: Count specifies the required
+                                          number of entries that must match. If the
+                                          count is null, all entries must match (a
+                                          logical AND). If the count is 1, at least
+                                          one entry must match (a logical OR). If
+                                          the count contains a value N, then N must
+                                          be less than or equal to the size of entries,
+                                          and at least N entries must match.
+                                        minimum: 1
+                                        type: integer
+                                      entries:
+                                        description: Entries contains the available
+                                          attestors. An attestor can be a static key,
+                                          attributes for keyless verification, or
+                                          a nested attestor declaration.
+                                        items:
+                                          properties:
+                                            annotations:
+                                              additionalProperties:
+                                                type: string
+                                              description: Annotations are used for
+                                                image verification. Every specified
+                                                key-value pair must exist and match
+                                                in the verified payload. The payload
+                                                may contain other key-value pairs.
+                                              type: object
+                                            attestor:
+                                              description: Attestor is a nested AttestorSet
+                                                used to specify a more complex set
+                                                of match authorities
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            certificates:
+                                              description: Certificates specifies
+                                                one or more certificates
+                                              properties:
+                                                cert:
+                                                  description: Certificate is an optional
+                                                    PEM encoded public certificate.
+                                                  type: string
+                                                certChain:
+                                                  description: CertificateChain is
+                                                    an optional PEM encoded set of
+                                                    certificates used to verify
+                                                  type: string
+                                                rekor:
+                                                  description: Rekor provides configuration
+                                                    for the Rekor transparency log
+                                                    service. If the value is nil,
+                                                    Rekor is not checked. If an empty
+                                                    object is provided the public
+                                                    instance of Rekor (https://rekor.sigstore.dev)
+                                                    is used.
+                                                  properties:
+                                                    url:
+                                                      description: URL is the address
+                                                        of the transparency log. Defaults
+                                                        to the public log https://rekor.sigstore.dev.
+                                                      type: string
+                                                  required:
+                                                  - url
+                                                  type: object
+                                              type: object
+                                            keyless:
+                                              description: Keyless is a set of attribute
+                                                used to verify a Sigstore keyless
+                                                attestor. See https://github.com/sigstore/cosign/blob/main/KEYLESS.md.
+                                              properties:
+                                                additionalExtensions:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: AdditionalExtensions
+                                                    are certificate-extensions used
+                                                    for keyless signing.
+                                                  type: object
+                                                issuer:
+                                                  description: Issuer is the certificate
+                                                    issuer used for keyless signing.
+                                                  type: string
+                                                rekor:
+                                                  description: Rekor provides configuration
+                                                    for the Rekor transparency log
+                                                    service. If the value is nil,
+                                                    Rekor is not checked and a root
+                                                    certificate chain is expected
+                                                    instead. If an empty object is
+                                                    provided the public instance of
+                                                    Rekor (https://rekor.sigstore.dev)
+                                                    is used.
+                                                  properties:
+                                                    url:
+                                                      description: URL is the address
+                                                        of the transparency log. Defaults
+                                                        to the public log https://rekor.sigstore.dev.
+                                                      type: string
+                                                  required:
+                                                  - url
+                                                  type: object
+                                                roots:
+                                                  description: Roots is an optional
+                                                    set of PEM encoded trusted root
+                                                    certificates. If not provided,
+                                                    the system roots are used.
+                                                  type: string
+                                                subject:
+                                                  description: Subject is the verified
+                                                    identity used for keyless signing,
+                                                    for example the email address
+                                                  type: string
+                                              type: object
+                                            keys:
+                                              description: Keys specifies one or more
+                                                public keys
+                                              properties:
+                                                publicKeys:
+                                                  description: Keys is a set of X.509
+                                                    public keys used to verify image
+                                                    signatures. The keys can be directly
+                                                    specified or can be a variable
+                                                    reference to a key specified in
+                                                    a ConfigMap (see https://kyverno.io/docs/writing-policies/variables/).
+                                                    When multiple keys are specified
+                                                    each key is processed as a separate
+                                                    staticKey entry (.attestors[*].entries.keys)
+                                                    within the set of attestors and
+                                                    the count is applied across the
+                                                    keys.
+                                                  type: string
+                                                rekor:
+                                                  description: Rekor provides configuration
+                                                    for the Rekor transparency log
+                                                    service. If the value is nil,
+                                                    Rekor is not checked. If an empty
+                                                    object is provided the public
+                                                    instance of Rekor (https://rekor.sigstore.dev)
+                                                    is used.
+                                                  properties:
+                                                    url:
+                                                      description: URL is the address
+                                                        of the transparency log. Defaults
+                                                        to the public log https://rekor.sigstore.dev.
+                                                      type: string
+                                                  required:
+                                                  - url
+                                                  type: object
+                                              type: object
+                                            repository:
+                                              description: Repository is an optional
+                                                alternate OCI repository to use for
+                                                signatures and attestations that match
+                                                this rule. If specified Repository
+                                                will override other OCI image repository
+                                                locations for this Attestor.
+                                              type: string
+                                          type: object
+                                        type: array
+                                    type: object
+                                  type: array
+                                dryRun:
+                                  description: DryRun configuration
+                                  properties:
+                                    enable:
+                                      type: boolean
+                                    namespace:
+                                      type: string
+                                  type: object
+                                ignoreFields:
+                                  description: Fields which will be ignored while
+                                    comparing manifests.
+                                  items:
+                                    properties:
+                                      fields:
+                                        items:
+                                          type: string
+                                        type: array
+                                      objects:
+                                        items:
+                                          properties:
+                                            group:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            name:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            version:
+                                              type: string
+                                          type: object
+                                        type: array
+                                    type: object
+                                  type: array
+                                repository:
+                                  description: Repository is an optional alternate
+                                    OCI repository to use for resource bundle reference.
+                                    The repository can be overridden per Attestor
+                                    or Attestation.
+                                  type: string
+                              type: object
+                            message:
+                              description: Message specifies a custom message to be
+                                displayed on failure.
+                              type: string
+                            pattern:
+                              description: Pattern specifies an overlay-style pattern
+                                used to check resources.
+                              x-kubernetes-preserve-unknown-fields: true
+                            podSecurity:
+                              description: PodSecurity applies exemptions for Kubernetes
+                                Pod Security admission by specifying exclusions for
+                                Pod Security Standards controls.
+                              properties:
+                                exclude:
+                                  description: Exclude specifies the Pod Security
+                                    Standard controls to be excluded.
+                                  items:
+                                    description: PodSecurityStandard specifies the
+                                      Pod Security Standard controls to be excluded.
+                                    properties:
+                                      controlName:
+                                        description: 'ControlName specifies the name
+                                          of the Pod Security Standard control. See:
+                                          https://kubernetes.io/docs/concepts/security/pod-security-standards/'
+                                        enum:
+                                        - HostProcess
+                                        - Host Namespaces
+                                        - Privileged Containers
+                                        - Capabilities
+                                        - HostPath Volumes
+                                        - Host Ports
+                                        - AppArmor
+                                        - SELinux
+                                        - /proc Mount Type
+                                        - Seccomp
+                                        - Sysctls
+                                        - Volume Types
+                                        - Privilege Escalation
+                                        - Running as Non-root
+                                        - Running as Non-root user
+                                        type: string
+                                      images:
+                                        description: 'Images selects matching containers
+                                          and applies the container level PSS. Each
+                                          image is the image name consisting of the
+                                          registry address, repository, image, and
+                                          tag. Empty list matches no containers, PSS
+                                          checks are applied at the pod level only.
+                                          Wildcards (''*'' and ''?'') are allowed.
+                                          See: https://kubernetes.io/docs/concepts/containers/images.'
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - controlName
+                                    type: object
+                                  type: array
+                                level:
+                                  description: Level defines the Pod Security Standard
+                                    level to be applied to workloads. Allowed values
+                                    are privileged, baseline, and restricted.
+                                  enum:
+                                  - privileged
+                                  - baseline
+                                  - restricted
+                                  type: string
+                                version:
+                                  description: Version defines the Pod Security Standard
+                                    versions that Kubernetes supports. Allowed values
+                                    are v1.19, v1.20, v1.21, v1.22, v1.23, v1.24,
+                                    v1.25, latest. Defaults to latest.
+                                  enum:
+                                  - v1.19
+                                  - v1.20
+                                  - v1.21
+                                  - v1.22
+                                  - v1.23
+                                  - v1.24
+                                  - v1.25
+                                  - latest
+                                  type: string
+                              type: object
+                          type: object
+                        verifyImages:
+                          description: VerifyImages is used to verify image signatures
+                            and mutate them to add a digest
+                          items:
+                            description: ImageVerification validates that images that
+                              match the specified pattern are signed with the supplied
+                              public key. Once the image is verified it is mutated
+                              to include the SHA digest retrieved during the registration.
+                            properties:
+                              additionalExtensions:
+                                additionalProperties:
+                                  type: string
+                                description: AdditionalExtensions are certificate-extensions
+                                  used for keyless signing. Deprecated.
+                                type: object
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                description: Annotations are used for image verification.
+                                  Every specified key-value pair must exist and match
+                                  in the verified payload. The payload may contain
+                                  other key-value pairs. Deprecated. Use annotations
+                                  per Attestor instead.
+                                type: object
+                              attestations:
+                                description: Attestations are optional checks for
+                                  signed in-toto Statements used to verify the image.
+                                  See https://github.com/in-toto/attestation. Kyverno
+                                  fetches signed attestations from the OCI registry
+                                  and decodes them into a list of Statement declarations.
+                                items:
+                                  description: Attestation are checks for signed in-toto
+                                    Statements that are used to verify the image.
+                                    See https://github.com/in-toto/attestation. Kyverno
+                                    fetches signed attestations from the OCI registry
+                                    and decodes them into a list of Statements.
+                                  properties:
+                                    conditions:
+                                      description: Conditions are used to verify attributes
+                                        within a Predicate. If no Conditions are specified
+                                        the attestation check is satisfied as long
+                                        there are predicates that match the predicate
+                                        type.
+                                      items:
+                                        description: AnyAllConditions consists of
+                                          conditions wrapped denoting a logical criteria
+                                          to be fulfilled. AnyConditions get fulfilled
+                                          when at least one of its sub-conditions
+                                          passes. AllConditions get fulfilled only
+                                          when all of its sub-conditions pass.
+                                        properties:
+                                          all:
+                                            description: AllConditions enable variable-based
+                                              conditional rule execution. This is
+                                              useful for finer control of when an
+                                              rule is applied. A condition can reference
+                                              object data using JMESPath notation.
+                                              Here, all of the conditions need to
+                                              pass
+                                            items:
+                                              description: Condition defines variable-based
+                                                conditional criteria for rule execution.
+                                              properties:
+                                                key:
+                                                  description: Key is the context
+                                                    entry (using JMESPath) for conditional
+                                                    rule evaluation.
+                                                  x-kubernetes-preserve-unknown-fields: true
+                                                operator:
+                                                  description: 'Operator is the conditional
+                                                    operation to perform. Valid operators
+                                                    are: Equals, NotEquals, In, AnyIn,
+                                                    AllIn, NotIn, AnyNotIn, AllNotIn,
+                                                    GreaterThanOrEquals, GreaterThan,
+                                                    LessThanOrEquals, LessThan, DurationGreaterThanOrEquals,
+                                                    DurationGreaterThan, DurationLessThanOrEquals,
+                                                    DurationLessThan'
+                                                  enum:
+                                                  - Equals
+                                                  - NotEquals
+                                                  - In
+                                                  - AnyIn
+                                                  - AllIn
+                                                  - NotIn
+                                                  - AnyNotIn
+                                                  - AllNotIn
+                                                  - GreaterThanOrEquals
+                                                  - GreaterThan
+                                                  - LessThanOrEquals
+                                                  - LessThan
+                                                  - DurationGreaterThanOrEquals
+                                                  - DurationGreaterThan
+                                                  - DurationLessThanOrEquals
+                                                  - DurationLessThan
+                                                  type: string
+                                                value:
+                                                  description: Value is the conditional
+                                                    value, or set of values. The values
+                                                    can be fixed set or can be variables
+                                                    declared using JMESPath.
+                                                  x-kubernetes-preserve-unknown-fields: true
+                                              type: object
+                                            type: array
+                                          any:
+                                            description: AnyConditions enable variable-based
+                                              conditional rule execution. This is
+                                              useful for finer control of when an
+                                              rule is applied. A condition can reference
+                                              object data using JMESPath notation.
+                                              Here, at least one of the conditions
+                                              need to pass
+                                            items:
+                                              description: Condition defines variable-based
+                                                conditional criteria for rule execution.
+                                              properties:
+                                                key:
+                                                  description: Key is the context
+                                                    entry (using JMESPath) for conditional
+                                                    rule evaluation.
+                                                  x-kubernetes-preserve-unknown-fields: true
+                                                operator:
+                                                  description: 'Operator is the conditional
+                                                    operation to perform. Valid operators
+                                                    are: Equals, NotEquals, In, AnyIn,
+                                                    AllIn, NotIn, AnyNotIn, AllNotIn,
+                                                    GreaterThanOrEquals, GreaterThan,
+                                                    LessThanOrEquals, LessThan, DurationGreaterThanOrEquals,
+                                                    DurationGreaterThan, DurationLessThanOrEquals,
+                                                    DurationLessThan'
+                                                  enum:
+                                                  - Equals
+                                                  - NotEquals
+                                                  - In
+                                                  - AnyIn
+                                                  - AllIn
+                                                  - NotIn
+                                                  - AnyNotIn
+                                                  - AllNotIn
+                                                  - GreaterThanOrEquals
+                                                  - GreaterThan
+                                                  - LessThanOrEquals
+                                                  - LessThan
+                                                  - DurationGreaterThanOrEquals
+                                                  - DurationGreaterThan
+                                                  - DurationLessThanOrEquals
+                                                  - DurationLessThan
+                                                  type: string
+                                                value:
+                                                  description: Value is the conditional
+                                                    value, or set of values. The values
+                                                    can be fixed set or can be variables
+                                                    declared using JMESPath.
+                                                  x-kubernetes-preserve-unknown-fields: true
+                                              type: object
+                                            type: array
+                                        type: object
+                                      type: array
+                                    predicateType:
+                                      description: PredicateType defines the type
+                                        of Predicate contained within the Statement.
+                                      type: string
+                                  type: object
+                                type: array
+                              attestors:
+                                description: Attestors specified the required attestors
+                                  (i.e. authorities)
+                                items:
+                                  properties:
+                                    count:
+                                      description: Count specifies the required number
+                                        of entries that must match. If the count is
+                                        null, all entries must match (a logical AND).
+                                        If the count is 1, at least one entry must
+                                        match (a logical OR). If the count contains
+                                        a value N, then N must be less than or equal
+                                        to the size of entries, and at least N entries
+                                        must match.
+                                      minimum: 1
+                                      type: integer
+                                    entries:
+                                      description: Entries contains the available
+                                        attestors. An attestor can be a static key,
+                                        attributes for keyless verification, or a
+                                        nested attestor declaration.
+                                      items:
+                                        properties:
+                                          annotations:
+                                            additionalProperties:
+                                              type: string
+                                            description: Annotations are used for
+                                              image verification. Every specified
+                                              key-value pair must exist and match
+                                              in the verified payload. The payload
+                                              may contain other key-value pairs.
+                                            type: object
+                                          attestor:
+                                            description: Attestor is a nested AttestorSet
+                                              used to specify a more complex set of
+                                              match authorities
+                                            x-kubernetes-preserve-unknown-fields: true
+                                          certificates:
+                                            description: Certificates specifies one
+                                              or more certificates
+                                            properties:
+                                              cert:
+                                                description: Certificate is an optional
+                                                  PEM encoded public certificate.
+                                                type: string
+                                              certChain:
+                                                description: CertificateChain is an
+                                                  optional PEM encoded set of certificates
+                                                  used to verify
+                                                type: string
+                                              rekor:
+                                                description: Rekor provides configuration
+                                                  for the Rekor transparency log service.
+                                                  If the value is nil, Rekor is not
+                                                  checked. If an empty object is provided
+                                                  the public instance of Rekor (https://rekor.sigstore.dev)
+                                                  is used.
+                                                properties:
+                                                  url:
+                                                    description: URL is the address
+                                                      of the transparency log. Defaults
+                                                      to the public log https://rekor.sigstore.dev.
+                                                    type: string
+                                                required:
+                                                - url
+                                                type: object
+                                            type: object
+                                          keyless:
+                                            description: Keyless is a set of attribute
+                                              used to verify a Sigstore keyless attestor.
+                                              See https://github.com/sigstore/cosign/blob/main/KEYLESS.md.
+                                            properties:
+                                              additionalExtensions:
+                                                additionalProperties:
+                                                  type: string
+                                                description: AdditionalExtensions
+                                                  are certificate-extensions used
+                                                  for keyless signing.
+                                                type: object
+                                              issuer:
+                                                description: Issuer is the certificate
+                                                  issuer used for keyless signing.
+                                                type: string
+                                              rekor:
+                                                description: Rekor provides configuration
+                                                  for the Rekor transparency log service.
+                                                  If the value is nil, Rekor is not
+                                                  checked and a root certificate chain
+                                                  is expected instead. If an empty
+                                                  object is provided the public instance
+                                                  of Rekor (https://rekor.sigstore.dev)
+                                                  is used.
+                                                properties:
+                                                  url:
+                                                    description: URL is the address
+                                                      of the transparency log. Defaults
+                                                      to the public log https://rekor.sigstore.dev.
+                                                    type: string
+                                                required:
+                                                - url
+                                                type: object
+                                              roots:
+                                                description: Roots is an optional
+                                                  set of PEM encoded trusted root
+                                                  certificates. If not provided, the
+                                                  system roots are used.
+                                                type: string
+                                              subject:
+                                                description: Subject is the verified
+                                                  identity used for keyless signing,
+                                                  for example the email address
+                                                type: string
+                                            type: object
+                                          keys:
+                                            description: Keys specifies one or more
+                                              public keys
+                                            properties:
+                                              publicKeys:
+                                                description: Keys is a set of X.509
+                                                  public keys used to verify image
+                                                  signatures. The keys can be directly
+                                                  specified or can be a variable reference
+                                                  to a key specified in a ConfigMap
+                                                  (see https://kyverno.io/docs/writing-policies/variables/).
+                                                  When multiple keys are specified
+                                                  each key is processed as a separate
+                                                  staticKey entry (.attestors[*].entries.keys)
+                                                  within the set of attestors and
+                                                  the count is applied across the
+                                                  keys.
+                                                type: string
+                                              rekor:
+                                                description: Rekor provides configuration
+                                                  for the Rekor transparency log service.
+                                                  If the value is nil, Rekor is not
+                                                  checked. If an empty object is provided
+                                                  the public instance of Rekor (https://rekor.sigstore.dev)
+                                                  is used.
+                                                properties:
+                                                  url:
+                                                    description: URL is the address
+                                                      of the transparency log. Defaults
+                                                      to the public log https://rekor.sigstore.dev.
+                                                    type: string
+                                                required:
+                                                - url
+                                                type: object
+                                            type: object
+                                          repository:
+                                            description: Repository is an optional
+                                              alternate OCI repository to use for
+                                              signatures and attestations that match
+                                              this rule. If specified Repository will
+                                              override other OCI image repository
+                                              locations for this Attestor.
+                                            type: string
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                              image:
+                                description: 'Image is the image name consisting of
+                                  the registry address, repository, image, and tag.
+                                  Wildcards (''*'' and ''?'') are allowed. See: https://kubernetes.io/docs/concepts/containers/images.
+                                  Deprecated. Use ImageReferences instead.'
+                                type: string
+                              imageReferences:
+                                description: 'ImageReferences is a list of matching
+                                  image reference patterns. At least one pattern in
+                                  the list must match the image for the rule to apply.
+                                  Each image reference consists of a registry address
+                                  (defaults to docker.io), repository, image, and
+                                  tag (defaults to latest). Wildcards (''*'' and ''?'')
+                                  are allowed. See: https://kubernetes.io/docs/concepts/containers/images.'
+                                items:
+                                  type: string
+                                type: array
+                              issuer:
+                                description: Issuer is the certificate issuer used
+                                  for keyless signing. Deprecated. Use KeylessAttestor
+                                  instead.
+                                type: string
+                              key:
+                                description: Key is the PEM encoded public key that
+                                  the image or attestation is signed with. Deprecated.
+                                  Use StaticKeyAttestor instead.
+                                type: string
+                              mutateDigest:
+                                default: true
+                                description: MutateDigest enables replacement of image
+                                  tags with digests. Defaults to true.
+                                type: boolean
+                              repository:
+                                description: Repository is an optional alternate OCI
+                                  repository to use for image signatures and attestations
+                                  that match this rule. If specified Repository will
+                                  override the default OCI image repository configured
+                                  for the installation. The repository can also be
+                                  overridden per Attestor or Attestation.
+                                type: string
+                              required:
+                                default: true
+                                description: Required validates that images are verified
+                                  i.e. have matched passed a signature or attestation
+                                  check.
+                                type: boolean
+                              roots:
+                                description: Roots is the PEM encoded Root certificate
+                                  chain used for keyless signing Deprecated. Use KeylessAttestor
+                                  instead.
+                                type: string
+                              subject:
+                                description: Subject is the identity used for keyless
+                                  signing, for example an email address Deprecated.
+                                  Use KeylessAttestor instead.
+                                type: string
+                              verifyDigest:
+                                default: true
+                                description: VerifyDigest validates that images have
+                                  a digest.
+                                type: boolean
+                            type: object
+                          type: array
+                      type: object
+                    type: array
+                type: object
+              conditions:
+                description: Conditions is a list of conditions that apply to the
+                  policy
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              ready:
+                description: Ready indicates if the policy is ready to serve the admission
+                  request. Deprecated in favor of Conditions
+                type: boolean
+            required:
+            - ready
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.background
+      name: Background
+      type: boolean
+    - jsonPath: .spec.validationFailureAction
+      name: Validate Action
+      type: string
+    - jsonPath: .spec.failurePolicy
+      name: Failure Policy
+      priority: 1
+      type: string
+    - jsonPath: .status.ready
+      name: Ready
+      type: boolean
+    name: v2beta1
+    schema:
+      openAPIV3Schema:
+        description: ClusterPolicy declares validation, mutation, and generation behaviors
+          for matching resources.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec declares policy behaviors.
+            properties:
+              applyRules:
+                description: ApplyRules controls how rules in a policy are applied.
+                  Rule are processed in the order of declaration. When set to `One`
+                  processing stops after a rule has been applied i.e. the rule matches
+                  and results in a pass, fail, or error. When set to `All` all rules
+                  in the policy are processed. The default is `All`.
+                enum:
+                - All
+                - One
+                type: string
+              background:
+                default: true
+                description: Background controls if rules are applied to existing
+                  resources during a background scan. Optional. Default value is "true".
+                  The value must be set to "false" if the policy rule uses variables
+                  that are only available in the admission review request (e.g. user
+                  name).
+                type: boolean
+              failurePolicy:
+                description: FailurePolicy defines how unexpected policy errors and
+                  webhook response timeout errors are handled. Rules within the same
+                  policy share the same failure behavior. Allowed values are Ignore
+                  or Fail. Defaults to Fail.
+                enum:
+                - Ignore
+                - Fail
+                type: string
+              generateExistingOnPolicyUpdate:
+                description: GenerateExistingOnPolicyUpdate controls whether to trigger
+                  generate rule in existing resources If is set to "true" generate
+                  rule will be triggered and applied to existing matched resources.
+                  Defaults to "false" if not specified.
+                type: boolean
+              mutateExistingOnPolicyUpdate:
+                description: MutateExistingOnPolicyUpdate controls if a mutateExisting
+                  policy is applied on policy events. Default value is "false".
+                type: boolean
+              rules:
+                description: Rules is a list of Rule instances. A Policy contains
+                  multiple rules and each rule can validate, mutate, or generate resources.
+                items:
+                  description: Rule defines a validation, mutation, or generation
+                    control for matching resources. Each rules contains a match declaration
+                    to select resources, and an optional exclude declaration to specify
+                    which resources to exclude.
+                  properties:
+                    context:
+                      description: Context defines variables and data sources that
+                        can be used during rule execution.
+                      items:
+                        description: ContextEntry adds variables and data sources
+                          to a rule Context. Either a ConfigMap reference or a APILookup
+                          must be provided.
+                        properties:
+                          apiCall:
+                            description: APICall defines an HTTP request to the Kubernetes
+                              API server. The JSON data retrieved is stored in the
+                              context.
+                            properties:
+                              jmesPath:
+                                description: JMESPath is an optional JSON Match Expression
+                                  that can be used to transform the JSON response
+                                  returned from the API server. For example a JMESPath
+                                  of "items | length(@)" applied to the API server
+                                  response to the URLPath "/apis/apps/v1/deployments"
+                                  will return the total count of deployments across
+                                  all namespaces.
+                                type: string
+                              urlPath:
+                                description: URLPath is the URL path to be used in
+                                  the HTTP GET request to the Kubernetes API server
+                                  (e.g. "/api/v1/namespaces" or  "/apis/apps/v1/deployments").
+                                  The format required is the same format used by the
+                                  `kubectl get --raw` command.
+                                type: string
+                            required:
+                            - urlPath
+                            type: object
+                          configMap:
+                            description: ConfigMap is the ConfigMap reference.
+                            properties:
+                              name:
+                                description: Name is the ConfigMap name.
+                                type: string
+                              namespace:
+                                description: Namespace is the ConfigMap namespace.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          imageRegistry:
+                            description: ImageRegistry defines requests to an OCI/Docker
+                              V2 registry to fetch image details.
+                            properties:
+                              jmesPath:
+                                description: JMESPath is an optional JSON Match Expression
+                                  that can be used to transform the ImageData struct
+                                  returned as a result of processing the image reference.
+                                type: string
+                              reference:
+                                description: 'Reference is image reference to a container
+                                  image in the registry. Example: ghcr.io/kyverno/kyverno:latest'
+                                type: string
+                            required:
+                            - reference
+                            type: object
+                          name:
+                            description: Name is the variable name.
+                            type: string
+                          variable:
+                            description: Variable defines an arbitrary JMESPath context
+                              variable that can be defined inline.
+                            properties:
+                              default:
+                                description: Default is an optional arbitrary JSON
+                                  object that the variable may take if the JMESPath
+                                  expression evaluates to nil
+                                x-kubernetes-preserve-unknown-fields: true
+                              jmesPath:
+                                description: JMESPath is an optional JMESPath Expression
+                                  that can be used to transform the variable.
+                                type: string
+                              value:
+                                description: Value is any arbitrary JSON object representable
+                                  in YAML or JSON form.
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                        type: object
+                      type: array
+                    exclude:
+                      description: ExcludeResources defines when this policy rule
+                        should not be applied. The exclude criteria can include resource
+                        information (e.g. kind, name, namespace, labels) and admission
+                        review request information like the name or role.
+                      properties:
+                        all:
+                          description: All allows specifying resources which will
+                            be ANDed
+                          items:
+                            description: ResourceFilter allow users to "AND" or "OR"
+                              between resources
+                            properties:
+                              clusterRoles:
+                                description: ClusterRoles is the list of cluster-wide
+                                  role names for the user.
+                                items:
+                                  type: string
+                                type: array
+                              resources:
+                                description: ResourceDescription contains information
+                                  about the resource being created or modified.
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations is a  map of annotations
+                                      (key-value pairs of type string). Annotation
+                                      keys and values support the wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (matches at least one character).
+                                    type: object
+                                  kinds:
+                                    description: Kinds is a list of resource kinds.
+                                    items:
+                                      type: string
+                                    type: array
+                                  name:
+                                    description: 'Name is the name of the resource.
+                                      The name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character). NOTE: "Name" is being deprecated
+                                      in favor of "Names".'
+                                    type: string
+                                  names:
+                                    description: Names are the names of the resources.
+                                      Each name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character).
+                                    items:
+                                      type: string
+                                    type: array
+                                  namespaceSelector:
+                                    description: 'NamespaceSelector is a label selector
+                                      for the resource namespace. Label keys and values
+                                      in `matchLabels` support the wildcard characters
+                                      `*` (matches zero or many characters) and `?`
+                                      (matches one character).Wildcards allows writing
+                                      label selectors like ["storage.k8s.io/*": "*"].
+                                      Note that using ["*" : "*"] matches any key
+                                      and value but does not match an empty label
+                                      set.'
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaces:
+                                    description: Namespaces is a list of namespaces
+                                      names. Each name supports wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (at least one character).
+                                    items:
+                                      type: string
+                                    type: array
+                                  selector:
+                                    description: 'Selector is a label selector. Label
+                                      keys and values in `matchLabels` support the
+                                      wildcard characters `*` (matches zero or many
+                                      characters) and `?` (matches one character).
+                                      Wildcards allows writing label selectors like
+                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                      : "*"] matches any key and value but does not
+                                      match an empty label set.'
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              roles:
+                                description: Roles is the list of namespaced role
+                                  names for the user.
+                                items:
+                                  type: string
+                                type: array
+                              subjects:
+                                description: Subjects is the list of subject names
+                                  like users, user groups, and service accounts.
+                                items:
+                                  description: Subject contains a reference to the
+                                    object or user identities a role binding applies
+                                    to.  This can either hold a direct API object
+                                    reference, or a value for non-objects such as
+                                    user and group names.
+                                  properties:
+                                    apiGroup:
+                                      description: APIGroup holds the API group of
+                                        the referenced subject. Defaults to "" for
+                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
+                                        for User and Group subjects.
+                                      type: string
+                                    kind:
+                                      description: Kind of object being referenced.
+                                        Values defined by this API group are "User",
+                                        "Group", and "ServiceAccount". If the Authorizer
+                                        does not recognized the kind value, the Authorizer
+                                        should report an error.
+                                      type: string
+                                    name:
+                                      description: Name of the object being referenced.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the referenced object.  If
+                                        the object kind is non-namespace, such as
+                                        "User" or "Group", and this value is not empty
+                                        the Authorizer should report an error.
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                type: array
+                            type: object
+                          type: array
+                        any:
+                          description: Any allows specifying resources which will
+                            be ORed
+                          items:
+                            description: ResourceFilter allow users to "AND" or "OR"
+                              between resources
+                            properties:
+                              clusterRoles:
+                                description: ClusterRoles is the list of cluster-wide
+                                  role names for the user.
+                                items:
+                                  type: string
+                                type: array
+                              resources:
+                                description: ResourceDescription contains information
+                                  about the resource being created or modified.
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations is a  map of annotations
+                                      (key-value pairs of type string). Annotation
+                                      keys and values support the wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (matches at least one character).
+                                    type: object
+                                  kinds:
+                                    description: Kinds is a list of resource kinds.
+                                    items:
+                                      type: string
+                                    type: array
+                                  name:
+                                    description: 'Name is the name of the resource.
+                                      The name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character). NOTE: "Name" is being deprecated
+                                      in favor of "Names".'
+                                    type: string
+                                  names:
+                                    description: Names are the names of the resources.
+                                      Each name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character).
+                                    items:
+                                      type: string
+                                    type: array
+                                  namespaceSelector:
+                                    description: 'NamespaceSelector is a label selector
+                                      for the resource namespace. Label keys and values
+                                      in `matchLabels` support the wildcard characters
+                                      `*` (matches zero or many characters) and `?`
+                                      (matches one character).Wildcards allows writing
+                                      label selectors like ["storage.k8s.io/*": "*"].
+                                      Note that using ["*" : "*"] matches any key
+                                      and value but does not match an empty label
+                                      set.'
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaces:
+                                    description: Namespaces is a list of namespaces
+                                      names. Each name supports wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (at least one character).
+                                    items:
+                                      type: string
+                                    type: array
+                                  selector:
+                                    description: 'Selector is a label selector. Label
+                                      keys and values in `matchLabels` support the
+                                      wildcard characters `*` (matches zero or many
+                                      characters) and `?` (matches one character).
+                                      Wildcards allows writing label selectors like
+                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                      : "*"] matches any key and value but does not
+                                      match an empty label set.'
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              roles:
+                                description: Roles is the list of namespaced role
+                                  names for the user.
+                                items:
+                                  type: string
+                                type: array
+                              subjects:
+                                description: Subjects is the list of subject names
+                                  like users, user groups, and service accounts.
+                                items:
+                                  description: Subject contains a reference to the
+                                    object or user identities a role binding applies
+                                    to.  This can either hold a direct API object
+                                    reference, or a value for non-objects such as
+                                    user and group names.
+                                  properties:
+                                    apiGroup:
+                                      description: APIGroup holds the API group of
+                                        the referenced subject. Defaults to "" for
+                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
+                                        for User and Group subjects.
+                                      type: string
+                                    kind:
+                                      description: Kind of object being referenced.
+                                        Values defined by this API group are "User",
+                                        "Group", and "ServiceAccount". If the Authorizer
+                                        does not recognized the kind value, the Authorizer
+                                        should report an error.
+                                      type: string
+                                    name:
+                                      description: Name of the object being referenced.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the referenced object.  If
+                                        the object kind is non-namespace, such as
+                                        "User" or "Group", and this value is not empty
+                                        the Authorizer should report an error.
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                type: array
+                            type: object
+                          type: array
+                      type: object
+                    generate:
+                      description: Generation is used to create new resources.
+                      properties:
+                        apiVersion:
+                          description: APIVersion specifies resource apiVersion.
+                          type: string
+                        clone:
+                          description: Clone specifies the source resource used to
+                            populate each generated resource. At most one of Data
+                            or Clone can be specified. If neither are provided, the
+                            generated resource will be created with default data only.
+                          properties:
+                            name:
+                              description: Name specifies name of the resource.
+                              type: string
+                            namespace:
+                              description: Namespace specifies source resource namespace.
+                              type: string
+                          type: object
+                        cloneList:
+                          description: CloneList specifies the list of source resource
+                            used to populate each generated resource.
+                          properties:
+                            kinds:
+                              description: Kinds is a list of resource kinds.
+                              items:
+                                type: string
+                              type: array
+                            namespace:
+                              description: Namespace specifies source resource namespace.
+                              type: string
+                            selector:
+                              description: Selector is a label selector. Label keys
+                                and values in `matchLabels`. wildcard characters are
+                                not supported.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        data:
+                          description: Data provides the resource declaration used
+                            to populate each generated resource. At most one of Data
+                            or Clone must be specified. If neither are provided, the
+                            generated resource will be created with default data only.
+                          x-kubernetes-preserve-unknown-fields: true
+                        kind:
+                          description: Kind specifies resource kind.
+                          type: string
+                        name:
+                          description: Name specifies the resource name.
+                          type: string
+                        namespace:
+                          description: Namespace specifies resource namespace.
+                          type: string
+                        synchronize:
+                          description: Synchronize controls if generated resources
+                            should be kept in-sync with their source resource. If
+                            Synchronize is set to "true" changes to generated resources
+                            will be overwritten with resource data from Data or the
+                            resource specified in the Clone declaration. Optional.
+                            Defaults to "false" if not specified.
+                          type: boolean
+                      type: object
+                    imageExtractors:
+                      additionalProperties:
+                        items:
+                          properties:
+                            key:
+                              description: Key is an optional name of the field within
+                                'path' that will be used to uniquely identify an image.
+                                Note - this field MUST be unique.
+                              type: string
+                            name:
+                              description: Name is the entry the image will be available
+                                under 'images.<name>' in the context. If this field
+                                is not defined, image entries will appear under 'images.custom'.
+                              type: string
+                            path:
+                              description: Path is the path to the object containing
+                                the image field in a custom resource. It should be
+                                slash-separated. Each slash-separated key must be
+                                a valid YAML key or a wildcard '*'. Wildcard keys
+                                are expanded in case of arrays or objects.
+                              type: string
+                            value:
+                              description: Value is an optional name of the field
+                                within 'path' that points to the image URI. This is
+                                useful when a custom 'key' is also defined.
+                              type: string
+                          required:
+                          - path
+                          type: object
+                        type: array
+                      description: ImageExtractors defines a mapping from kinds to
+                        ImageExtractorConfigs. This config is only valid for verifyImages
+                        rules.
+                      type: object
+                    match:
+                      description: MatchResources defines when this policy rule should
+                        be applied. The match criteria can include resource information
+                        (e.g. kind, name, namespace, labels) and admission review
+                        request information like the user name or role. At least one
+                        kind is required.
+                      properties:
+                        all:
+                          description: All allows specifying resources which will
+                            be ANDed
+                          items:
+                            description: ResourceFilter allow users to "AND" or "OR"
+                              between resources
+                            properties:
+                              clusterRoles:
+                                description: ClusterRoles is the list of cluster-wide
+                                  role names for the user.
+                                items:
+                                  type: string
+                                type: array
+                              resources:
+                                description: ResourceDescription contains information
+                                  about the resource being created or modified.
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations is a  map of annotations
+                                      (key-value pairs of type string). Annotation
+                                      keys and values support the wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (matches at least one character).
+                                    type: object
+                                  kinds:
+                                    description: Kinds is a list of resource kinds.
+                                    items:
+                                      type: string
+                                    type: array
+                                  name:
+                                    description: 'Name is the name of the resource.
+                                      The name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character). NOTE: "Name" is being deprecated
+                                      in favor of "Names".'
+                                    type: string
+                                  names:
+                                    description: Names are the names of the resources.
+                                      Each name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character).
+                                    items:
+                                      type: string
+                                    type: array
+                                  namespaceSelector:
+                                    description: 'NamespaceSelector is a label selector
+                                      for the resource namespace. Label keys and values
+                                      in `matchLabels` support the wildcard characters
+                                      `*` (matches zero or many characters) and `?`
+                                      (matches one character).Wildcards allows writing
+                                      label selectors like ["storage.k8s.io/*": "*"].
+                                      Note that using ["*" : "*"] matches any key
+                                      and value but does not match an empty label
+                                      set.'
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaces:
+                                    description: Namespaces is a list of namespaces
+                                      names. Each name supports wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (at least one character).
+                                    items:
+                                      type: string
+                                    type: array
+                                  selector:
+                                    description: 'Selector is a label selector. Label
+                                      keys and values in `matchLabels` support the
+                                      wildcard characters `*` (matches zero or many
+                                      characters) and `?` (matches one character).
+                                      Wildcards allows writing label selectors like
+                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                      : "*"] matches any key and value but does not
+                                      match an empty label set.'
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              roles:
+                                description: Roles is the list of namespaced role
+                                  names for the user.
+                                items:
+                                  type: string
+                                type: array
+                              subjects:
+                                description: Subjects is the list of subject names
+                                  like users, user groups, and service accounts.
+                                items:
+                                  description: Subject contains a reference to the
+                                    object or user identities a role binding applies
+                                    to.  This can either hold a direct API object
+                                    reference, or a value for non-objects such as
+                                    user and group names.
+                                  properties:
+                                    apiGroup:
+                                      description: APIGroup holds the API group of
+                                        the referenced subject. Defaults to "" for
+                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
+                                        for User and Group subjects.
+                                      type: string
+                                    kind:
+                                      description: Kind of object being referenced.
+                                        Values defined by this API group are "User",
+                                        "Group", and "ServiceAccount". If the Authorizer
+                                        does not recognized the kind value, the Authorizer
+                                        should report an error.
+                                      type: string
+                                    name:
+                                      description: Name of the object being referenced.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the referenced object.  If
+                                        the object kind is non-namespace, such as
+                                        "User" or "Group", and this value is not empty
+                                        the Authorizer should report an error.
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                type: array
+                            type: object
+                          type: array
+                        any:
+                          description: Any allows specifying resources which will
+                            be ORed
+                          items:
+                            description: ResourceFilter allow users to "AND" or "OR"
+                              between resources
+                            properties:
+                              clusterRoles:
+                                description: ClusterRoles is the list of cluster-wide
+                                  role names for the user.
+                                items:
+                                  type: string
+                                type: array
+                              resources:
+                                description: ResourceDescription contains information
+                                  about the resource being created or modified.
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations is a  map of annotations
+                                      (key-value pairs of type string). Annotation
+                                      keys and values support the wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (matches at least one character).
+                                    type: object
+                                  kinds:
+                                    description: Kinds is a list of resource kinds.
+                                    items:
+                                      type: string
+                                    type: array
+                                  name:
+                                    description: 'Name is the name of the resource.
+                                      The name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character). NOTE: "Name" is being deprecated
+                                      in favor of "Names".'
+                                    type: string
+                                  names:
+                                    description: Names are the names of the resources.
+                                      Each name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character).
+                                    items:
+                                      type: string
+                                    type: array
+                                  namespaceSelector:
+                                    description: 'NamespaceSelector is a label selector
+                                      for the resource namespace. Label keys and values
+                                      in `matchLabels` support the wildcard characters
+                                      `*` (matches zero or many characters) and `?`
+                                      (matches one character).Wildcards allows writing
+                                      label selectors like ["storage.k8s.io/*": "*"].
+                                      Note that using ["*" : "*"] matches any key
+                                      and value but does not match an empty label
+                                      set.'
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaces:
+                                    description: Namespaces is a list of namespaces
+                                      names. Each name supports wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (at least one character).
+                                    items:
+                                      type: string
+                                    type: array
+                                  selector:
+                                    description: 'Selector is a label selector. Label
+                                      keys and values in `matchLabels` support the
+                                      wildcard characters `*` (matches zero or many
+                                      characters) and `?` (matches one character).
+                                      Wildcards allows writing label selectors like
+                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                      : "*"] matches any key and value but does not
+                                      match an empty label set.'
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              roles:
+                                description: Roles is the list of namespaced role
+                                  names for the user.
+                                items:
+                                  type: string
+                                type: array
+                              subjects:
+                                description: Subjects is the list of subject names
+                                  like users, user groups, and service accounts.
+                                items:
+                                  description: Subject contains a reference to the
+                                    object or user identities a role binding applies
+                                    to.  This can either hold a direct API object
+                                    reference, or a value for non-objects such as
+                                    user and group names.
+                                  properties:
+                                    apiGroup:
+                                      description: APIGroup holds the API group of
+                                        the referenced subject. Defaults to "" for
+                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
+                                        for User and Group subjects.
+                                      type: string
+                                    kind:
+                                      description: Kind of object being referenced.
+                                        Values defined by this API group are "User",
+                                        "Group", and "ServiceAccount". If the Authorizer
+                                        does not recognized the kind value, the Authorizer
+                                        should report an error.
+                                      type: string
+                                    name:
+                                      description: Name of the object being referenced.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the referenced object.  If
+                                        the object kind is non-namespace, such as
+                                        "User" or "Group", and this value is not empty
+                                        the Authorizer should report an error.
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                type: array
+                            type: object
+                          type: array
+                      type: object
+                    mutate:
+                      description: Mutation is used to modify matching resources.
+                      properties:
+                        foreach:
+                          description: ForEach applies mutation rules to a list of
+                            sub-elements by creating a context for each entry in the
+                            list and looping over it to apply the specified logic.
+                          items:
+                            description: ForEach applies mutation rules to a list
+                              of sub-elements by creating a context for each entry
+                              in the list and looping over it to apply the specified
+                              logic.
+                            properties:
+                              context:
+                                description: Context defines variables and data sources
+                                  that can be used during rule execution.
+                                items:
+                                  description: ContextEntry adds variables and data
+                                    sources to a rule Context. Either a ConfigMap
+                                    reference or a APILookup must be provided.
+                                  properties:
+                                    apiCall:
+                                      description: APICall defines an HTTP request
+                                        to the Kubernetes API server. The JSON data
+                                        retrieved is stored in the context.
+                                      properties:
+                                        jmesPath:
+                                          description: JMESPath is an optional JSON
+                                            Match Expression that can be used to transform
+                                            the JSON response returned from the API
+                                            server. For example a JMESPath of "items
+                                            | length(@)" applied to the API server
+                                            response to the URLPath "/apis/apps/v1/deployments"
+                                            will return the total count of deployments
+                                            across all namespaces.
+                                          type: string
+                                        urlPath:
+                                          description: URLPath is the URL path to
+                                            be used in the HTTP GET request to the
+                                            Kubernetes API server (e.g. "/api/v1/namespaces"
+                                            or  "/apis/apps/v1/deployments"). The
+                                            format required is the same format used
+                                            by the `kubectl get --raw` command.
+                                          type: string
+                                      required:
+                                      - urlPath
+                                      type: object
+                                    configMap:
+                                      description: ConfigMap is the ConfigMap reference.
+                                      properties:
+                                        name:
+                                          description: Name is the ConfigMap name.
+                                          type: string
+                                        namespace:
+                                          description: Namespace is the ConfigMap
+                                            namespace.
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    imageRegistry:
+                                      description: ImageRegistry defines requests
+                                        to an OCI/Docker V2 registry to fetch image
+                                        details.
+                                      properties:
+                                        jmesPath:
+                                          description: JMESPath is an optional JSON
+                                            Match Expression that can be used to transform
+                                            the ImageData struct returned as a result
+                                            of processing the image reference.
+                                          type: string
+                                        reference:
+                                          description: 'Reference is image reference
+                                            to a container image in the registry.
+                                            Example: ghcr.io/kyverno/kyverno:latest'
+                                          type: string
+                                      required:
+                                      - reference
+                                      type: object
+                                    name:
+                                      description: Name is the variable name.
+                                      type: string
+                                    variable:
+                                      description: Variable defines an arbitrary JMESPath
+                                        context variable that can be defined inline.
+                                      properties:
+                                        default:
+                                          description: Default is an optional arbitrary
+                                            JSON object that the variable may take
+                                            if the JMESPath expression evaluates to
+                                            nil
+                                          x-kubernetes-preserve-unknown-fields: true
+                                        jmesPath:
+                                          description: JMESPath is an optional JMESPath
+                                            Expression that can be used to transform
+                                            the variable.
+                                          type: string
+                                        value:
+                                          description: Value is any arbitrary JSON
+                                            object representable in YAML or JSON form.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                  type: object
+                                type: array
+                              list:
+                                description: List specifies a JMESPath expression
+                                  that results in one or more elements to which the
+                                  validation logic is applied.
+                                type: string
+                              patchStrategicMerge:
+                                description: PatchStrategicMerge is a strategic merge
+                                  patch used to modify resources. See https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/
+                                  and https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.
+                                x-kubernetes-preserve-unknown-fields: true
+                              patchesJson6902:
+                                description: PatchesJSON6902 is a list of RFC 6902
+                                  JSON Patch declarations used to modify resources.
+                                  See https://tools.ietf.org/html/rfc6902 and https://kubectl.docs.kubernetes.io/references/kustomize/patchesjson6902/.
+                                type: string
+                              preconditions:
+                                description: 'AnyAllConditions are used to determine
+                                  if a policy rule should be applied by evaluating
+                                  a set of conditions. The declaration can contain
+                                  nested `any` or `all` statements. See: https://kyverno.io/docs/writing-policies/preconditions/'
+                                properties:
+                                  all:
+                                    description: AllConditions enable variable-based
+                                      conditional rule execution. This is useful for
+                                      finer control of when an rule is applied. A
+                                      condition can reference object data using JMESPath
+                                      notation. Here, all of the conditions need to
+                                      pass
+                                    items:
+                                      description: Condition defines variable-based
+                                        conditional criteria for rule execution.
+                                      properties:
+                                        key:
+                                          description: Key is the context entry (using
+                                            JMESPath) for conditional rule evaluation.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                        operator:
+                                          description: 'Operator is the conditional
+                                            operation to perform. Valid operators
+                                            are: Equals, NotEquals, In, AnyIn, AllIn,
+                                            NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,
+                                            GreaterThan, LessThanOrEquals, LessThan,
+                                            DurationGreaterThanOrEquals, DurationGreaterThan,
+                                            DurationLessThanOrEquals, DurationLessThan'
+                                          enum:
+                                          - Equals
+                                          - NotEquals
+                                          - In
+                                          - AnyIn
+                                          - AllIn
+                                          - NotIn
+                                          - AnyNotIn
+                                          - AllNotIn
+                                          - GreaterThanOrEquals
+                                          - GreaterThan
+                                          - LessThanOrEquals
+                                          - LessThan
+                                          - DurationGreaterThanOrEquals
+                                          - DurationGreaterThan
+                                          - DurationLessThanOrEquals
+                                          - DurationLessThan
+                                          type: string
+                                        value:
+                                          description: Value is the conditional value,
+                                            or set of values. The values can be fixed
+                                            set or can be variables declared using
+                                            JMESPath.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                    type: array
+                                  any:
+                                    description: AnyConditions enable variable-based
+                                      conditional rule execution. This is useful for
+                                      finer control of when an rule is applied. A
+                                      condition can reference object data using JMESPath
+                                      notation. Here, at least one of the conditions
+                                      need to pass
+                                    items:
+                                      description: Condition defines variable-based
+                                        conditional criteria for rule execution.
+                                      properties:
+                                        key:
+                                          description: Key is the context entry (using
+                                            JMESPath) for conditional rule evaluation.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                        operator:
+                                          description: 'Operator is the conditional
+                                            operation to perform. Valid operators
+                                            are: Equals, NotEquals, In, AnyIn, AllIn,
+                                            NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,
+                                            GreaterThan, LessThanOrEquals, LessThan,
+                                            DurationGreaterThanOrEquals, DurationGreaterThan,
+                                            DurationLessThanOrEquals, DurationLessThan'
+                                          enum:
+                                          - Equals
+                                          - NotEquals
+                                          - In
+                                          - AnyIn
+                                          - AllIn
+                                          - NotIn
+                                          - AnyNotIn
+                                          - AllNotIn
+                                          - GreaterThanOrEquals
+                                          - GreaterThan
+                                          - LessThanOrEquals
+                                          - LessThan
+                                          - DurationGreaterThanOrEquals
+                                          - DurationGreaterThan
+                                          - DurationLessThanOrEquals
+                                          - DurationLessThan
+                                          type: string
+                                        value:
+                                          description: Value is the conditional value,
+                                            or set of values. The values can be fixed
+                                            set or can be variables declared using
+                                            JMESPath.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                    type: array
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          type: array
+                        patchStrategicMerge:
+                          description: PatchStrategicMerge is a strategic merge patch
+                            used to modify resources. See https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/
+                            and https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.
+                          x-kubernetes-preserve-unknown-fields: true
+                        patchesJson6902:
+                          description: PatchesJSON6902 is a list of RFC 6902 JSON
+                            Patch declarations used to modify resources. See https://tools.ietf.org/html/rfc6902
+                            and https://kubectl.docs.kubernetes.io/references/kustomize/patchesjson6902/.
+                          type: string
+                        targets:
+                          description: Targets defines the target resources to be
+                            mutated.
+                          items:
+                            properties:
+                              apiVersion:
+                                description: APIVersion specifies resource apiVersion.
+                                type: string
+                              kind:
+                                description: Kind specifies resource kind.
+                                type: string
+                              name:
+                                description: Name specifies the resource name.
+                                type: string
+                              namespace:
+                                description: Namespace specifies resource namespace.
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    name:
+                      description: Name is a label to identify the rule, It must be
+                        unique within the policy.
+                      maxLength: 63
+                      type: string
+                    preconditions:
+                      description: 'Preconditions are used to determine if a policy
+                        rule should be applied by evaluating a set of conditions.
+                        The declaration can contain nested `any` or `all` statements.
+                        A direct list of conditions (without `any` or `all` statements
+                        is supported for backwards compatibility but See: https://kyverno.io/docs/writing-policies/preconditions/'
+                      properties:
+                        all:
+                          description: AllConditions enable variable-based conditional
+                            rule execution. This is useful for finer control of when
+                            an rule is applied. A condition can reference object data
+                            using JMESPath notation. Here, all of the conditions need
+                            to pass
+                          items:
+                            properties:
+                              key:
+                                description: Key is the context entry (using JMESPath)
+                                  for conditional rule evaluation.
+                                x-kubernetes-preserve-unknown-fields: true
+                              operator:
+                                description: 'Operator is the conditional operation
+                                  to perform. Valid operators are: Equals, NotEquals,
+                                  In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,
+                                  GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals,
+                                  DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan'
+                                enum:
+                                - Equals
+                                - NotEquals
+                                - AnyIn
+                                - AllIn
+                                - AnyNotIn
+                                - AllNotIn
+                                - GreaterThanOrEquals
+                                - GreaterThan
+                                - LessThanOrEquals
+                                - LessThan
+                                - DurationGreaterThanOrEquals
+                                - DurationGreaterThan
+                                - DurationLessThanOrEquals
+                                - DurationLessThan
+                                type: string
+                              value:
+                                description: Value is the conditional value, or set
+                                  of values. The values can be fixed set or can be
+                                  variables declared using JMESPath.
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          type: array
+                        any:
+                          description: AnyConditions enable variable-based conditional
+                            rule execution. This is useful for finer control of when
+                            an rule is applied. A condition can reference object data
+                            using JMESPath notation. Here, at least one of the conditions
+                            need to pass
+                          items:
+                            properties:
+                              key:
+                                description: Key is the context entry (using JMESPath)
+                                  for conditional rule evaluation.
+                                x-kubernetes-preserve-unknown-fields: true
+                              operator:
+                                description: 'Operator is the conditional operation
+                                  to perform. Valid operators are: Equals, NotEquals,
+                                  In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,
+                                  GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals,
+                                  DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan'
+                                enum:
+                                - Equals
+                                - NotEquals
+                                - AnyIn
+                                - AllIn
+                                - AnyNotIn
+                                - AllNotIn
+                                - GreaterThanOrEquals
+                                - GreaterThan
+                                - LessThanOrEquals
+                                - LessThan
+                                - DurationGreaterThanOrEquals
+                                - DurationGreaterThan
+                                - DurationLessThanOrEquals
+                                - DurationLessThan
+                                type: string
+                              value:
+                                description: Value is the conditional value, or set
+                                  of values. The values can be fixed set or can be
+                                  variables declared using JMESPath.
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          type: array
+                      type: object
+                    validate:
+                      description: Validation is used to validate matching resources.
+                      properties:
+                        anyPattern:
+                          description: AnyPattern specifies list of validation patterns.
+                            At least one of the patterns must be satisfied for the
+                            validation rule to succeed.
+                          x-kubernetes-preserve-unknown-fields: true
+                        deny:
+                          description: Deny defines conditions used to pass or fail
+                            a validation rule.
+                          properties:
+                            conditions:
+                              description: 'Multiple conditions can be declared under
+                                an `any` or `all` statement. A direct list of conditions
+                                (without `any` or `all` statements) is also supported
+                                for backwards compatibility See: https://kyverno.io/docs/writing-policies/validate/#deny-rules'
+                              properties:
+                                all:
+                                  description: AllConditions enable variable-based
+                                    conditional rule execution. This is useful for
+                                    finer control of when an rule is applied. A condition
+                                    can reference object data using JMESPath notation.
+                                    Here, all of the conditions need to pass
+                                  items:
+                                    properties:
+                                      key:
+                                        description: Key is the context entry (using
+                                          JMESPath) for conditional rule evaluation.
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      operator:
+                                        description: 'Operator is the conditional
+                                          operation to perform. Valid operators are:
+                                          Equals, NotEquals, In, AnyIn, AllIn, NotIn,
+                                          AnyNotIn, AllNotIn, GreaterThanOrEquals,
+                                          GreaterThan, LessThanOrEquals, LessThan,
+                                          DurationGreaterThanOrEquals, DurationGreaterThan,
+                                          DurationLessThanOrEquals, DurationLessThan'
+                                        enum:
+                                        - Equals
+                                        - NotEquals
+                                        - AnyIn
+                                        - AllIn
+                                        - AnyNotIn
+                                        - AllNotIn
+                                        - GreaterThanOrEquals
+                                        - GreaterThan
+                                        - LessThanOrEquals
+                                        - LessThan
+                                        - DurationGreaterThanOrEquals
+                                        - DurationGreaterThan
+                                        - DurationLessThanOrEquals
+                                        - DurationLessThan
+                                        type: string
+                                      value:
+                                        description: Value is the conditional value,
+                                          or set of values. The values can be fixed
+                                          set or can be variables declared using JMESPath.
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                  type: array
+                                any:
+                                  description: AnyConditions enable variable-based
+                                    conditional rule execution. This is useful for
+                                    finer control of when an rule is applied. A condition
+                                    can reference object data using JMESPath notation.
+                                    Here, at least one of the conditions need to pass
+                                  items:
+                                    properties:
+                                      key:
+                                        description: Key is the context entry (using
+                                          JMESPath) for conditional rule evaluation.
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      operator:
+                                        description: 'Operator is the conditional
+                                          operation to perform. Valid operators are:
+                                          Equals, NotEquals, In, AnyIn, AllIn, NotIn,
+                                          AnyNotIn, AllNotIn, GreaterThanOrEquals,
+                                          GreaterThan, LessThanOrEquals, LessThan,
+                                          DurationGreaterThanOrEquals, DurationGreaterThan,
+                                          DurationLessThanOrEquals, DurationLessThan'
+                                        enum:
+                                        - Equals
+                                        - NotEquals
+                                        - AnyIn
+                                        - AllIn
+                                        - AnyNotIn
+                                        - AllNotIn
+                                        - GreaterThanOrEquals
+                                        - GreaterThan
+                                        - LessThanOrEquals
+                                        - LessThan
+                                        - DurationGreaterThanOrEquals
+                                        - DurationGreaterThan
+                                        - DurationLessThanOrEquals
+                                        - DurationLessThan
+                                        type: string
+                                      value:
+                                        description: Value is the conditional value,
+                                          or set of values. The values can be fixed
+                                          set or can be variables declared using JMESPath.
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                  type: array
+                              type: object
+                          type: object
+                        foreach:
+                          description: ForEach applies validate rules to a list of
+                            sub-elements by creating a context for each entry in the
+                            list and looping over it to apply the specified logic.
+                          items:
+                            description: ForEach applies validate rules to a list
+                              of sub-elements by creating a context for each entry
+                              in the list and looping over it to apply the specified
+                              logic.
+                            properties:
+                              anyPattern:
+                                description: AnyPattern specifies list of validation
+                                  patterns. At least one of the patterns must be satisfied
+                                  for the validation rule to succeed.
+                                x-kubernetes-preserve-unknown-fields: true
+                              context:
+                                description: Context defines variables and data sources
+                                  that can be used during rule execution.
+                                items:
+                                  description: ContextEntry adds variables and data
+                                    sources to a rule Context. Either a ConfigMap
+                                    reference or a APILookup must be provided.
+                                  properties:
+                                    apiCall:
+                                      description: APICall defines an HTTP request
+                                        to the Kubernetes API server. The JSON data
+                                        retrieved is stored in the context.
+                                      properties:
+                                        jmesPath:
+                                          description: JMESPath is an optional JSON
+                                            Match Expression that can be used to transform
+                                            the JSON response returned from the API
+                                            server. For example a JMESPath of "items
+                                            | length(@)" applied to the API server
+                                            response to the URLPath "/apis/apps/v1/deployments"
+                                            will return the total count of deployments
+                                            across all namespaces.
+                                          type: string
+                                        urlPath:
+                                          description: URLPath is the URL path to
+                                            be used in the HTTP GET request to the
+                                            Kubernetes API server (e.g. "/api/v1/namespaces"
+                                            or  "/apis/apps/v1/deployments"). The
+                                            format required is the same format used
+                                            by the `kubectl get --raw` command.
+                                          type: string
+                                      required:
+                                      - urlPath
+                                      type: object
+                                    configMap:
+                                      description: ConfigMap is the ConfigMap reference.
+                                      properties:
+                                        name:
+                                          description: Name is the ConfigMap name.
+                                          type: string
+                                        namespace:
+                                          description: Namespace is the ConfigMap
+                                            namespace.
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    imageRegistry:
+                                      description: ImageRegistry defines requests
+                                        to an OCI/Docker V2 registry to fetch image
+                                        details.
+                                      properties:
+                                        jmesPath:
+                                          description: JMESPath is an optional JSON
+                                            Match Expression that can be used to transform
+                                            the ImageData struct returned as a result
+                                            of processing the image reference.
+                                          type: string
+                                        reference:
+                                          description: 'Reference is image reference
+                                            to a container image in the registry.
+                                            Example: ghcr.io/kyverno/kyverno:latest'
+                                          type: string
+                                      required:
+                                      - reference
+                                      type: object
+                                    name:
+                                      description: Name is the variable name.
+                                      type: string
+                                    variable:
+                                      description: Variable defines an arbitrary JMESPath
+                                        context variable that can be defined inline.
+                                      properties:
+                                        default:
+                                          description: Default is an optional arbitrary
+                                            JSON object that the variable may take
+                                            if the JMESPath expression evaluates to
+                                            nil
+                                          x-kubernetes-preserve-unknown-fields: true
+                                        jmesPath:
+                                          description: JMESPath is an optional JMESPath
+                                            Expression that can be used to transform
+                                            the variable.
+                                          type: string
+                                        value:
+                                          description: Value is any arbitrary JSON
+                                            object representable in YAML or JSON form.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                  type: object
+                                type: array
+                              deny:
+                                description: Deny defines conditions used to pass
+                                  or fail a validation rule.
+                                properties:
+                                  conditions:
+                                    description: 'Multiple conditions can be declared
+                                      under an `any` or `all` statement. A direct
+                                      list of conditions (without `any` or `all` statements)
+                                      is also supported for backwards compatibility
+                                      but will be deprecated in the next major release.
+                                      See: https://kyverno.io/docs/writing-policies/validate/#deny-rules'
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              elementScope:
+                                description: ElementScope specifies whether to use
+                                  the current list element as the scope for validation.
+                                  Defaults to "true" if not specified. When set to
+                                  "false", "request.object" is used as the validation
+                                  scope within the foreach block to allow referencing
+                                  other elements in the subtree.
+                                type: boolean
+                              list:
+                                description: List specifies a JMESPath expression
+                                  that results in one or more elements to which the
+                                  validation logic is applied.
+                                type: string
+                              pattern:
+                                description: Pattern specifies an overlay-style pattern
+                                  used to check resources.
+                                x-kubernetes-preserve-unknown-fields: true
+                              preconditions:
+                                description: 'AnyAllConditions are used to determine
+                                  if a policy rule should be applied by evaluating
+                                  a set of conditions. The declaration can contain
+                                  nested `any` or `all` statements. See: https://kyverno.io/docs/writing-policies/preconditions/'
+                                properties:
+                                  all:
+                                    description: AllConditions enable variable-based
+                                      conditional rule execution. This is useful for
+                                      finer control of when an rule is applied. A
+                                      condition can reference object data using JMESPath
+                                      notation. Here, all of the conditions need to
+                                      pass
+                                    items:
+                                      description: Condition defines variable-based
+                                        conditional criteria for rule execution.
+                                      properties:
+                                        key:
+                                          description: Key is the context entry (using
+                                            JMESPath) for conditional rule evaluation.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                        operator:
+                                          description: 'Operator is the conditional
+                                            operation to perform. Valid operators
+                                            are: Equals, NotEquals, In, AnyIn, AllIn,
+                                            NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,
+                                            GreaterThan, LessThanOrEquals, LessThan,
+                                            DurationGreaterThanOrEquals, DurationGreaterThan,
+                                            DurationLessThanOrEquals, DurationLessThan'
+                                          enum:
+                                          - Equals
+                                          - NotEquals
+                                          - In
+                                          - AnyIn
+                                          - AllIn
+                                          - NotIn
+                                          - AnyNotIn
+                                          - AllNotIn
+                                          - GreaterThanOrEquals
+                                          - GreaterThan
+                                          - LessThanOrEquals
+                                          - LessThan
+                                          - DurationGreaterThanOrEquals
+                                          - DurationGreaterThan
+                                          - DurationLessThanOrEquals
+                                          - DurationLessThan
+                                          type: string
+                                        value:
+                                          description: Value is the conditional value,
+                                            or set of values. The values can be fixed
+                                            set or can be variables declared using
+                                            JMESPath.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                    type: array
+                                  any:
+                                    description: AnyConditions enable variable-based
+                                      conditional rule execution. This is useful for
+                                      finer control of when an rule is applied. A
+                                      condition can reference object data using JMESPath
+                                      notation. Here, at least one of the conditions
+                                      need to pass
+                                    items:
+                                      description: Condition defines variable-based
+                                        conditional criteria for rule execution.
+                                      properties:
+                                        key:
+                                          description: Key is the context entry (using
+                                            JMESPath) for conditional rule evaluation.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                        operator:
+                                          description: 'Operator is the conditional
+                                            operation to perform. Valid operators
+                                            are: Equals, NotEquals, In, AnyIn, AllIn,
+                                            NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,
+                                            GreaterThan, LessThanOrEquals, LessThan,
+                                            DurationGreaterThanOrEquals, DurationGreaterThan,
+                                            DurationLessThanOrEquals, DurationLessThan'
+                                          enum:
+                                          - Equals
+                                          - NotEquals
+                                          - In
+                                          - AnyIn
+                                          - AllIn
+                                          - NotIn
+                                          - AnyNotIn
+                                          - AllNotIn
+                                          - GreaterThanOrEquals
+                                          - GreaterThan
+                                          - LessThanOrEquals
+                                          - LessThan
+                                          - DurationGreaterThanOrEquals
+                                          - DurationGreaterThan
+                                          - DurationLessThanOrEquals
+                                          - DurationLessThan
+                                          type: string
+                                        value:
+                                          description: Value is the conditional value,
+                                            or set of values. The values can be fixed
+                                            set or can be variables declared using
+                                            JMESPath.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                    type: array
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          type: array
+                        manifests:
+                          description: Manifest specifies conditions for manifest
+                            verification
+                          properties:
+                            annotationDomain:
+                              description: AnnotationDomain is custom domain of annotation
+                                for message and signature. Default is "cosign.sigstore.dev".
+                              type: string
+                            attestors:
+                              description: Attestors specified the required attestors
+                                (i.e. authorities)
+                              items:
+                                properties:
+                                  count:
+                                    description: Count specifies the required number
+                                      of entries that must match. If the count is
+                                      null, all entries must match (a logical AND).
+                                      If the count is 1, at least one entry must match
+                                      (a logical OR). If the count contains a value
+                                      N, then N must be less than or equal to the
+                                      size of entries, and at least N entries must
+                                      match.
+                                    minimum: 1
+                                    type: integer
+                                  entries:
+                                    description: Entries contains the available attestors.
+                                      An attestor can be a static key, attributes
+                                      for keyless verification, or a nested attestor
+                                      declaration.
+                                    items:
+                                      properties:
+                                        annotations:
+                                          additionalProperties:
+                                            type: string
+                                          description: Annotations are used for image
+                                            verification. Every specified key-value
+                                            pair must exist and match in the verified
+                                            payload. The payload may contain other
+                                            key-value pairs.
+                                          type: object
+                                        attestor:
+                                          description: Attestor is a nested AttestorSet
+                                            used to specify a more complex set of
+                                            match authorities
+                                          x-kubernetes-preserve-unknown-fields: true
+                                        certificates:
+                                          description: Certificates specifies one
+                                            or more certificates
+                                          properties:
+                                            cert:
+                                              description: Certificate is an optional
+                                                PEM encoded public certificate.
+                                              type: string
+                                            certChain:
+                                              description: CertificateChain is an
+                                                optional PEM encoded set of certificates
+                                                used to verify
+                                              type: string
+                                            rekor:
+                                              description: Rekor provides configuration
+                                                for the Rekor transparency log service.
+                                                If the value is nil, Rekor is not
+                                                checked. If an empty object is provided
+                                                the public instance of Rekor (https://rekor.sigstore.dev)
+                                                is used.
+                                              properties:
+                                                url:
+                                                  description: URL is the address
+                                                    of the transparency log. Defaults
+                                                    to the public log https://rekor.sigstore.dev.
+                                                  type: string
+                                              required:
+                                              - url
+                                              type: object
+                                          type: object
+                                        keyless:
+                                          description: Keyless is a set of attribute
+                                            used to verify a Sigstore keyless attestor.
+                                            See https://github.com/sigstore/cosign/blob/main/KEYLESS.md.
+                                          properties:
+                                            additionalExtensions:
+                                              additionalProperties:
+                                                type: string
+                                              description: AdditionalExtensions are
+                                                certificate-extensions used for keyless
+                                                signing.
+                                              type: object
+                                            issuer:
+                                              description: Issuer is the certificate
+                                                issuer used for keyless signing.
+                                              type: string
+                                            rekor:
+                                              description: Rekor provides configuration
+                                                for the Rekor transparency log service.
+                                                If the value is nil, Rekor is not
+                                                checked and a root certificate chain
+                                                is expected instead. If an empty object
+                                                is provided the public instance of
+                                                Rekor (https://rekor.sigstore.dev)
+                                                is used.
+                                              properties:
+                                                url:
+                                                  description: URL is the address
+                                                    of the transparency log. Defaults
+                                                    to the public log https://rekor.sigstore.dev.
+                                                  type: string
+                                              required:
+                                              - url
+                                              type: object
+                                            roots:
+                                              description: Roots is an optional set
+                                                of PEM encoded trusted root certificates.
+                                                If not provided, the system roots
+                                                are used.
+                                              type: string
+                                            subject:
+                                              description: Subject is the verified
+                                                identity used for keyless signing,
+                                                for example the email address
+                                              type: string
+                                          type: object
+                                        keys:
+                                          description: Keys specifies one or more
+                                            public keys
+                                          properties:
+                                            publicKeys:
+                                              description: Keys is a set of X.509
+                                                public keys used to verify image signatures.
+                                                The keys can be directly specified
+                                                or can be a variable reference to
+                                                a key specified in a ConfigMap (see
+                                                https://kyverno.io/docs/writing-policies/variables/).
+                                                When multiple keys are specified each
+                                                key is processed as a separate staticKey
+                                                entry (.attestors[*].entries.keys)
+                                                within the set of attestors and the
+                                                count is applied across the keys.
+                                              type: string
+                                            rekor:
+                                              description: Rekor provides configuration
+                                                for the Rekor transparency log service.
+                                                If the value is nil, Rekor is not
+                                                checked. If an empty object is provided
+                                                the public instance of Rekor (https://rekor.sigstore.dev)
+                                                is used.
+                                              properties:
+                                                url:
+                                                  description: URL is the address
+                                                    of the transparency log. Defaults
+                                                    to the public log https://rekor.sigstore.dev.
+                                                  type: string
+                                              required:
+                                              - url
+                                              type: object
+                                          type: object
+                                        repository:
+                                          description: Repository is an optional alternate
+                                            OCI repository to use for signatures and
+                                            attestations that match this rule. If
+                                            specified Repository will override other
+                                            OCI image repository locations for this
+                                            Attestor.
+                                          type: string
+                                      type: object
+                                    type: array
+                                type: object
+                              type: array
+                            dryRun:
+                              description: DryRun configuration
+                              properties:
+                                enable:
+                                  type: boolean
+                                namespace:
+                                  type: string
+                              type: object
+                            ignoreFields:
+                              description: Fields which will be ignored while comparing
+                                manifests.
+                              items:
+                                properties:
+                                  fields:
+                                    items:
+                                      type: string
+                                    type: array
+                                  objects:
+                                    items:
+                                      properties:
+                                        group:
+                                          type: string
+                                        kind:
+                                          type: string
+                                        name:
+                                          type: string
+                                        namespace:
+                                          type: string
+                                        version:
+                                          type: string
+                                      type: object
+                                    type: array
+                                type: object
+                              type: array
+                            repository:
+                              description: Repository is an optional alternate OCI
+                                repository to use for resource bundle reference. The
+                                repository can be overridden per Attestor or Attestation.
+                              type: string
+                          type: object
+                        message:
+                          description: Message specifies a custom message to be displayed
+                            on failure.
+                          type: string
+                        pattern:
+                          description: Pattern specifies an overlay-style pattern
+                            used to check resources.
+                          x-kubernetes-preserve-unknown-fields: true
+                        podSecurity:
+                          description: PodSecurity applies exemptions for Kubernetes
+                            Pod Security admission by specifying exclusions for Pod
+                            Security Standards controls.
+                          properties:
+                            exclude:
+                              description: Exclude specifies the Pod Security Standard
+                                controls to be excluded.
+                              items:
+                                description: PodSecurityStandard specifies the Pod
+                                  Security Standard controls to be excluded.
+                                properties:
+                                  controlName:
+                                    description: 'ControlName specifies the name of
+                                      the Pod Security Standard control. See: https://kubernetes.io/docs/concepts/security/pod-security-standards/'
+                                    enum:
+                                    - HostProcess
+                                    - Host Namespaces
+                                    - Privileged Containers
+                                    - Capabilities
+                                    - HostPath Volumes
+                                    - Host Ports
+                                    - AppArmor
+                                    - SELinux
+                                    - /proc Mount Type
+                                    - Seccomp
+                                    - Sysctls
+                                    - Volume Types
+                                    - Privilege Escalation
+                                    - Running as Non-root
+                                    - Running as Non-root user
+                                    type: string
+                                  images:
+                                    description: 'Images selects matching containers
+                                      and applies the container level PSS. Each image
+                                      is the image name consisting of the registry
+                                      address, repository, image, and tag. Empty list
+                                      matches no containers, PSS checks are applied
+                                      at the pod level only. Wildcards (''*'' and
+                                      ''?'') are allowed. See: https://kubernetes.io/docs/concepts/containers/images.'
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - controlName
+                                type: object
+                              type: array
+                            level:
+                              description: Level defines the Pod Security Standard
+                                level to be applied to workloads. Allowed values are
+                                privileged, baseline, and restricted.
+                              enum:
+                              - privileged
+                              - baseline
+                              - restricted
+                              type: string
+                            version:
+                              description: Version defines the Pod Security Standard
+                                versions that Kubernetes supports. Allowed values
+                                are v1.19, v1.20, v1.21, v1.22, v1.23, v1.24, v1.25,
+                                latest. Defaults to latest.
+                              enum:
+                              - v1.19
+                              - v1.20
+                              - v1.21
+                              - v1.22
+                              - v1.23
+                              - v1.24
+                              - v1.25
+                              - latest
+                              type: string
+                          type: object
+                      type: object
+                    verifyImages:
+                      description: VerifyImages is used to verify image signatures
+                        and mutate them to add a digest
+                      items:
+                        description: ImageVerification validates that images that
+                          match the specified pattern are signed with the supplied
+                          public key. Once the image is verified it is mutated to
+                          include the SHA digest retrieved during the registration.
+                        properties:
+                          attestations:
+                            description: Attestations are optional checks for signed
+                              in-toto Statements used to verify the image. See https://github.com/in-toto/attestation.
+                              Kyverno fetches signed attestations from the OCI registry
+                              and decodes them into a list of Statement declarations.
+                            items:
+                              description: Attestation are checks for signed in-toto
+                                Statements that are used to verify the image. See
+                                https://github.com/in-toto/attestation. Kyverno fetches
+                                signed attestations from the OCI registry and decodes
+                                them into a list of Statements.
+                              properties:
+                                conditions:
+                                  description: Conditions are used to verify attributes
+                                    within a Predicate. If no Conditions are specified
+                                    the attestation check is satisfied as long there
+                                    are predicates that match the predicate type.
+                                  items:
+                                    description: AnyAllConditions consists of conditions
+                                      wrapped denoting a logical criteria to be fulfilled.
+                                      AnyConditions get fulfilled when at least one
+                                      of its sub-conditions passes. AllConditions
+                                      get fulfilled only when all of its sub-conditions
+                                      pass.
+                                    properties:
+                                      all:
+                                        description: AllConditions enable variable-based
+                                          conditional rule execution. This is useful
+                                          for finer control of when an rule is applied.
+                                          A condition can reference object data using
+                                          JMESPath notation. Here, all of the conditions
+                                          need to pass
+                                        items:
+                                          description: Condition defines variable-based
+                                            conditional criteria for rule execution.
+                                          properties:
+                                            key:
+                                              description: Key is the context entry
+                                                (using JMESPath) for conditional rule
+                                                evaluation.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            operator:
+                                              description: 'Operator is the conditional
+                                                operation to perform. Valid operators
+                                                are: Equals, NotEquals, In, AnyIn,
+                                                AllIn, NotIn, AnyNotIn, AllNotIn,
+                                                GreaterThanOrEquals, GreaterThan,
+                                                LessThanOrEquals, LessThan, DurationGreaterThanOrEquals,
+                                                DurationGreaterThan, DurationLessThanOrEquals,
+                                                DurationLessThan'
+                                              enum:
+                                              - Equals
+                                              - NotEquals
+                                              - In
+                                              - AnyIn
+                                              - AllIn
+                                              - NotIn
+                                              - AnyNotIn
+                                              - AllNotIn
+                                              - GreaterThanOrEquals
+                                              - GreaterThan
+                                              - LessThanOrEquals
+                                              - LessThan
+                                              - DurationGreaterThanOrEquals
+                                              - DurationGreaterThan
+                                              - DurationLessThanOrEquals
+                                              - DurationLessThan
+                                              type: string
+                                            value:
+                                              description: Value is the conditional
+                                                value, or set of values. The values
+                                                can be fixed set or can be variables
+                                                declared using JMESPath.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                        type: array
+                                      any:
+                                        description: AnyConditions enable variable-based
+                                          conditional rule execution. This is useful
+                                          for finer control of when an rule is applied.
+                                          A condition can reference object data using
+                                          JMESPath notation. Here, at least one of
+                                          the conditions need to pass
+                                        items:
+                                          description: Condition defines variable-based
+                                            conditional criteria for rule execution.
+                                          properties:
+                                            key:
+                                              description: Key is the context entry
+                                                (using JMESPath) for conditional rule
+                                                evaluation.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            operator:
+                                              description: 'Operator is the conditional
+                                                operation to perform. Valid operators
+                                                are: Equals, NotEquals, In, AnyIn,
+                                                AllIn, NotIn, AnyNotIn, AllNotIn,
+                                                GreaterThanOrEquals, GreaterThan,
+                                                LessThanOrEquals, LessThan, DurationGreaterThanOrEquals,
+                                                DurationGreaterThan, DurationLessThanOrEquals,
+                                                DurationLessThan'
+                                              enum:
+                                              - Equals
+                                              - NotEquals
+                                              - In
+                                              - AnyIn
+                                              - AllIn
+                                              - NotIn
+                                              - AnyNotIn
+                                              - AllNotIn
+                                              - GreaterThanOrEquals
+                                              - GreaterThan
+                                              - LessThanOrEquals
+                                              - LessThan
+                                              - DurationGreaterThanOrEquals
+                                              - DurationGreaterThan
+                                              - DurationLessThanOrEquals
+                                              - DurationLessThan
+                                              type: string
+                                            value:
+                                              description: Value is the conditional
+                                                value, or set of values. The values
+                                                can be fixed set or can be variables
+                                                declared using JMESPath.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                        type: array
+                                    type: object
+                                  type: array
+                                predicateType:
+                                  description: PredicateType defines the type of Predicate
+                                    contained within the Statement.
+                                  type: string
+                              type: object
+                            type: array
+                          attestors:
+                            description: Attestors specified the required attestors
+                              (i.e. authorities)
+                            items:
+                              properties:
+                                count:
+                                  description: Count specifies the required number
+                                    of entries that must match. If the count is null,
+                                    all entries must match (a logical AND). If the
+                                    count is 1, at least one entry must match (a logical
+                                    OR). If the count contains a value N, then N must
+                                    be less than or equal to the size of entries,
+                                    and at least N entries must match.
+                                  minimum: 1
+                                  type: integer
+                                entries:
+                                  description: Entries contains the available attestors.
+                                    An attestor can be a static key, attributes for
+                                    keyless verification, or a nested attestor declaration.
+                                  items:
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations are used for image
+                                          verification. Every specified key-value
+                                          pair must exist and match in the verified
+                                          payload. The payload may contain other key-value
+                                          pairs.
+                                        type: object
+                                      attestor:
+                                        description: Attestor is a nested AttestorSet
+                                          used to specify a more complex set of match
+                                          authorities
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      certificates:
+                                        description: Certificates specifies one or
+                                          more certificates
+                                        properties:
+                                          cert:
+                                            description: Certificate is an optional
+                                              PEM encoded public certificate.
+                                            type: string
+                                          certChain:
+                                            description: CertificateChain is an optional
+                                              PEM encoded set of certificates used
+                                              to verify
+                                            type: string
+                                          rekor:
+                                            description: Rekor provides configuration
+                                              for the Rekor transparency log service.
+                                              If the value is nil, Rekor is not checked.
+                                              If an empty object is provided the public
+                                              instance of Rekor (https://rekor.sigstore.dev)
+                                              is used.
+                                            properties:
+                                              url:
+                                                description: URL is the address of
+                                                  the transparency log. Defaults to
+                                                  the public log https://rekor.sigstore.dev.
+                                                type: string
+                                            required:
+                                            - url
+                                            type: object
+                                        type: object
+                                      keyless:
+                                        description: Keyless is a set of attribute
+                                          used to verify a Sigstore keyless attestor.
+                                          See https://github.com/sigstore/cosign/blob/main/KEYLESS.md.
+                                        properties:
+                                          additionalExtensions:
+                                            additionalProperties:
+                                              type: string
+                                            description: AdditionalExtensions are
+                                              certificate-extensions used for keyless
+                                              signing.
+                                            type: object
+                                          issuer:
+                                            description: Issuer is the certificate
+                                              issuer used for keyless signing.
+                                            type: string
+                                          rekor:
+                                            description: Rekor provides configuration
+                                              for the Rekor transparency log service.
+                                              If the value is nil, Rekor is not checked
+                                              and a root certificate chain is expected
+                                              instead. If an empty object is provided
+                                              the public instance of Rekor (https://rekor.sigstore.dev)
+                                              is used.
+                                            properties:
+                                              url:
+                                                description: URL is the address of
+                                                  the transparency log. Defaults to
+                                                  the public log https://rekor.sigstore.dev.
+                                                type: string
+                                            required:
+                                            - url
+                                            type: object
+                                          roots:
+                                            description: Roots is an optional set
+                                              of PEM encoded trusted root certificates.
+                                              If not provided, the system roots are
+                                              used.
+                                            type: string
+                                          subject:
+                                            description: Subject is the verified identity
+                                              used for keyless signing, for example
+                                              the email address
+                                            type: string
+                                        type: object
+                                      keys:
+                                        description: Keys specifies one or more public
+                                          keys
+                                        properties:
+                                          publicKeys:
+                                            description: Keys is a set of X.509 public
+                                              keys used to verify image signatures.
+                                              The keys can be directly specified or
+                                              can be a variable reference to a key
+                                              specified in a ConfigMap (see https://kyverno.io/docs/writing-policies/variables/).
+                                              When multiple keys are specified each
+                                              key is processed as a separate staticKey
+                                              entry (.attestors[*].entries.keys) within
+                                              the set of attestors and the count is
+                                              applied across the keys.
+                                            type: string
+                                          rekor:
+                                            description: Rekor provides configuration
+                                              for the Rekor transparency log service.
+                                              If the value is nil, Rekor is not checked.
+                                              If an empty object is provided the public
+                                              instance of Rekor (https://rekor.sigstore.dev)
+                                              is used.
+                                            properties:
+                                              url:
+                                                description: URL is the address of
+                                                  the transparency log. Defaults to
+                                                  the public log https://rekor.sigstore.dev.
+                                                type: string
+                                            required:
+                                            - url
+                                            type: object
+                                        type: object
+                                      repository:
+                                        description: Repository is an optional alternate
+                                          OCI repository to use for signatures and
+                                          attestations that match this rule. If specified
+                                          Repository will override other OCI image
+                                          repository locations for this Attestor.
+                                        type: string
+                                    type: object
+                                  type: array
+                              type: object
+                            type: array
+                          imageReferences:
+                            description: 'ImageReferences is a list of matching image
+                              reference patterns. At least one pattern in the list
+                              must match the image for the rule to apply. Each image
+                              reference consists of a registry address (defaults to
+                              docker.io), repository, image, and tag (defaults to
+                              latest). Wildcards (''*'' and ''?'') are allowed. See:
+                              https://kubernetes.io/docs/concepts/containers/images.'
+                            items:
+                              type: string
+                            type: array
+                          mutateDigest:
+                            default: true
+                            description: MutateDigest enables replacement of image
+                              tags with digests. Defaults to true.
+                            type: boolean
+                          repository:
+                            description: Repository is an optional alternate OCI repository
+                              to use for image signatures and attestations that match
+                              this rule. If specified Repository will override the
+                              default OCI image repository configured for the installation.
+                              The repository can also be overridden per Attestor or
+                              Attestation.
+                            type: string
+                          required:
+                            default: true
+                            description: Required validates that images are verified
+                              i.e. have matched passed a signature or attestation
+                              check.
+                            type: boolean
+                          verifyDigest:
+                            default: true
+                            description: VerifyDigest validates that images have a
+                              digest.
+                            type: boolean
+                        type: object
+                      type: array
+                  type: object
+                type: array
+              schemaValidation:
+                description: SchemaValidation skips policy validation checks. Optional.
+                  The default value is set to "true", it must be set to "false" to
+                  disable the validation checks.
+                type: boolean
+              validationFailureAction:
+                default: audit
+                description: ValidationFailureAction defines if a validation policy
+                  rule violation should block the admission review request (enforce),
+                  or allow (audit) the admission review request and report an error
+                  in a policy report. Optional. Allowed values are audit or enforce.
+                  The default value is "audit".
+                enum:
+                - audit
+                - enforce
+                type: string
+              validationFailureActionOverrides:
+                description: ValidationFailureActionOverrides is a Cluster Policy
+                  attribute that specifies ValidationFailureAction namespace-wise.
+                  It overrides ValidationFailureAction for the specified namespaces.
+                items:
+                  properties:
+                    action:
+                      description: ValidationFailureAction defines the policy validation
+                        failure action
+                      enum:
+                      - audit
+                      - enforce
+                      type: string
+                    namespaces:
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                type: array
+              webhookTimeoutSeconds:
+                description: WebhookTimeoutSeconds specifies the maximum time in seconds
+                  allowed to apply this policy. After the configured time expires,
+                  the admission request may fail, or may simply ignore the policy
+                  results, based on the failure policy. The default timeout is 10s,
+                  the value must be between 1 and 30 seconds.
+                format: int32
+                type: integer
+            type: object
+          status:
+            description: Status contains policy runtime data.
+            properties:
+              autogen:
+                description: Autogen contains autogen status information
+                properties:
+                  rules:
+                    description: Rules is a list of Rule instances. It contains auto
+                      generated rules added for pod controllers
+                    items:
+                      description: Rule defines a validation, mutation, or generation
+                        control for matching resources. Each rules contains a match
+                        declaration to select resources, and an optional exclude declaration
+                        to specify which resources to exclude.
+                      properties:
+                        context:
+                          description: Context defines variables and data sources
+                            that can be used during rule execution.
+                          items:
+                            description: ContextEntry adds variables and data sources
+                              to a rule Context. Either a ConfigMap reference or a
+                              APILookup must be provided.
+                            properties:
+                              apiCall:
+                                description: APICall defines an HTTP request to the
+                                  Kubernetes API server. The JSON data retrieved is
+                                  stored in the context.
+                                properties:
+                                  jmesPath:
+                                    description: JMESPath is an optional JSON Match
+                                      Expression that can be used to transform the
+                                      JSON response returned from the API server.
+                                      For example a JMESPath of "items | length(@)"
+                                      applied to the API server response to the URLPath
+                                      "/apis/apps/v1/deployments" will return the
+                                      total count of deployments across all namespaces.
+                                    type: string
+                                  urlPath:
+                                    description: URLPath is the URL path to be used
+                                      in the HTTP GET request to the Kubernetes API
+                                      server (e.g. "/api/v1/namespaces" or  "/apis/apps/v1/deployments").
+                                      The format required is the same format used
+                                      by the `kubectl get --raw` command.
+                                    type: string
+                                required:
+                                - urlPath
+                                type: object
+                              configMap:
+                                description: ConfigMap is the ConfigMap reference.
+                                properties:
+                                  name:
+                                    description: Name is the ConfigMap name.
+                                    type: string
+                                  namespace:
+                                    description: Namespace is the ConfigMap namespace.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              imageRegistry:
+                                description: ImageRegistry defines requests to an
+                                  OCI/Docker V2 registry to fetch image details.
+                                properties:
+                                  jmesPath:
+                                    description: JMESPath is an optional JSON Match
+                                      Expression that can be used to transform the
+                                      ImageData struct returned as a result of processing
+                                      the image reference.
+                                    type: string
+                                  reference:
+                                    description: 'Reference is image reference to
+                                      a container image in the registry. Example:
+                                      ghcr.io/kyverno/kyverno:latest'
+                                    type: string
+                                required:
+                                - reference
+                                type: object
+                              name:
+                                description: Name is the variable name.
+                                type: string
+                              variable:
+                                description: Variable defines an arbitrary JMESPath
+                                  context variable that can be defined inline.
+                                properties:
+                                  default:
+                                    description: Default is an optional arbitrary
+                                      JSON object that the variable may take if the
+                                      JMESPath expression evaluates to nil
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  jmesPath:
+                                    description: JMESPath is an optional JMESPath
+                                      Expression that can be used to transform the
+                                      variable.
+                                    type: string
+                                  value:
+                                    description: Value is any arbitrary JSON object
+                                      representable in YAML or JSON form.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                            type: object
+                          type: array
+                        exclude:
+                          description: ExcludeResources defines when this policy rule
+                            should not be applied. The exclude criteria can include
+                            resource information (e.g. kind, name, namespace, labels)
+                            and admission review request information like the name
+                            or role.
+                          properties:
+                            all:
+                              description: All allows specifying resources which will
+                                be ANDed
+                              items:
+                                description: ResourceFilter allow users to "AND" or
+                                  "OR" between resources
+                                properties:
+                                  clusterRoles:
+                                    description: ClusterRoles is the list of cluster-wide
+                                      role names for the user.
+                                    items:
+                                      type: string
+                                    type: array
+                                  resources:
+                                    description: ResourceDescription contains information
+                                      about the resource being created or modified.
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations is a  map of annotations
+                                          (key-value pairs of type string). Annotation
+                                          keys and values support the wildcard characters
+                                          "*" (matches zero or many characters) and
+                                          "?" (matches at least one character).
+                                        type: object
+                                      kinds:
+                                        description: Kinds is a list of resource kinds.
+                                        items:
+                                          type: string
+                                        type: array
+                                      name:
+                                        description: 'Name is the name of the resource.
+                                          The name supports wildcard characters "*"
+                                          (matches zero or many characters) and "?"
+                                          (at least one character). NOTE: "Name" is
+                                          being deprecated in favor of "Names".'
+                                        type: string
+                                      names:
+                                        description: Names are the names of the resources.
+                                          Each name supports wildcard characters "*"
+                                          (matches zero or many characters) and "?"
+                                          (at least one character).
+                                        items:
+                                          type: string
+                                        type: array
+                                      namespaceSelector:
+                                        description: 'NamespaceSelector is a label
+                                          selector for the resource namespace. Label
+                                          keys and values in `matchLabels` support
+                                          the wildcard characters `*` (matches zero
+                                          or many characters) and `?` (matches one
+                                          character).Wildcards allows writing label
+                                          selectors like ["storage.k8s.io/*": "*"].
+                                          Note that using ["*" : "*"] matches any
+                                          key and value but does not match an empty
+                                          label set.'
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      namespaces:
+                                        description: Namespaces is a list of namespaces
+                                          names. Each name supports wildcard characters
+                                          "*" (matches zero or many characters) and
+                                          "?" (at least one character).
+                                        items:
+                                          type: string
+                                        type: array
+                                      selector:
+                                        description: 'Selector is a label selector.
+                                          Label keys and values in `matchLabels` support
+                                          the wildcard characters `*` (matches zero
+                                          or many characters) and `?` (matches one
+                                          character). Wildcards allows writing label
+                                          selectors like ["storage.k8s.io/*": "*"].
+                                          Note that using ["*" : "*"] matches any
+                                          key and value but does not match an empty
+                                          label set.'
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  roles:
+                                    description: Roles is the list of namespaced role
+                                      names for the user.
+                                    items:
+                                      type: string
+                                    type: array
+                                  subjects:
+                                    description: Subjects is the list of subject names
+                                      like users, user groups, and service accounts.
+                                    items:
+                                      description: Subject contains a reference to
+                                        the object or user identities a role binding
+                                        applies to.  This can either hold a direct
+                                        API object reference, or a value for non-objects
+                                        such as user and group names.
+                                      properties:
+                                        apiGroup:
+                                          description: APIGroup holds the API group
+                                            of the referenced subject. Defaults to
+                                            "" for ServiceAccount subjects. Defaults
+                                            to "rbac.authorization.k8s.io" for User
+                                            and Group subjects.
+                                          type: string
+                                        kind:
+                                          description: Kind of object being referenced.
+                                            Values defined by this API group are "User",
+                                            "Group", and "ServiceAccount". If the
+                                            Authorizer does not recognized the kind
+                                            value, the Authorizer should report an
+                                            error.
+                                          type: string
+                                        name:
+                                          description: Name of the object being referenced.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the referenced
+                                            object.  If the object kind is non-namespace,
+                                            such as "User" or "Group", and this value
+                                            is not empty the Authorizer should report
+                                            an error.
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    type: array
+                                type: object
+                              type: array
+                            any:
+                              description: Any allows specifying resources which will
+                                be ORed
+                              items:
+                                description: ResourceFilter allow users to "AND" or
+                                  "OR" between resources
+                                properties:
+                                  clusterRoles:
+                                    description: ClusterRoles is the list of cluster-wide
+                                      role names for the user.
+                                    items:
+                                      type: string
+                                    type: array
+                                  resources:
+                                    description: ResourceDescription contains information
+                                      about the resource being created or modified.
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations is a  map of annotations
+                                          (key-value pairs of type string). Annotation
+                                          keys and values support the wildcard characters
+                                          "*" (matches zero or many characters) and
+                                          "?" (matches at least one character).
+                                        type: object
+                                      kinds:
+                                        description: Kinds is a list of resource kinds.
+                                        items:
+                                          type: string
+                                        type: array
+                                      name:
+                                        description: 'Name is the name of the resource.
+                                          The name supports wildcard characters "*"
+                                          (matches zero or many characters) and "?"
+                                          (at least one character). NOTE: "Name" is
+                                          being deprecated in favor of "Names".'
+                                        type: string
+                                      names:
+                                        description: Names are the names of the resources.
+                                          Each name supports wildcard characters "*"
+                                          (matches zero or many characters) and "?"
+                                          (at least one character).
+                                        items:
+                                          type: string
+                                        type: array
+                                      namespaceSelector:
+                                        description: 'NamespaceSelector is a label
+                                          selector for the resource namespace. Label
+                                          keys and values in `matchLabels` support
+                                          the wildcard characters `*` (matches zero
+                                          or many characters) and `?` (matches one
+                                          character).Wildcards allows writing label
+                                          selectors like ["storage.k8s.io/*": "*"].
+                                          Note that using ["*" : "*"] matches any
+                                          key and value but does not match an empty
+                                          label set.'
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      namespaces:
+                                        description: Namespaces is a list of namespaces
+                                          names. Each name supports wildcard characters
+                                          "*" (matches zero or many characters) and
+                                          "?" (at least one character).
+                                        items:
+                                          type: string
+                                        type: array
+                                      selector:
+                                        description: 'Selector is a label selector.
+                                          Label keys and values in `matchLabels` support
+                                          the wildcard characters `*` (matches zero
+                                          or many characters) and `?` (matches one
+                                          character). Wildcards allows writing label
+                                          selectors like ["storage.k8s.io/*": "*"].
+                                          Note that using ["*" : "*"] matches any
+                                          key and value but does not match an empty
+                                          label set.'
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  roles:
+                                    description: Roles is the list of namespaced role
+                                      names for the user.
+                                    items:
+                                      type: string
+                                    type: array
+                                  subjects:
+                                    description: Subjects is the list of subject names
+                                      like users, user groups, and service accounts.
+                                    items:
+                                      description: Subject contains a reference to
+                                        the object or user identities a role binding
+                                        applies to.  This can either hold a direct
+                                        API object reference, or a value for non-objects
+                                        such as user and group names.
+                                      properties:
+                                        apiGroup:
+                                          description: APIGroup holds the API group
+                                            of the referenced subject. Defaults to
+                                            "" for ServiceAccount subjects. Defaults
+                                            to "rbac.authorization.k8s.io" for User
+                                            and Group subjects.
+                                          type: string
+                                        kind:
+                                          description: Kind of object being referenced.
+                                            Values defined by this API group are "User",
+                                            "Group", and "ServiceAccount". If the
+                                            Authorizer does not recognized the kind
+                                            value, the Authorizer should report an
+                                            error.
+                                          type: string
+                                        name:
+                                          description: Name of the object being referenced.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the referenced
+                                            object.  If the object kind is non-namespace,
+                                            such as "User" or "Group", and this value
+                                            is not empty the Authorizer should report
+                                            an error.
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    type: array
+                                type: object
+                              type: array
+                            clusterRoles:
+                              description: ClusterRoles is the list of cluster-wide
+                                role names for the user.
+                              items:
+                                type: string
+                              type: array
+                            resources:
+                              description: ResourceDescription contains information
+                                about the resource being created or modified. Requires
+                                at least one tag to be specified when under MatchResources.
+                                Specifying ResourceDescription directly under match
+                                is being deprecated. Please specify under "any" or
+                                "all" instead.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  description: Annotations is a  map of annotations
+                                    (key-value pairs of type string). Annotation keys
+                                    and values support the wildcard characters "*"
+                                    (matches zero or many characters) and "?" (matches
+                                    at least one character).
+                                  type: object
+                                kinds:
+                                  description: Kinds is a list of resource kinds.
+                                  items:
+                                    type: string
+                                  type: array
+                                name:
+                                  description: 'Name is the name of the resource.
+                                    The name supports wildcard characters "*" (matches
+                                    zero or many characters) and "?" (at least one
+                                    character). NOTE: "Name" is being deprecated in
+                                    favor of "Names".'
+                                  type: string
+                                names:
+                                  description: Names are the names of the resources.
+                                    Each name supports wildcard characters "*" (matches
+                                    zero or many characters) and "?" (at least one
+                                    character).
+                                  items:
+                                    type: string
+                                  type: array
+                                namespaceSelector:
+                                  description: 'NamespaceSelector is a label selector
+                                    for the resource namespace. Label keys and values
+                                    in `matchLabels` support the wildcard characters
+                                    `*` (matches zero or many characters) and `?`
+                                    (matches one character).Wildcards allows writing
+                                    label selectors like ["storage.k8s.io/*": "*"].
+                                    Note that using ["*" : "*"] matches any key and
+                                    value but does not match an empty label set.'
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: Namespaces is a list of namespaces
+                                    names. Each name supports wildcard characters
+                                    "*" (matches zero or many characters) and "?"
+                                    (at least one character).
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: 'Selector is a label selector. Label
+                                    keys and values in `matchLabels` support the wildcard
+                                    characters `*` (matches zero or many characters)
+                                    and `?` (matches one character). Wildcards allows
+                                    writing label selectors like ["storage.k8s.io/*":
+                                    "*"]. Note that using ["*" : "*"] matches any
+                                    key and value but does not match an empty label
+                                    set.'
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            roles:
+                              description: Roles is the list of namespaced role names
+                                for the user.
+                              items:
+                                type: string
+                              type: array
+                            subjects:
+                              description: Subjects is the list of subject names like
+                                users, user groups, and service accounts.
+                              items:
+                                description: Subject contains a reference to the object
+                                  or user identities a role binding applies to.  This
+                                  can either hold a direct API object reference, or
+                                  a value for non-objects such as user and group names.
+                                properties:
+                                  apiGroup:
+                                    description: APIGroup holds the API group of the
+                                      referenced subject. Defaults to "" for ServiceAccount
+                                      subjects. Defaults to "rbac.authorization.k8s.io"
+                                      for User and Group subjects.
+                                    type: string
+                                  kind:
+                                    description: Kind of object being referenced.
+                                      Values defined by this API group are "User",
+                                      "Group", and "ServiceAccount". If the Authorizer
+                                      does not recognized the kind value, the Authorizer
+                                      should report an error.
+                                    type: string
+                                  name:
+                                    description: Name of the object being referenced.
+                                    type: string
+                                  namespace:
+                                    description: Namespace of the referenced object.  If
+                                      the object kind is non-namespace, such as "User"
+                                      or "Group", and this value is not empty the
+                                      Authorizer should report an error.
+                                    type: string
+                                required:
+                                - kind
+                                - name
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              type: array
+                          type: object
+                        generate:
+                          description: Generation is used to create new resources.
+                          properties:
+                            apiVersion:
+                              description: APIVersion specifies resource apiVersion.
+                              type: string
+                            clone:
+                              description: Clone specifies the source resource used
+                                to populate each generated resource. At most one of
+                                Data or Clone can be specified. If neither are provided,
+                                the generated resource will be created with default
+                                data only.
+                              properties:
+                                name:
+                                  description: Name specifies name of the resource.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies source resource
+                                    namespace.
+                                  type: string
+                              type: object
+                            cloneList:
+                              description: CloneList specifies the list of source
+                                resource used to populate each generated resource.
+                              properties:
+                                kinds:
+                                  description: Kinds is a list of resource kinds.
+                                  items:
+                                    type: string
+                                  type: array
+                                namespace:
+                                  description: Namespace specifies source resource
+                                    namespace.
+                                  type: string
+                                selector:
+                                  description: Selector is a label selector. Label
+                                    keys and values in `matchLabels`. wildcard characters
+                                    are not supported.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            data:
+                              description: Data provides the resource declaration
+                                used to populate each generated resource. At most
+                                one of Data or Clone must be specified. If neither
+                                are provided, the generated resource will be created
+                                with default data only.
+                              x-kubernetes-preserve-unknown-fields: true
+                            kind:
+                              description: Kind specifies resource kind.
+                              type: string
+                            name:
+                              description: Name specifies the resource name.
+                              type: string
+                            namespace:
+                              description: Namespace specifies resource namespace.
+                              type: string
+                            synchronize:
+                              description: Synchronize controls if generated resources
+                                should be kept in-sync with their source resource.
+                                If Synchronize is set to "true" changes to generated
+                                resources will be overwritten with resource data from
+                                Data or the resource specified in the Clone declaration.
+                                Optional. Defaults to "false" if not specified.
+                              type: boolean
+                          type: object
+                        imageExtractors:
+                          additionalProperties:
+                            items:
+                              properties:
+                                key:
+                                  description: Key is an optional name of the field
+                                    within 'path' that will be used to uniquely identify
+                                    an image. Note - this field MUST be unique.
+                                  type: string
+                                name:
+                                  description: Name is the entry the image will be
+                                    available under 'images.<name>' in the context.
+                                    If this field is not defined, image entries will
+                                    appear under 'images.custom'.
+                                  type: string
+                                path:
+                                  description: Path is the path to the object containing
+                                    the image field in a custom resource. It should
+                                    be slash-separated. Each slash-separated key must
+                                    be a valid YAML key or a wildcard '*'. Wildcard
+                                    keys are expanded in case of arrays or objects.
+                                  type: string
+                                value:
+                                  description: Value is an optional name of the field
+                                    within 'path' that points to the image URI. This
+                                    is useful when a custom 'key' is also defined.
+                                  type: string
+                              required:
+                              - path
+                              type: object
+                            type: array
+                          description: ImageExtractors defines a mapping from kinds
+                            to ImageExtractorConfigs. This config is only valid for
+                            verifyImages rules.
+                          type: object
+                        match:
+                          description: MatchResources defines when this policy rule
+                            should be applied. The match criteria can include resource
+                            information (e.g. kind, name, namespace, labels) and admission
+                            review request information like the user name or role.
+                            At least one kind is required.
+                          properties:
+                            all:
+                              description: All allows specifying resources which will
+                                be ANDed
+                              items:
+                                description: ResourceFilter allow users to "AND" or
+                                  "OR" between resources
+                                properties:
+                                  clusterRoles:
+                                    description: ClusterRoles is the list of cluster-wide
+                                      role names for the user.
+                                    items:
+                                      type: string
+                                    type: array
+                                  resources:
+                                    description: ResourceDescription contains information
+                                      about the resource being created or modified.
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations is a  map of annotations
+                                          (key-value pairs of type string). Annotation
+                                          keys and values support the wildcard characters
+                                          "*" (matches zero or many characters) and
+                                          "?" (matches at least one character).
+                                        type: object
+                                      kinds:
+                                        description: Kinds is a list of resource kinds.
+                                        items:
+                                          type: string
+                                        type: array
+                                      name:
+                                        description: 'Name is the name of the resource.
+                                          The name supports wildcard characters "*"
+                                          (matches zero or many characters) and "?"
+                                          (at least one character). NOTE: "Name" is
+                                          being deprecated in favor of "Names".'
+                                        type: string
+                                      names:
+                                        description: Names are the names of the resources.
+                                          Each name supports wildcard characters "*"
+                                          (matches zero or many characters) and "?"
+                                          (at least one character).
+                                        items:
+                                          type: string
+                                        type: array
+                                      namespaceSelector:
+                                        description: 'NamespaceSelector is a label
+                                          selector for the resource namespace. Label
+                                          keys and values in `matchLabels` support
+                                          the wildcard characters `*` (matches zero
+                                          or many characters) and `?` (matches one
+                                          character).Wildcards allows writing label
+                                          selectors like ["storage.k8s.io/*": "*"].
+                                          Note that using ["*" : "*"] matches any
+                                          key and value but does not match an empty
+                                          label set.'
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      namespaces:
+                                        description: Namespaces is a list of namespaces
+                                          names. Each name supports wildcard characters
+                                          "*" (matches zero or many characters) and
+                                          "?" (at least one character).
+                                        items:
+                                          type: string
+                                        type: array
+                                      selector:
+                                        description: 'Selector is a label selector.
+                                          Label keys and values in `matchLabels` support
+                                          the wildcard characters `*` (matches zero
+                                          or many characters) and `?` (matches one
+                                          character). Wildcards allows writing label
+                                          selectors like ["storage.k8s.io/*": "*"].
+                                          Note that using ["*" : "*"] matches any
+                                          key and value but does not match an empty
+                                          label set.'
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  roles:
+                                    description: Roles is the list of namespaced role
+                                      names for the user.
+                                    items:
+                                      type: string
+                                    type: array
+                                  subjects:
+                                    description: Subjects is the list of subject names
+                                      like users, user groups, and service accounts.
+                                    items:
+                                      description: Subject contains a reference to
+                                        the object or user identities a role binding
+                                        applies to.  This can either hold a direct
+                                        API object reference, or a value for non-objects
+                                        such as user and group names.
+                                      properties:
+                                        apiGroup:
+                                          description: APIGroup holds the API group
+                                            of the referenced subject. Defaults to
+                                            "" for ServiceAccount subjects. Defaults
+                                            to "rbac.authorization.k8s.io" for User
+                                            and Group subjects.
+                                          type: string
+                                        kind:
+                                          description: Kind of object being referenced.
+                                            Values defined by this API group are "User",
+                                            "Group", and "ServiceAccount". If the
+                                            Authorizer does not recognized the kind
+                                            value, the Authorizer should report an
+                                            error.
+                                          type: string
+                                        name:
+                                          description: Name of the object being referenced.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the referenced
+                                            object.  If the object kind is non-namespace,
+                                            such as "User" or "Group", and this value
+                                            is not empty the Authorizer should report
+                                            an error.
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    type: array
+                                type: object
+                              type: array
+                            any:
+                              description: Any allows specifying resources which will
+                                be ORed
+                              items:
+                                description: ResourceFilter allow users to "AND" or
+                                  "OR" between resources
+                                properties:
+                                  clusterRoles:
+                                    description: ClusterRoles is the list of cluster-wide
+                                      role names for the user.
+                                    items:
+                                      type: string
+                                    type: array
+                                  resources:
+                                    description: ResourceDescription contains information
+                                      about the resource being created or modified.
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations is a  map of annotations
+                                          (key-value pairs of type string). Annotation
+                                          keys and values support the wildcard characters
+                                          "*" (matches zero or many characters) and
+                                          "?" (matches at least one character).
+                                        type: object
+                                      kinds:
+                                        description: Kinds is a list of resource kinds.
+                                        items:
+                                          type: string
+                                        type: array
+                                      name:
+                                        description: 'Name is the name of the resource.
+                                          The name supports wildcard characters "*"
+                                          (matches zero or many characters) and "?"
+                                          (at least one character). NOTE: "Name" is
+                                          being deprecated in favor of "Names".'
+                                        type: string
+                                      names:
+                                        description: Names are the names of the resources.
+                                          Each name supports wildcard characters "*"
+                                          (matches zero or many characters) and "?"
+                                          (at least one character).
+                                        items:
+                                          type: string
+                                        type: array
+                                      namespaceSelector:
+                                        description: 'NamespaceSelector is a label
+                                          selector for the resource namespace. Label
+                                          keys and values in `matchLabels` support
+                                          the wildcard characters `*` (matches zero
+                                          or many characters) and `?` (matches one
+                                          character).Wildcards allows writing label
+                                          selectors like ["storage.k8s.io/*": "*"].
+                                          Note that using ["*" : "*"] matches any
+                                          key and value but does not match an empty
+                                          label set.'
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      namespaces:
+                                        description: Namespaces is a list of namespaces
+                                          names. Each name supports wildcard characters
+                                          "*" (matches zero or many characters) and
+                                          "?" (at least one character).
+                                        items:
+                                          type: string
+                                        type: array
+                                      selector:
+                                        description: 'Selector is a label selector.
+                                          Label keys and values in `matchLabels` support
+                                          the wildcard characters `*` (matches zero
+                                          or many characters) and `?` (matches one
+                                          character). Wildcards allows writing label
+                                          selectors like ["storage.k8s.io/*": "*"].
+                                          Note that using ["*" : "*"] matches any
+                                          key and value but does not match an empty
+                                          label set.'
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  roles:
+                                    description: Roles is the list of namespaced role
+                                      names for the user.
+                                    items:
+                                      type: string
+                                    type: array
+                                  subjects:
+                                    description: Subjects is the list of subject names
+                                      like users, user groups, and service accounts.
+                                    items:
+                                      description: Subject contains a reference to
+                                        the object or user identities a role binding
+                                        applies to.  This can either hold a direct
+                                        API object reference, or a value for non-objects
+                                        such as user and group names.
+                                      properties:
+                                        apiGroup:
+                                          description: APIGroup holds the API group
+                                            of the referenced subject. Defaults to
+                                            "" for ServiceAccount subjects. Defaults
+                                            to "rbac.authorization.k8s.io" for User
+                                            and Group subjects.
+                                          type: string
+                                        kind:
+                                          description: Kind of object being referenced.
+                                            Values defined by this API group are "User",
+                                            "Group", and "ServiceAccount". If the
+                                            Authorizer does not recognized the kind
+                                            value, the Authorizer should report an
+                                            error.
+                                          type: string
+                                        name:
+                                          description: Name of the object being referenced.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the referenced
+                                            object.  If the object kind is non-namespace,
+                                            such as "User" or "Group", and this value
+                                            is not empty the Authorizer should report
+                                            an error.
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    type: array
+                                type: object
+                              type: array
+                            clusterRoles:
+                              description: ClusterRoles is the list of cluster-wide
+                                role names for the user.
+                              items:
+                                type: string
+                              type: array
+                            resources:
+                              description: ResourceDescription contains information
+                                about the resource being created or modified. Requires
+                                at least one tag to be specified when under MatchResources.
+                                Specifying ResourceDescription directly under match
+                                is being deprecated. Please specify under "any" or
+                                "all" instead.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  description: Annotations is a  map of annotations
+                                    (key-value pairs of type string). Annotation keys
+                                    and values support the wildcard characters "*"
+                                    (matches zero or many characters) and "?" (matches
+                                    at least one character).
+                                  type: object
+                                kinds:
+                                  description: Kinds is a list of resource kinds.
+                                  items:
+                                    type: string
+                                  type: array
+                                name:
+                                  description: 'Name is the name of the resource.
+                                    The name supports wildcard characters "*" (matches
+                                    zero or many characters) and "?" (at least one
+                                    character). NOTE: "Name" is being deprecated in
+                                    favor of "Names".'
+                                  type: string
+                                names:
+                                  description: Names are the names of the resources.
+                                    Each name supports wildcard characters "*" (matches
+                                    zero or many characters) and "?" (at least one
+                                    character).
+                                  items:
+                                    type: string
+                                  type: array
+                                namespaceSelector:
+                                  description: 'NamespaceSelector is a label selector
+                                    for the resource namespace. Label keys and values
+                                    in `matchLabels` support the wildcard characters
+                                    `*` (matches zero or many characters) and `?`
+                                    (matches one character).Wildcards allows writing
+                                    label selectors like ["storage.k8s.io/*": "*"].
+                                    Note that using ["*" : "*"] matches any key and
+                                    value but does not match an empty label set.'
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: Namespaces is a list of namespaces
+                                    names. Each name supports wildcard characters
+                                    "*" (matches zero or many characters) and "?"
+                                    (at least one character).
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: 'Selector is a label selector. Label
+                                    keys and values in `matchLabels` support the wildcard
+                                    characters `*` (matches zero or many characters)
+                                    and `?` (matches one character). Wildcards allows
+                                    writing label selectors like ["storage.k8s.io/*":
+                                    "*"]. Note that using ["*" : "*"] matches any
+                                    key and value but does not match an empty label
+                                    set.'
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            roles:
+                              description: Roles is the list of namespaced role names
+                                for the user.
+                              items:
+                                type: string
+                              type: array
+                            subjects:
+                              description: Subjects is the list of subject names like
+                                users, user groups, and service accounts.
+                              items:
+                                description: Subject contains a reference to the object
+                                  or user identities a role binding applies to.  This
+                                  can either hold a direct API object reference, or
+                                  a value for non-objects such as user and group names.
+                                properties:
+                                  apiGroup:
+                                    description: APIGroup holds the API group of the
+                                      referenced subject. Defaults to "" for ServiceAccount
+                                      subjects. Defaults to "rbac.authorization.k8s.io"
+                                      for User and Group subjects.
+                                    type: string
+                                  kind:
+                                    description: Kind of object being referenced.
+                                      Values defined by this API group are "User",
+                                      "Group", and "ServiceAccount". If the Authorizer
+                                      does not recognized the kind value, the Authorizer
+                                      should report an error.
+                                    type: string
+                                  name:
+                                    description: Name of the object being referenced.
+                                    type: string
+                                  namespace:
+                                    description: Namespace of the referenced object.  If
+                                      the object kind is non-namespace, such as "User"
+                                      or "Group", and this value is not empty the
+                                      Authorizer should report an error.
+                                    type: string
+                                required:
+                                - kind
+                                - name
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              type: array
+                          type: object
+                        mutate:
+                          description: Mutation is used to modify matching resources.
+                          properties:
+                            foreach:
+                              description: ForEach applies mutation rules to a list
+                                of sub-elements by creating a context for each entry
+                                in the list and looping over it to apply the specified
+                                logic.
+                              items:
+                                description: ForEach applies mutation rules to a list
+                                  of sub-elements by creating a context for each entry
+                                  in the list and looping over it to apply the specified
+                                  logic.
+                                properties:
+                                  context:
+                                    description: Context defines variables and data
+                                      sources that can be used during rule execution.
+                                    items:
+                                      description: ContextEntry adds variables and
+                                        data sources to a rule Context. Either a ConfigMap
+                                        reference or a APILookup must be provided.
+                                      properties:
+                                        apiCall:
+                                          description: APICall defines an HTTP request
+                                            to the Kubernetes API server. The JSON
+                                            data retrieved is stored in the context.
+                                          properties:
+                                            jmesPath:
+                                              description: JMESPath is an optional
+                                                JSON Match Expression that can be
+                                                used to transform the JSON response
+                                                returned from the API server. For
+                                                example a JMESPath of "items | length(@)"
+                                                applied to the API server response
+                                                to the URLPath "/apis/apps/v1/deployments"
+                                                will return the total count of deployments
+                                                across all namespaces.
+                                              type: string
+                                            urlPath:
+                                              description: URLPath is the URL path
+                                                to be used in the HTTP GET request
+                                                to the Kubernetes API server (e.g.
+                                                "/api/v1/namespaces" or  "/apis/apps/v1/deployments").
+                                                The format required is the same format
+                                                used by the `kubectl get --raw` command.
+                                              type: string
+                                          required:
+                                          - urlPath
+                                          type: object
+                                        configMap:
+                                          description: ConfigMap is the ConfigMap
+                                            reference.
+                                          properties:
+                                            name:
+                                              description: Name is the ConfigMap name.
+                                              type: string
+                                            namespace:
+                                              description: Namespace is the ConfigMap
+                                                namespace.
+                                              type: string
+                                          required:
+                                          - name
+                                          type: object
+                                        imageRegistry:
+                                          description: ImageRegistry defines requests
+                                            to an OCI/Docker V2 registry to fetch
+                                            image details.
+                                          properties:
+                                            jmesPath:
+                                              description: JMESPath is an optional
+                                                JSON Match Expression that can be
+                                                used to transform the ImageData struct
+                                                returned as a result of processing
+                                                the image reference.
+                                              type: string
+                                            reference:
+                                              description: 'Reference is image reference
+                                                to a container image in the registry.
+                                                Example: ghcr.io/kyverno/kyverno:latest'
+                                              type: string
+                                          required:
+                                          - reference
+                                          type: object
+                                        name:
+                                          description: Name is the variable name.
+                                          type: string
+                                        variable:
+                                          description: Variable defines an arbitrary
+                                            JMESPath context variable that can be
+                                            defined inline.
+                                          properties:
+                                            default:
+                                              description: Default is an optional
+                                                arbitrary JSON object that the variable
+                                                may take if the JMESPath expression
+                                                evaluates to nil
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            jmesPath:
+                                              description: JMESPath is an optional
+                                                JMESPath Expression that can be used
+                                                to transform the variable.
+                                              type: string
+                                            value:
+                                              description: Value is any arbitrary
+                                                JSON object representable in YAML
+                                                or JSON form.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                      type: object
+                                    type: array
+                                  list:
+                                    description: List specifies a JMESPath expression
+                                      that results in one or more elements to which
+                                      the validation logic is applied.
+                                    type: string
+                                  patchStrategicMerge:
+                                    description: PatchStrategicMerge is a strategic
+                                      merge patch used to modify resources. See https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/
+                                      and https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  patchesJson6902:
+                                    description: PatchesJSON6902 is a list of RFC
+                                      6902 JSON Patch declarations used to modify
+                                      resources. See https://tools.ietf.org/html/rfc6902
+                                      and https://kubectl.docs.kubernetes.io/references/kustomize/patchesjson6902/.
+                                    type: string
+                                  preconditions:
+                                    description: 'AnyAllConditions are used to determine
+                                      if a policy rule should be applied by evaluating
+                                      a set of conditions. The declaration can contain
+                                      nested `any` or `all` statements. See: https://kyverno.io/docs/writing-policies/preconditions/'
+                                    properties:
+                                      all:
+                                        description: AllConditions enable variable-based
+                                          conditional rule execution. This is useful
+                                          for finer control of when an rule is applied.
+                                          A condition can reference object data using
+                                          JMESPath notation. Here, all of the conditions
+                                          need to pass
+                                        items:
+                                          description: Condition defines variable-based
+                                            conditional criteria for rule execution.
+                                          properties:
+                                            key:
+                                              description: Key is the context entry
+                                                (using JMESPath) for conditional rule
+                                                evaluation.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            operator:
+                                              description: 'Operator is the conditional
+                                                operation to perform. Valid operators
+                                                are: Equals, NotEquals, In, AnyIn,
+                                                AllIn, NotIn, AnyNotIn, AllNotIn,
+                                                GreaterThanOrEquals, GreaterThan,
+                                                LessThanOrEquals, LessThan, DurationGreaterThanOrEquals,
+                                                DurationGreaterThan, DurationLessThanOrEquals,
+                                                DurationLessThan'
+                                              enum:
+                                              - Equals
+                                              - NotEquals
+                                              - In
+                                              - AnyIn
+                                              - AllIn
+                                              - NotIn
+                                              - AnyNotIn
+                                              - AllNotIn
+                                              - GreaterThanOrEquals
+                                              - GreaterThan
+                                              - LessThanOrEquals
+                                              - LessThan
+                                              - DurationGreaterThanOrEquals
+                                              - DurationGreaterThan
+                                              - DurationLessThanOrEquals
+                                              - DurationLessThan
+                                              type: string
+                                            value:
+                                              description: Value is the conditional
+                                                value, or set of values. The values
+                                                can be fixed set or can be variables
+                                                declared using JMESPath.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                        type: array
+                                      any:
+                                        description: AnyConditions enable variable-based
+                                          conditional rule execution. This is useful
+                                          for finer control of when an rule is applied.
+                                          A condition can reference object data using
+                                          JMESPath notation. Here, at least one of
+                                          the conditions need to pass
+                                        items:
+                                          description: Condition defines variable-based
+                                            conditional criteria for rule execution.
+                                          properties:
+                                            key:
+                                              description: Key is the context entry
+                                                (using JMESPath) for conditional rule
+                                                evaluation.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            operator:
+                                              description: 'Operator is the conditional
+                                                operation to perform. Valid operators
+                                                are: Equals, NotEquals, In, AnyIn,
+                                                AllIn, NotIn, AnyNotIn, AllNotIn,
+                                                GreaterThanOrEquals, GreaterThan,
+                                                LessThanOrEquals, LessThan, DurationGreaterThanOrEquals,
+                                                DurationGreaterThan, DurationLessThanOrEquals,
+                                                DurationLessThan'
+                                              enum:
+                                              - Equals
+                                              - NotEquals
+                                              - In
+                                              - AnyIn
+                                              - AllIn
+                                              - NotIn
+                                              - AnyNotIn
+                                              - AllNotIn
+                                              - GreaterThanOrEquals
+                                              - GreaterThan
+                                              - LessThanOrEquals
+                                              - LessThan
+                                              - DurationGreaterThanOrEquals
+                                              - DurationGreaterThan
+                                              - DurationLessThanOrEquals
+                                              - DurationLessThan
+                                              type: string
+                                            value:
+                                              description: Value is the conditional
+                                                value, or set of values. The values
+                                                can be fixed set or can be variables
+                                                declared using JMESPath.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                        type: array
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              type: array
+                            patchStrategicMerge:
+                              description: PatchStrategicMerge is a strategic merge
+                                patch used to modify resources. See https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/
+                                and https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.
+                              x-kubernetes-preserve-unknown-fields: true
+                            patchesJson6902:
+                              description: PatchesJSON6902 is a list of RFC 6902 JSON
+                                Patch declarations used to modify resources. See https://tools.ietf.org/html/rfc6902
+                                and https://kubectl.docs.kubernetes.io/references/kustomize/patchesjson6902/.
+                              type: string
+                            targets:
+                              description: Targets defines the target resources to
+                                be mutated.
+                              items:
+                                properties:
+                                  apiVersion:
+                                    description: APIVersion specifies resource apiVersion.
+                                    type: string
+                                  kind:
+                                    description: Kind specifies resource kind.
+                                    type: string
+                                  name:
+                                    description: Name specifies the resource name.
+                                    type: string
+                                  namespace:
+                                    description: Namespace specifies resource namespace.
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        name:
+                          description: Name is a label to identify the rule, It must
+                            be unique within the policy.
+                          maxLength: 63
+                          type: string
+                        preconditions:
+                          description: 'Preconditions are used to determine if a policy
+                            rule should be applied by evaluating a set of conditions.
+                            The declaration can contain nested `any` or `all` statements.
+                            A direct list of conditions (without `any` or `all` statements
+                            is supported for backwards compatibility but will be deprecated
+                            in the next major release. See: https://kyverno.io/docs/writing-policies/preconditions/'
+                          x-kubernetes-preserve-unknown-fields: true
+                        validate:
+                          description: Validation is used to validate matching resources.
+                          properties:
+                            anyPattern:
+                              description: AnyPattern specifies list of validation
+                                patterns. At least one of the patterns must be satisfied
+                                for the validation rule to succeed.
+                              x-kubernetes-preserve-unknown-fields: true
+                            deny:
+                              description: Deny defines conditions used to pass or
+                                fail a validation rule.
+                              properties:
+                                conditions:
+                                  description: 'Multiple conditions can be declared
+                                    under an `any` or `all` statement. A direct list
+                                    of conditions (without `any` or `all` statements)
+                                    is also supported for backwards compatibility
+                                    but will be deprecated in the next major release.
+                                    See: https://kyverno.io/docs/writing-policies/validate/#deny-rules'
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            foreach:
+                              description: ForEach applies validate rules to a list
+                                of sub-elements by creating a context for each entry
+                                in the list and looping over it to apply the specified
+                                logic.
+                              items:
+                                description: ForEach applies validate rules to a list
+                                  of sub-elements by creating a context for each entry
+                                  in the list and looping over it to apply the specified
+                                  logic.
+                                properties:
+                                  anyPattern:
+                                    description: AnyPattern specifies list of validation
+                                      patterns. At least one of the patterns must
+                                      be satisfied for the validation rule to succeed.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  context:
+                                    description: Context defines variables and data
+                                      sources that can be used during rule execution.
+                                    items:
+                                      description: ContextEntry adds variables and
+                                        data sources to a rule Context. Either a ConfigMap
+                                        reference or a APILookup must be provided.
+                                      properties:
+                                        apiCall:
+                                          description: APICall defines an HTTP request
+                                            to the Kubernetes API server. The JSON
+                                            data retrieved is stored in the context.
+                                          properties:
+                                            jmesPath:
+                                              description: JMESPath is an optional
+                                                JSON Match Expression that can be
+                                                used to transform the JSON response
+                                                returned from the API server. For
+                                                example a JMESPath of "items | length(@)"
+                                                applied to the API server response
+                                                to the URLPath "/apis/apps/v1/deployments"
+                                                will return the total count of deployments
+                                                across all namespaces.
+                                              type: string
+                                            urlPath:
+                                              description: URLPath is the URL path
+                                                to be used in the HTTP GET request
+                                                to the Kubernetes API server (e.g.
+                                                "/api/v1/namespaces" or  "/apis/apps/v1/deployments").
+                                                The format required is the same format
+                                                used by the `kubectl get --raw` command.
+                                              type: string
+                                          required:
+                                          - urlPath
+                                          type: object
+                                        configMap:
+                                          description: ConfigMap is the ConfigMap
+                                            reference.
+                                          properties:
+                                            name:
+                                              description: Name is the ConfigMap name.
+                                              type: string
+                                            namespace:
+                                              description: Namespace is the ConfigMap
+                                                namespace.
+                                              type: string
+                                          required:
+                                          - name
+                                          type: object
+                                        imageRegistry:
+                                          description: ImageRegistry defines requests
+                                            to an OCI/Docker V2 registry to fetch
+                                            image details.
+                                          properties:
+                                            jmesPath:
+                                              description: JMESPath is an optional
+                                                JSON Match Expression that can be
+                                                used to transform the ImageData struct
+                                                returned as a result of processing
+                                                the image reference.
+                                              type: string
+                                            reference:
+                                              description: 'Reference is image reference
+                                                to a container image in the registry.
+                                                Example: ghcr.io/kyverno/kyverno:latest'
+                                              type: string
+                                          required:
+                                          - reference
+                                          type: object
+                                        name:
+                                          description: Name is the variable name.
+                                          type: string
+                                        variable:
+                                          description: Variable defines an arbitrary
+                                            JMESPath context variable that can be
+                                            defined inline.
+                                          properties:
+                                            default:
+                                              description: Default is an optional
+                                                arbitrary JSON object that the variable
+                                                may take if the JMESPath expression
+                                                evaluates to nil
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            jmesPath:
+                                              description: JMESPath is an optional
+                                                JMESPath Expression that can be used
+                                                to transform the variable.
+                                              type: string
+                                            value:
+                                              description: Value is any arbitrary
+                                                JSON object representable in YAML
+                                                or JSON form.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                      type: object
+                                    type: array
+                                  deny:
+                                    description: Deny defines conditions used to pass
+                                      or fail a validation rule.
+                                    properties:
+                                      conditions:
+                                        description: 'Multiple conditions can be declared
+                                          under an `any` or `all` statement. A direct
+                                          list of conditions (without `any` or `all`
+                                          statements) is also supported for backwards
+                                          compatibility but will be deprecated in
+                                          the next major release. See: https://kyverno.io/docs/writing-policies/validate/#deny-rules'
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                  elementScope:
+                                    description: ElementScope specifies whether to
+                                      use the current list element as the scope for
+                                      validation. Defaults to "true" if not specified.
+                                      When set to "false", "request.object" is used
+                                      as the validation scope within the foreach block
+                                      to allow referencing other elements in the subtree.
+                                    type: boolean
+                                  list:
+                                    description: List specifies a JMESPath expression
+                                      that results in one or more elements to which
+                                      the validation logic is applied.
+                                    type: string
+                                  pattern:
+                                    description: Pattern specifies an overlay-style
+                                      pattern used to check resources.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  preconditions:
+                                    description: 'AnyAllConditions are used to determine
+                                      if a policy rule should be applied by evaluating
+                                      a set of conditions. The declaration can contain
+                                      nested `any` or `all` statements. See: https://kyverno.io/docs/writing-policies/preconditions/'
+                                    properties:
+                                      all:
+                                        description: AllConditions enable variable-based
+                                          conditional rule execution. This is useful
+                                          for finer control of when an rule is applied.
+                                          A condition can reference object data using
+                                          JMESPath notation. Here, all of the conditions
+                                          need to pass
+                                        items:
+                                          description: Condition defines variable-based
+                                            conditional criteria for rule execution.
+                                          properties:
+                                            key:
+                                              description: Key is the context entry
+                                                (using JMESPath) for conditional rule
+                                                evaluation.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            operator:
+                                              description: 'Operator is the conditional
+                                                operation to perform. Valid operators
+                                                are: Equals, NotEquals, In, AnyIn,
+                                                AllIn, NotIn, AnyNotIn, AllNotIn,
+                                                GreaterThanOrEquals, GreaterThan,
+                                                LessThanOrEquals, LessThan, DurationGreaterThanOrEquals,
+                                                DurationGreaterThan, DurationLessThanOrEquals,
+                                                DurationLessThan'
+                                              enum:
+                                              - Equals
+                                              - NotEquals
+                                              - In
+                                              - AnyIn
+                                              - AllIn
+                                              - NotIn
+                                              - AnyNotIn
+                                              - AllNotIn
+                                              - GreaterThanOrEquals
+                                              - GreaterThan
+                                              - LessThanOrEquals
+                                              - LessThan
+                                              - DurationGreaterThanOrEquals
+                                              - DurationGreaterThan
+                                              - DurationLessThanOrEquals
+                                              - DurationLessThan
+                                              type: string
+                                            value:
+                                              description: Value is the conditional
+                                                value, or set of values. The values
+                                                can be fixed set or can be variables
+                                                declared using JMESPath.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                        type: array
+                                      any:
+                                        description: AnyConditions enable variable-based
+                                          conditional rule execution. This is useful
+                                          for finer control of when an rule is applied.
+                                          A condition can reference object data using
+                                          JMESPath notation. Here, at least one of
+                                          the conditions need to pass
+                                        items:
+                                          description: Condition defines variable-based
+                                            conditional criteria for rule execution.
+                                          properties:
+                                            key:
+                                              description: Key is the context entry
+                                                (using JMESPath) for conditional rule
+                                                evaluation.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            operator:
+                                              description: 'Operator is the conditional
+                                                operation to perform. Valid operators
+                                                are: Equals, NotEquals, In, AnyIn,
+                                                AllIn, NotIn, AnyNotIn, AllNotIn,
+                                                GreaterThanOrEquals, GreaterThan,
+                                                LessThanOrEquals, LessThan, DurationGreaterThanOrEquals,
+                                                DurationGreaterThan, DurationLessThanOrEquals,
+                                                DurationLessThan'
+                                              enum:
+                                              - Equals
+                                              - NotEquals
+                                              - In
+                                              - AnyIn
+                                              - AllIn
+                                              - NotIn
+                                              - AnyNotIn
+                                              - AllNotIn
+                                              - GreaterThanOrEquals
+                                              - GreaterThan
+                                              - LessThanOrEquals
+                                              - LessThan
+                                              - DurationGreaterThanOrEquals
+                                              - DurationGreaterThan
+                                              - DurationLessThanOrEquals
+                                              - DurationLessThan
+                                              type: string
+                                            value:
+                                              description: Value is the conditional
+                                                value, or set of values. The values
+                                                can be fixed set or can be variables
+                                                declared using JMESPath.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                        type: array
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              type: array
+                            manifests:
+                              description: Manifest specifies conditions for manifest
+                                verification
+                              properties:
+                                annotationDomain:
+                                  description: AnnotationDomain is custom domain of
+                                    annotation for message and signature. Default
+                                    is "cosign.sigstore.dev".
+                                  type: string
+                                attestors:
+                                  description: Attestors specified the required attestors
+                                    (i.e. authorities)
+                                  items:
+                                    properties:
+                                      count:
+                                        description: Count specifies the required
+                                          number of entries that must match. If the
+                                          count is null, all entries must match (a
+                                          logical AND). If the count is 1, at least
+                                          one entry must match (a logical OR). If
+                                          the count contains a value N, then N must
+                                          be less than or equal to the size of entries,
+                                          and at least N entries must match.
+                                        minimum: 1
+                                        type: integer
+                                      entries:
+                                        description: Entries contains the available
+                                          attestors. An attestor can be a static key,
+                                          attributes for keyless verification, or
+                                          a nested attestor declaration.
+                                        items:
+                                          properties:
+                                            annotations:
+                                              additionalProperties:
+                                                type: string
+                                              description: Annotations are used for
+                                                image verification. Every specified
+                                                key-value pair must exist and match
+                                                in the verified payload. The payload
+                                                may contain other key-value pairs.
+                                              type: object
+                                            attestor:
+                                              description: Attestor is a nested AttestorSet
+                                                used to specify a more complex set
+                                                of match authorities
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            certificates:
+                                              description: Certificates specifies
+                                                one or more certificates
+                                              properties:
+                                                cert:
+                                                  description: Certificate is an optional
+                                                    PEM encoded public certificate.
+                                                  type: string
+                                                certChain:
+                                                  description: CertificateChain is
+                                                    an optional PEM encoded set of
+                                                    certificates used to verify
+                                                  type: string
+                                                rekor:
+                                                  description: Rekor provides configuration
+                                                    for the Rekor transparency log
+                                                    service. If the value is nil,
+                                                    Rekor is not checked. If an empty
+                                                    object is provided the public
+                                                    instance of Rekor (https://rekor.sigstore.dev)
+                                                    is used.
+                                                  properties:
+                                                    url:
+                                                      description: URL is the address
+                                                        of the transparency log. Defaults
+                                                        to the public log https://rekor.sigstore.dev.
+                                                      type: string
+                                                  required:
+                                                  - url
+                                                  type: object
+                                              type: object
+                                            keyless:
+                                              description: Keyless is a set of attribute
+                                                used to verify a Sigstore keyless
+                                                attestor. See https://github.com/sigstore/cosign/blob/main/KEYLESS.md.
+                                              properties:
+                                                additionalExtensions:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: AdditionalExtensions
+                                                    are certificate-extensions used
+                                                    for keyless signing.
+                                                  type: object
+                                                issuer:
+                                                  description: Issuer is the certificate
+                                                    issuer used for keyless signing.
+                                                  type: string
+                                                rekor:
+                                                  description: Rekor provides configuration
+                                                    for the Rekor transparency log
+                                                    service. If the value is nil,
+                                                    Rekor is not checked and a root
+                                                    certificate chain is expected
+                                                    instead. If an empty object is
+                                                    provided the public instance of
+                                                    Rekor (https://rekor.sigstore.dev)
+                                                    is used.
+                                                  properties:
+                                                    url:
+                                                      description: URL is the address
+                                                        of the transparency log. Defaults
+                                                        to the public log https://rekor.sigstore.dev.
+                                                      type: string
+                                                  required:
+                                                  - url
+                                                  type: object
+                                                roots:
+                                                  description: Roots is an optional
+                                                    set of PEM encoded trusted root
+                                                    certificates. If not provided,
+                                                    the system roots are used.
+                                                  type: string
+                                                subject:
+                                                  description: Subject is the verified
+                                                    identity used for keyless signing,
+                                                    for example the email address
+                                                  type: string
+                                              type: object
+                                            keys:
+                                              description: Keys specifies one or more
+                                                public keys
+                                              properties:
+                                                publicKeys:
+                                                  description: Keys is a set of X.509
+                                                    public keys used to verify image
+                                                    signatures. The keys can be directly
+                                                    specified or can be a variable
+                                                    reference to a key specified in
+                                                    a ConfigMap (see https://kyverno.io/docs/writing-policies/variables/).
+                                                    When multiple keys are specified
+                                                    each key is processed as a separate
+                                                    staticKey entry (.attestors[*].entries.keys)
+                                                    within the set of attestors and
+                                                    the count is applied across the
+                                                    keys.
+                                                  type: string
+                                                rekor:
+                                                  description: Rekor provides configuration
+                                                    for the Rekor transparency log
+                                                    service. If the value is nil,
+                                                    Rekor is not checked. If an empty
+                                                    object is provided the public
+                                                    instance of Rekor (https://rekor.sigstore.dev)
+                                                    is used.
+                                                  properties:
+                                                    url:
+                                                      description: URL is the address
+                                                        of the transparency log. Defaults
+                                                        to the public log https://rekor.sigstore.dev.
+                                                      type: string
+                                                  required:
+                                                  - url
+                                                  type: object
+                                              type: object
+                                            repository:
+                                              description: Repository is an optional
+                                                alternate OCI repository to use for
+                                                signatures and attestations that match
+                                                this rule. If specified Repository
+                                                will override other OCI image repository
+                                                locations for this Attestor.
+                                              type: string
+                                          type: object
+                                        type: array
+                                    type: object
+                                  type: array
+                                dryRun:
+                                  description: DryRun configuration
+                                  properties:
+                                    enable:
+                                      type: boolean
+                                    namespace:
+                                      type: string
+                                  type: object
+                                ignoreFields:
+                                  description: Fields which will be ignored while
+                                    comparing manifests.
+                                  items:
+                                    properties:
+                                      fields:
+                                        items:
+                                          type: string
+                                        type: array
+                                      objects:
+                                        items:
+                                          properties:
+                                            group:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            name:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            version:
+                                              type: string
+                                          type: object
+                                        type: array
+                                    type: object
+                                  type: array
+                                repository:
+                                  description: Repository is an optional alternate
+                                    OCI repository to use for resource bundle reference.
+                                    The repository can be overridden per Attestor
+                                    or Attestation.
+                                  type: string
+                              type: object
+                            message:
+                              description: Message specifies a custom message to be
+                                displayed on failure.
+                              type: string
+                            pattern:
+                              description: Pattern specifies an overlay-style pattern
+                                used to check resources.
+                              x-kubernetes-preserve-unknown-fields: true
+                            podSecurity:
+                              description: PodSecurity applies exemptions for Kubernetes
+                                Pod Security admission by specifying exclusions for
+                                Pod Security Standards controls.
+                              properties:
+                                exclude:
+                                  description: Exclude specifies the Pod Security
+                                    Standard controls to be excluded.
+                                  items:
+                                    description: PodSecurityStandard specifies the
+                                      Pod Security Standard controls to be excluded.
+                                    properties:
+                                      controlName:
+                                        description: 'ControlName specifies the name
+                                          of the Pod Security Standard control. See:
+                                          https://kubernetes.io/docs/concepts/security/pod-security-standards/'
+                                        enum:
+                                        - HostProcess
+                                        - Host Namespaces
+                                        - Privileged Containers
+                                        - Capabilities
+                                        - HostPath Volumes
+                                        - Host Ports
+                                        - AppArmor
+                                        - SELinux
+                                        - /proc Mount Type
+                                        - Seccomp
+                                        - Sysctls
+                                        - Volume Types
+                                        - Privilege Escalation
+                                        - Running as Non-root
+                                        - Running as Non-root user
+                                        type: string
+                                      images:
+                                        description: 'Images selects matching containers
+                                          and applies the container level PSS. Each
+                                          image is the image name consisting of the
+                                          registry address, repository, image, and
+                                          tag. Empty list matches no containers, PSS
+                                          checks are applied at the pod level only.
+                                          Wildcards (''*'' and ''?'') are allowed.
+                                          See: https://kubernetes.io/docs/concepts/containers/images.'
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - controlName
+                                    type: object
+                                  type: array
+                                level:
+                                  description: Level defines the Pod Security Standard
+                                    level to be applied to workloads. Allowed values
+                                    are privileged, baseline, and restricted.
+                                  enum:
+                                  - privileged
+                                  - baseline
+                                  - restricted
+                                  type: string
+                                version:
+                                  description: Version defines the Pod Security Standard
+                                    versions that Kubernetes supports. Allowed values
+                                    are v1.19, v1.20, v1.21, v1.22, v1.23, v1.24,
+                                    v1.25, latest. Defaults to latest.
+                                  enum:
+                                  - v1.19
+                                  - v1.20
+                                  - v1.21
+                                  - v1.22
+                                  - v1.23
+                                  - v1.24
+                                  - v1.25
+                                  - latest
+                                  type: string
+                              type: object
+                          type: object
+                        verifyImages:
+                          description: VerifyImages is used to verify image signatures
+                            and mutate them to add a digest
+                          items:
+                            description: ImageVerification validates that images that
+                              match the specified pattern are signed with the supplied
+                              public key. Once the image is verified it is mutated
+                              to include the SHA digest retrieved during the registration.
+                            properties:
+                              additionalExtensions:
+                                additionalProperties:
+                                  type: string
+                                description: AdditionalExtensions are certificate-extensions
+                                  used for keyless signing. Deprecated.
+                                type: object
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                description: Annotations are used for image verification.
+                                  Every specified key-value pair must exist and match
+                                  in the verified payload. The payload may contain
+                                  other key-value pairs. Deprecated. Use annotations
+                                  per Attestor instead.
+                                type: object
+                              attestations:
+                                description: Attestations are optional checks for
+                                  signed in-toto Statements used to verify the image.
+                                  See https://github.com/in-toto/attestation. Kyverno
+                                  fetches signed attestations from the OCI registry
+                                  and decodes them into a list of Statement declarations.
+                                items:
+                                  description: Attestation are checks for signed in-toto
+                                    Statements that are used to verify the image.
+                                    See https://github.com/in-toto/attestation. Kyverno
+                                    fetches signed attestations from the OCI registry
+                                    and decodes them into a list of Statements.
+                                  properties:
+                                    conditions:
+                                      description: Conditions are used to verify attributes
+                                        within a Predicate. If no Conditions are specified
+                                        the attestation check is satisfied as long
+                                        there are predicates that match the predicate
+                                        type.
+                                      items:
+                                        description: AnyAllConditions consists of
+                                          conditions wrapped denoting a logical criteria
+                                          to be fulfilled. AnyConditions get fulfilled
+                                          when at least one of its sub-conditions
+                                          passes. AllConditions get fulfilled only
+                                          when all of its sub-conditions pass.
+                                        properties:
+                                          all:
+                                            description: AllConditions enable variable-based
+                                              conditional rule execution. This is
+                                              useful for finer control of when an
+                                              rule is applied. A condition can reference
+                                              object data using JMESPath notation.
+                                              Here, all of the conditions need to
+                                              pass
+                                            items:
+                                              description: Condition defines variable-based
+                                                conditional criteria for rule execution.
+                                              properties:
+                                                key:
+                                                  description: Key is the context
+                                                    entry (using JMESPath) for conditional
+                                                    rule evaluation.
+                                                  x-kubernetes-preserve-unknown-fields: true
+                                                operator:
+                                                  description: 'Operator is the conditional
+                                                    operation to perform. Valid operators
+                                                    are: Equals, NotEquals, In, AnyIn,
+                                                    AllIn, NotIn, AnyNotIn, AllNotIn,
+                                                    GreaterThanOrEquals, GreaterThan,
+                                                    LessThanOrEquals, LessThan, DurationGreaterThanOrEquals,
+                                                    DurationGreaterThan, DurationLessThanOrEquals,
+                                                    DurationLessThan'
+                                                  enum:
+                                                  - Equals
+                                                  - NotEquals
+                                                  - In
+                                                  - AnyIn
+                                                  - AllIn
+                                                  - NotIn
+                                                  - AnyNotIn
+                                                  - AllNotIn
+                                                  - GreaterThanOrEquals
+                                                  - GreaterThan
+                                                  - LessThanOrEquals
+                                                  - LessThan
+                                                  - DurationGreaterThanOrEquals
+                                                  - DurationGreaterThan
+                                                  - DurationLessThanOrEquals
+                                                  - DurationLessThan
+                                                  type: string
+                                                value:
+                                                  description: Value is the conditional
+                                                    value, or set of values. The values
+                                                    can be fixed set or can be variables
+                                                    declared using JMESPath.
+                                                  x-kubernetes-preserve-unknown-fields: true
+                                              type: object
+                                            type: array
+                                          any:
+                                            description: AnyConditions enable variable-based
+                                              conditional rule execution. This is
+                                              useful for finer control of when an
+                                              rule is applied. A condition can reference
+                                              object data using JMESPath notation.
+                                              Here, at least one of the conditions
+                                              need to pass
+                                            items:
+                                              description: Condition defines variable-based
+                                                conditional criteria for rule execution.
+                                              properties:
+                                                key:
+                                                  description: Key is the context
+                                                    entry (using JMESPath) for conditional
+                                                    rule evaluation.
+                                                  x-kubernetes-preserve-unknown-fields: true
+                                                operator:
+                                                  description: 'Operator is the conditional
+                                                    operation to perform. Valid operators
+                                                    are: Equals, NotEquals, In, AnyIn,
+                                                    AllIn, NotIn, AnyNotIn, AllNotIn,
+                                                    GreaterThanOrEquals, GreaterThan,
+                                                    LessThanOrEquals, LessThan, DurationGreaterThanOrEquals,
+                                                    DurationGreaterThan, DurationLessThanOrEquals,
+                                                    DurationLessThan'
+                                                  enum:
+                                                  - Equals
+                                                  - NotEquals
+                                                  - In
+                                                  - AnyIn
+                                                  - AllIn
+                                                  - NotIn
+                                                  - AnyNotIn
+                                                  - AllNotIn
+                                                  - GreaterThanOrEquals
+                                                  - GreaterThan
+                                                  - LessThanOrEquals
+                                                  - LessThan
+                                                  - DurationGreaterThanOrEquals
+                                                  - DurationGreaterThan
+                                                  - DurationLessThanOrEquals
+                                                  - DurationLessThan
+                                                  type: string
+                                                value:
+                                                  description: Value is the conditional
+                                                    value, or set of values. The values
+                                                    can be fixed set or can be variables
+                                                    declared using JMESPath.
+                                                  x-kubernetes-preserve-unknown-fields: true
+                                              type: object
+                                            type: array
+                                        type: object
+                                      type: array
+                                    predicateType:
+                                      description: PredicateType defines the type
+                                        of Predicate contained within the Statement.
+                                      type: string
+                                  type: object
+                                type: array
+                              attestors:
+                                description: Attestors specified the required attestors
+                                  (i.e. authorities)
+                                items:
+                                  properties:
+                                    count:
+                                      description: Count specifies the required number
+                                        of entries that must match. If the count is
+                                        null, all entries must match (a logical AND).
+                                        If the count is 1, at least one entry must
+                                        match (a logical OR). If the count contains
+                                        a value N, then N must be less than or equal
+                                        to the size of entries, and at least N entries
+                                        must match.
+                                      minimum: 1
+                                      type: integer
+                                    entries:
+                                      description: Entries contains the available
+                                        attestors. An attestor can be a static key,
+                                        attributes for keyless verification, or a
+                                        nested attestor declaration.
+                                      items:
+                                        properties:
+                                          annotations:
+                                            additionalProperties:
+                                              type: string
+                                            description: Annotations are used for
+                                              image verification. Every specified
+                                              key-value pair must exist and match
+                                              in the verified payload. The payload
+                                              may contain other key-value pairs.
+                                            type: object
+                                          attestor:
+                                            description: Attestor is a nested AttestorSet
+                                              used to specify a more complex set of
+                                              match authorities
+                                            x-kubernetes-preserve-unknown-fields: true
+                                          certificates:
+                                            description: Certificates specifies one
+                                              or more certificates
+                                            properties:
+                                              cert:
+                                                description: Certificate is an optional
+                                                  PEM encoded public certificate.
+                                                type: string
+                                              certChain:
+                                                description: CertificateChain is an
+                                                  optional PEM encoded set of certificates
+                                                  used to verify
+                                                type: string
+                                              rekor:
+                                                description: Rekor provides configuration
+                                                  for the Rekor transparency log service.
+                                                  If the value is nil, Rekor is not
+                                                  checked. If an empty object is provided
+                                                  the public instance of Rekor (https://rekor.sigstore.dev)
+                                                  is used.
+                                                properties:
+                                                  url:
+                                                    description: URL is the address
+                                                      of the transparency log. Defaults
+                                                      to the public log https://rekor.sigstore.dev.
+                                                    type: string
+                                                required:
+                                                - url
+                                                type: object
+                                            type: object
+                                          keyless:
+                                            description: Keyless is a set of attribute
+                                              used to verify a Sigstore keyless attestor.
+                                              See https://github.com/sigstore/cosign/blob/main/KEYLESS.md.
+                                            properties:
+                                              additionalExtensions:
+                                                additionalProperties:
+                                                  type: string
+                                                description: AdditionalExtensions
+                                                  are certificate-extensions used
+                                                  for keyless signing.
+                                                type: object
+                                              issuer:
+                                                description: Issuer is the certificate
+                                                  issuer used for keyless signing.
+                                                type: string
+                                              rekor:
+                                                description: Rekor provides configuration
+                                                  for the Rekor transparency log service.
+                                                  If the value is nil, Rekor is not
+                                                  checked and a root certificate chain
+                                                  is expected instead. If an empty
+                                                  object is provided the public instance
+                                                  of Rekor (https://rekor.sigstore.dev)
+                                                  is used.
+                                                properties:
+                                                  url:
+                                                    description: URL is the address
+                                                      of the transparency log. Defaults
+                                                      to the public log https://rekor.sigstore.dev.
+                                                    type: string
+                                                required:
+                                                - url
+                                                type: object
+                                              roots:
+                                                description: Roots is an optional
+                                                  set of PEM encoded trusted root
+                                                  certificates. If not provided, the
+                                                  system roots are used.
+                                                type: string
+                                              subject:
+                                                description: Subject is the verified
+                                                  identity used for keyless signing,
+                                                  for example the email address
+                                                type: string
+                                            type: object
+                                          keys:
+                                            description: Keys specifies one or more
+                                              public keys
+                                            properties:
+                                              publicKeys:
+                                                description: Keys is a set of X.509
+                                                  public keys used to verify image
+                                                  signatures. The keys can be directly
+                                                  specified or can be a variable reference
+                                                  to a key specified in a ConfigMap
+                                                  (see https://kyverno.io/docs/writing-policies/variables/).
+                                                  When multiple keys are specified
+                                                  each key is processed as a separate
+                                                  staticKey entry (.attestors[*].entries.keys)
+                                                  within the set of attestors and
+                                                  the count is applied across the
+                                                  keys.
+                                                type: string
+                                              rekor:
+                                                description: Rekor provides configuration
+                                                  for the Rekor transparency log service.
+                                                  If the value is nil, Rekor is not
+                                                  checked. If an empty object is provided
+                                                  the public instance of Rekor (https://rekor.sigstore.dev)
+                                                  is used.
+                                                properties:
+                                                  url:
+                                                    description: URL is the address
+                                                      of the transparency log. Defaults
+                                                      to the public log https://rekor.sigstore.dev.
+                                                    type: string
+                                                required:
+                                                - url
+                                                type: object
+                                            type: object
+                                          repository:
+                                            description: Repository is an optional
+                                              alternate OCI repository to use for
+                                              signatures and attestations that match
+                                              this rule. If specified Repository will
+                                              override other OCI image repository
+                                              locations for this Attestor.
+                                            type: string
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                              image:
+                                description: 'Image is the image name consisting of
+                                  the registry address, repository, image, and tag.
+                                  Wildcards (''*'' and ''?'') are allowed. See: https://kubernetes.io/docs/concepts/containers/images.
+                                  Deprecated. Use ImageReferences instead.'
+                                type: string
+                              imageReferences:
+                                description: 'ImageReferences is a list of matching
+                                  image reference patterns. At least one pattern in
+                                  the list must match the image for the rule to apply.
+                                  Each image reference consists of a registry address
+                                  (defaults to docker.io), repository, image, and
+                                  tag (defaults to latest). Wildcards (''*'' and ''?'')
+                                  are allowed. See: https://kubernetes.io/docs/concepts/containers/images.'
+                                items:
+                                  type: string
+                                type: array
+                              issuer:
+                                description: Issuer is the certificate issuer used
+                                  for keyless signing. Deprecated. Use KeylessAttestor
+                                  instead.
+                                type: string
+                              key:
+                                description: Key is the PEM encoded public key that
+                                  the image or attestation is signed with. Deprecated.
+                                  Use StaticKeyAttestor instead.
+                                type: string
+                              mutateDigest:
+                                default: true
+                                description: MutateDigest enables replacement of image
+                                  tags with digests. Defaults to true.
+                                type: boolean
+                              repository:
+                                description: Repository is an optional alternate OCI
+                                  repository to use for image signatures and attestations
+                                  that match this rule. If specified Repository will
+                                  override the default OCI image repository configured
+                                  for the installation. The repository can also be
+                                  overridden per Attestor or Attestation.
+                                type: string
+                              required:
+                                default: true
+                                description: Required validates that images are verified
+                                  i.e. have matched passed a signature or attestation
+                                  check.
+                                type: boolean
+                              roots:
+                                description: Roots is the PEM encoded Root certificate
+                                  chain used for keyless signing Deprecated. Use KeylessAttestor
+                                  instead.
+                                type: string
+                              subject:
+                                description: Subject is the identity used for keyless
+                                  signing, for example an email address Deprecated.
+                                  Use KeylessAttestor instead.
+                                type: string
+                              verifyDigest:
+                                default: true
+                                description: VerifyDigest validates that images have
+                                  a digest.
+                                type: boolean
+                            type: object
+                          type: array
+                      type: object
+                    type: array
+                type: object
+              conditions:
+                description: Conditions is a list of conditions that apply to the
+                  policy
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              ready:
+                description: Ready indicates if the policy is ready to serve the admission
+                  request. Deprecated in favor of Conditions
+                type: boolean
+            required:
+            - ready
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clusterpolicyreports.wgpolicyk8s.io.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clusterpolicyreports.wgpolicyk8s.io.yaml
@@ -1,0 +1,369 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Replace=true
+    controller-gen.kubebuilder.io/version: v0.10.0
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: kyverno
+    app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/version: v1.8.1
+  name: clusterpolicyreports.wgpolicyk8s.io
+spec:
+  group: wgpolicyk8s.io
+  names:
+    kind: ClusterPolicyReport
+    listKind: ClusterPolicyReportList
+    plural: clusterpolicyreports
+    shortNames:
+    - cpolr
+    singular: clusterpolicyreport
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .scope.kind
+      name: Kind
+      priority: 1
+      type: string
+    - jsonPath: .scope.name
+      name: Name
+      priority: 1
+      type: string
+    - jsonPath: .summary.pass
+      name: Pass
+      type: integer
+    - jsonPath: .summary.fail
+      name: Fail
+      type: integer
+    - jsonPath: .summary.warn
+      name: Warn
+      type: integer
+    - jsonPath: .summary.error
+      name: Error
+      type: integer
+    - jsonPath: .summary.skip
+      name: Skip
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: ClusterPolicyReport is the Schema for the clusterpolicyreports
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          results:
+            description: PolicyReportResult provides result details
+            items:
+              description: PolicyReportResult provides the result for an individual
+                policy
+              properties:
+                category:
+                  description: Category indicates policy category
+                  type: string
+                message:
+                  description: Description is a short user friendly message for the
+                    policy rule
+                  type: string
+                policy:
+                  description: Policy is the name or identifier of the policy
+                  type: string
+                properties:
+                  additionalProperties:
+                    type: string
+                  description: Properties provides additional information for the
+                    policy rule
+                  type: object
+                resourceSelector:
+                  description: SubjectSelector is an optional label selector for checked
+                    Kubernetes resources. For example, a policy result may apply to
+                    all pods that match a label. Either a Subject or a SubjectSelector
+                    can be specified. If neither are provided, the result is assumed
+                    to be for the policy report scope.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                  x-kubernetes-map-type: atomic
+                resources:
+                  description: Subjects is an optional reference to the checked Kubernetes
+                    resources
+                  items:
+                    description: "ObjectReference contains enough information to let
+                      you inspect or modify the referred object. --- New uses of this
+                      type are discouraged because of difficulty describing its usage
+                      when embedded in APIs. 1. Ignored fields.  It includes many
+                      fields which are not generally honored.  For instance, ResourceVersion
+                      and FieldPath are both very rarely valid in actual usage. 2.
+                      Invalid usage help.  It is impossible to add specific help for
+                      individual usage.  In most embedded usages, there are particular
+                      restrictions like, \"must refer only to types A and B\" or \"UID
+                      not honored\" or \"name must be restricted\". Those cannot be
+                      well described when embedded. 3. Inconsistent validation.  Because
+                      the usages are different, the validation rules are different
+                      by usage, which makes it hard for users to predict what will
+                      happen. 4. The fields are both imprecise and overly precise.
+                      \ Kind is not a precise mapping to a URL. This can produce ambiguity
+                      during interpretation and require a REST mapping.  In most cases,
+                      the dependency is on the group,resource tuple and the version
+                      of the actual struct is irrelevant. 5. We cannot easily change
+                      it.  Because this type is embedded in many locations, updates
+                      to this type will affect numerous schemas.  Don't make new APIs
+                      embed an underspecified API type they do not control. \n Instead
+                      of using this type, create a locally provided and used type
+                      that is well-focused on your reference. For example, ServiceReferences
+                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                      ."
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object. TODO: this design is not final and this field
+                          is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  type: array
+                result:
+                  description: Result indicates the outcome of the policy rule execution
+                  enum:
+                  - pass
+                  - fail
+                  - warn
+                  - error
+                  - skip
+                  type: string
+                rule:
+                  description: Rule is the name or identifier of the rule within the
+                    policy
+                  type: string
+                scored:
+                  description: Scored indicates if this result is scored
+                  type: boolean
+                severity:
+                  description: Severity indicates policy check result criticality
+                  enum:
+                  - critical
+                  - high
+                  - low
+                  - medium
+                  - info
+                  type: string
+                source:
+                  description: Source is an identifier for the policy engine that
+                    manages this report
+                  type: string
+                timestamp:
+                  description: Timestamp indicates the time the result was found
+                  properties:
+                    nanos:
+                      description: Non-negative fractions of a second at nanosecond
+                        resolution. Negative second values with fractions must still
+                        have non-negative nanos values that count forward in time.
+                        Must be from 0 to 999,999,999 inclusive. This field may be
+                        limited in precision depending on context.
+                      format: int32
+                      type: integer
+                    seconds:
+                      description: Represents seconds of UTC time since Unix epoch
+                        1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
+                        9999-12-31T23:59:59Z inclusive.
+                      format: int64
+                      type: integer
+                  required:
+                  - nanos
+                  - seconds
+                  type: object
+              required:
+              - policy
+              type: object
+            type: array
+          scope:
+            description: Scope is an optional reference to the report scope (e.g.
+              a Deployment, Namespace, or Node)
+            properties:
+              apiVersion:
+                description: API version of the referent.
+                type: string
+              fieldPath:
+                description: 'If referring to a piece of an object instead of an entire
+                  object, this string should contain a valid JSON/Go field access
+                  statement, such as desiredState.manifest.containers[2]. For example,
+                  if the object reference is to a container within a pod, this would
+                  take on a value like: "spec.containers{name}" (where "name" refers
+                  to the name of the container that triggered the event) or if no
+                  container name is specified "spec.containers[2]" (container with
+                  index 2 in this pod). This syntax is chosen only to have some well-defined
+                  way of referencing a part of an object. TODO: this design is not
+                  final and this field is subject to change in the future.'
+                type: string
+              kind:
+                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              name:
+                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                type: string
+              namespace:
+                description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                type: string
+              resourceVersion:
+                description: 'Specific resourceVersion to which this reference is
+                  made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                type: string
+              uid:
+                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                type: string
+            type: object
+            x-kubernetes-map-type: atomic
+          scopeSelector:
+            description: ScopeSelector is an optional selector for multiple scopes
+              (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
+              should be specified.
+            properties:
+              matchExpressions:
+                description: matchExpressions is a list of label selector requirements.
+                  The requirements are ANDed.
+                items:
+                  description: A label selector requirement is a selector that contains
+                    values, a key, and an operator that relates the key and values.
+                  properties:
+                    key:
+                      description: key is the label key that the selector applies
+                        to.
+                      type: string
+                    operator:
+                      description: operator represents a key's relationship to a set
+                        of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                      type: string
+                    values:
+                      description: values is an array of string values. If the operator
+                        is In or NotIn, the values array must be non-empty. If the
+                        operator is Exists or DoesNotExist, the values array must
+                        be empty. This array is replaced during a strategic merge
+                        patch.
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - key
+                  - operator
+                  type: object
+                type: array
+              matchLabels:
+                additionalProperties:
+                  type: string
+                description: matchLabels is a map of {key,value} pairs. A single {key,value}
+                  in the matchLabels map is equivalent to an element of matchExpressions,
+                  whose key field is "key", the operator is "In", and the values array
+                  contains only "value". The requirements are ANDed.
+                type: object
+            type: object
+            x-kubernetes-map-type: atomic
+          summary:
+            description: PolicyReportSummary provides a summary of results
+            properties:
+              error:
+                description: Error provides the count of policies that could not be
+                  evaluated
+                type: integer
+              fail:
+                description: Fail provides the count of policies whose requirements
+                  were not met
+                type: integer
+              pass:
+                description: Pass provides the count of policies whose requirements
+                  were met
+                type: integer
+              skip:
+                description: Skip indicates the count of policies that were not selected
+                  for evaluation
+                type: integer
+              warn:
+                description: Warn provides the count of non-scored policies whose
+                  requirements were not met
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_generaterequests.kyverno.io.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_generaterequests.kyverno.io.yaml
@@ -1,0 +1,190 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Replace=true
+    controller-gen.kubebuilder.io/version: v0.10.0
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: kyverno
+    app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/version: v1.8.1
+  name: generaterequests.kyverno.io
+spec:
+  group: kyverno.io
+  names:
+    kind: GenerateRequest
+    listKind: GenerateRequestList
+    plural: generaterequests
+    shortNames:
+    - gr
+    singular: generaterequest
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.policy
+      name: Policy
+      type: string
+    - jsonPath: .spec.resource.kind
+      name: ResourceKind
+      type: string
+    - jsonPath: .spec.resource.name
+      name: ResourceName
+      type: string
+    - jsonPath: .spec.resource.namespace
+      name: ResourceNamespace
+      type: string
+    - jsonPath: .status.state
+      name: status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: GenerateRequest is a request to process generate rule.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec is the information to identify the generate request.
+            properties:
+              context:
+                description: Context ...
+                properties:
+                  admissionRequestInfo:
+                    description: AdmissionRequestInfoObject stores the admission request
+                      and operation details
+                    properties:
+                      admissionRequest:
+                        type: string
+                      operation:
+                        description: Operation is the type of resource operation being
+                          checked for admission control
+                        type: string
+                    type: object
+                  userInfo:
+                    description: RequestInfo contains permission info carried in an
+                      admission request.
+                    properties:
+                      clusterRoles:
+                        description: ClusterRoles is a list of possible clusterRoles
+                          send the request.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      roles:
+                        description: Roles is a list of possible role send the request.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      userInfo:
+                        description: UserInfo is the userInfo carried in the admission
+                          request.
+                        properties:
+                          extra:
+                            additionalProperties:
+                              description: ExtraValue masks the value so protobuf
+                                can generate
+                              items:
+                                type: string
+                              type: array
+                            description: Any additional information provided by the
+                              authenticator.
+                            type: object
+                          groups:
+                            description: The names of groups this user is a part of.
+                            items:
+                              type: string
+                            type: array
+                          uid:
+                            description: A unique value that identifies this user
+                              across time. If this user is deleted and another user
+                              by the same name is added, they will have different
+                              UIDs.
+                            type: string
+                          username:
+                            description: The name that uniquely identifies this user
+                              among all active users.
+                            type: string
+                        type: object
+                    type: object
+                type: object
+              policy:
+                description: Specifies the name of the policy.
+                type: string
+              resource:
+                description: ResourceSpec is the information to identify the generate
+                  request.
+                properties:
+                  apiVersion:
+                    description: APIVersion specifies resource apiVersion.
+                    type: string
+                  kind:
+                    description: Kind specifies resource kind.
+                    type: string
+                  name:
+                    description: Name specifies the resource name.
+                    type: string
+                  namespace:
+                    description: Namespace specifies resource namespace.
+                    type: string
+                type: object
+            required:
+            - context
+            - policy
+            - resource
+            type: object
+          status:
+            description: Status contains statistics related to generate request.
+            properties:
+              generatedResources:
+                description: This will track the resources that are generated by the
+                  generate Policy. Will be used during clean up resources.
+                items:
+                  properties:
+                    apiVersion:
+                      description: APIVersion specifies resource apiVersion.
+                      type: string
+                    kind:
+                      description: Kind specifies resource kind.
+                      type: string
+                    name:
+                      description: Name specifies the resource name.
+                      type: string
+                    namespace:
+                      description: Namespace specifies resource namespace.
+                      type: string
+                  type: object
+                type: array
+              message:
+                description: Specifies request status message.
+                type: string
+              state:
+                description: State represents state of the generate request.
+                type: string
+            required:
+            - state
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_policies.kyverno.io.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_policies.kyverno.io.yaml
@@ -1,0 +1,11242 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Replace=true
+    controller-gen.kubebuilder.io/version: v0.10.0
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: kyverno
+    app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/version: v1.8.1
+  name: policies.kyverno.io
+spec:
+  group: kyverno.io
+  names:
+    kind: Policy
+    listKind: PolicyList
+    plural: policies
+    shortNames:
+    - pol
+    singular: policy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.background
+      name: Background
+      type: boolean
+    - jsonPath: .spec.validationFailureAction
+      name: Validate Action
+      type: string
+    - jsonPath: .spec.failurePolicy
+      name: Failure Policy
+      priority: 1
+      type: string
+    - jsonPath: .status.ready
+      name: Ready
+      type: boolean
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: 'Policy declares validation, mutation, and generation behaviors
+          for matching resources. See: https://kyverno.io/docs/writing-policies/ for
+          more information.'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines policy behaviors and contains one or more rules.
+            properties:
+              applyRules:
+                description: ApplyRules controls how rules in a policy are applied.
+                  Rule are processed in the order of declaration. When set to `One`
+                  processing stops after a rule has been applied i.e. the rule matches
+                  and results in a pass, fail, or error. When set to `All` all rules
+                  in the policy are processed. The default is `All`.
+                enum:
+                - All
+                - One
+                type: string
+              background:
+                default: true
+                description: Background controls if rules are applied to existing
+                  resources during a background scan. Optional. Default value is "true".
+                  The value must be set to "false" if the policy rule uses variables
+                  that are only available in the admission review request (e.g. user
+                  name).
+                type: boolean
+              failurePolicy:
+                description: FailurePolicy defines how unexpected policy errors and
+                  webhook response timeout errors are handled. Rules within the same
+                  policy share the same failure behavior. Allowed values are Ignore
+                  or Fail. Defaults to Fail.
+                enum:
+                - Ignore
+                - Fail
+                type: string
+              generateExistingOnPolicyUpdate:
+                description: GenerateExistingOnPolicyUpdate controls whether to trigger
+                  generate rule in existing resources If is set to "true" generate
+                  rule will be triggered and applied to existing matched resources.
+                  Defaults to "false" if not specified.
+                type: boolean
+              mutateExistingOnPolicyUpdate:
+                description: MutateExistingOnPolicyUpdate controls if a mutateExisting
+                  policy is applied on policy events. Default value is "false".
+                type: boolean
+              rules:
+                description: Rules is a list of Rule instances. A Policy contains
+                  multiple rules and each rule can validate, mutate, or generate resources.
+                items:
+                  description: Rule defines a validation, mutation, or generation
+                    control for matching resources. Each rules contains a match declaration
+                    to select resources, and an optional exclude declaration to specify
+                    which resources to exclude.
+                  properties:
+                    context:
+                      description: Context defines variables and data sources that
+                        can be used during rule execution.
+                      items:
+                        description: ContextEntry adds variables and data sources
+                          to a rule Context. Either a ConfigMap reference or a APILookup
+                          must be provided.
+                        properties:
+                          apiCall:
+                            description: APICall defines an HTTP request to the Kubernetes
+                              API server. The JSON data retrieved is stored in the
+                              context.
+                            properties:
+                              jmesPath:
+                                description: JMESPath is an optional JSON Match Expression
+                                  that can be used to transform the JSON response
+                                  returned from the API server. For example a JMESPath
+                                  of "items | length(@)" applied to the API server
+                                  response to the URLPath "/apis/apps/v1/deployments"
+                                  will return the total count of deployments across
+                                  all namespaces.
+                                type: string
+                              urlPath:
+                                description: URLPath is the URL path to be used in
+                                  the HTTP GET request to the Kubernetes API server
+                                  (e.g. "/api/v1/namespaces" or  "/apis/apps/v1/deployments").
+                                  The format required is the same format used by the
+                                  `kubectl get --raw` command.
+                                type: string
+                            required:
+                            - urlPath
+                            type: object
+                          configMap:
+                            description: ConfigMap is the ConfigMap reference.
+                            properties:
+                              name:
+                                description: Name is the ConfigMap name.
+                                type: string
+                              namespace:
+                                description: Namespace is the ConfigMap namespace.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          imageRegistry:
+                            description: ImageRegistry defines requests to an OCI/Docker
+                              V2 registry to fetch image details.
+                            properties:
+                              jmesPath:
+                                description: JMESPath is an optional JSON Match Expression
+                                  that can be used to transform the ImageData struct
+                                  returned as a result of processing the image reference.
+                                type: string
+                              reference:
+                                description: 'Reference is image reference to a container
+                                  image in the registry. Example: ghcr.io/kyverno/kyverno:latest'
+                                type: string
+                            required:
+                            - reference
+                            type: object
+                          name:
+                            description: Name is the variable name.
+                            type: string
+                          variable:
+                            description: Variable defines an arbitrary JMESPath context
+                              variable that can be defined inline.
+                            properties:
+                              default:
+                                description: Default is an optional arbitrary JSON
+                                  object that the variable may take if the JMESPath
+                                  expression evaluates to nil
+                                x-kubernetes-preserve-unknown-fields: true
+                              jmesPath:
+                                description: JMESPath is an optional JMESPath Expression
+                                  that can be used to transform the variable.
+                                type: string
+                              value:
+                                description: Value is any arbitrary JSON object representable
+                                  in YAML or JSON form.
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                        type: object
+                      type: array
+                    exclude:
+                      description: ExcludeResources defines when this policy rule
+                        should not be applied. The exclude criteria can include resource
+                        information (e.g. kind, name, namespace, labels) and admission
+                        review request information like the name or role.
+                      properties:
+                        all:
+                          description: All allows specifying resources which will
+                            be ANDed
+                          items:
+                            description: ResourceFilter allow users to "AND" or "OR"
+                              between resources
+                            properties:
+                              clusterRoles:
+                                description: ClusterRoles is the list of cluster-wide
+                                  role names for the user.
+                                items:
+                                  type: string
+                                type: array
+                              resources:
+                                description: ResourceDescription contains information
+                                  about the resource being created or modified.
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations is a  map of annotations
+                                      (key-value pairs of type string). Annotation
+                                      keys and values support the wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (matches at least one character).
+                                    type: object
+                                  kinds:
+                                    description: Kinds is a list of resource kinds.
+                                    items:
+                                      type: string
+                                    type: array
+                                  name:
+                                    description: 'Name is the name of the resource.
+                                      The name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character). NOTE: "Name" is being deprecated
+                                      in favor of "Names".'
+                                    type: string
+                                  names:
+                                    description: Names are the names of the resources.
+                                      Each name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character).
+                                    items:
+                                      type: string
+                                    type: array
+                                  namespaceSelector:
+                                    description: 'NamespaceSelector is a label selector
+                                      for the resource namespace. Label keys and values
+                                      in `matchLabels` support the wildcard characters
+                                      `*` (matches zero or many characters) and `?`
+                                      (matches one character).Wildcards allows writing
+                                      label selectors like ["storage.k8s.io/*": "*"].
+                                      Note that using ["*" : "*"] matches any key
+                                      and value but does not match an empty label
+                                      set.'
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaces:
+                                    description: Namespaces is a list of namespaces
+                                      names. Each name supports wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (at least one character).
+                                    items:
+                                      type: string
+                                    type: array
+                                  selector:
+                                    description: 'Selector is a label selector. Label
+                                      keys and values in `matchLabels` support the
+                                      wildcard characters `*` (matches zero or many
+                                      characters) and `?` (matches one character).
+                                      Wildcards allows writing label selectors like
+                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                      : "*"] matches any key and value but does not
+                                      match an empty label set.'
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              roles:
+                                description: Roles is the list of namespaced role
+                                  names for the user.
+                                items:
+                                  type: string
+                                type: array
+                              subjects:
+                                description: Subjects is the list of subject names
+                                  like users, user groups, and service accounts.
+                                items:
+                                  description: Subject contains a reference to the
+                                    object or user identities a role binding applies
+                                    to.  This can either hold a direct API object
+                                    reference, or a value for non-objects such as
+                                    user and group names.
+                                  properties:
+                                    apiGroup:
+                                      description: APIGroup holds the API group of
+                                        the referenced subject. Defaults to "" for
+                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
+                                        for User and Group subjects.
+                                      type: string
+                                    kind:
+                                      description: Kind of object being referenced.
+                                        Values defined by this API group are "User",
+                                        "Group", and "ServiceAccount". If the Authorizer
+                                        does not recognized the kind value, the Authorizer
+                                        should report an error.
+                                      type: string
+                                    name:
+                                      description: Name of the object being referenced.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the referenced object.  If
+                                        the object kind is non-namespace, such as
+                                        "User" or "Group", and this value is not empty
+                                        the Authorizer should report an error.
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                type: array
+                            type: object
+                          type: array
+                        any:
+                          description: Any allows specifying resources which will
+                            be ORed
+                          items:
+                            description: ResourceFilter allow users to "AND" or "OR"
+                              between resources
+                            properties:
+                              clusterRoles:
+                                description: ClusterRoles is the list of cluster-wide
+                                  role names for the user.
+                                items:
+                                  type: string
+                                type: array
+                              resources:
+                                description: ResourceDescription contains information
+                                  about the resource being created or modified.
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations is a  map of annotations
+                                      (key-value pairs of type string). Annotation
+                                      keys and values support the wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (matches at least one character).
+                                    type: object
+                                  kinds:
+                                    description: Kinds is a list of resource kinds.
+                                    items:
+                                      type: string
+                                    type: array
+                                  name:
+                                    description: 'Name is the name of the resource.
+                                      The name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character). NOTE: "Name" is being deprecated
+                                      in favor of "Names".'
+                                    type: string
+                                  names:
+                                    description: Names are the names of the resources.
+                                      Each name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character).
+                                    items:
+                                      type: string
+                                    type: array
+                                  namespaceSelector:
+                                    description: 'NamespaceSelector is a label selector
+                                      for the resource namespace. Label keys and values
+                                      in `matchLabels` support the wildcard characters
+                                      `*` (matches zero or many characters) and `?`
+                                      (matches one character).Wildcards allows writing
+                                      label selectors like ["storage.k8s.io/*": "*"].
+                                      Note that using ["*" : "*"] matches any key
+                                      and value but does not match an empty label
+                                      set.'
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaces:
+                                    description: Namespaces is a list of namespaces
+                                      names. Each name supports wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (at least one character).
+                                    items:
+                                      type: string
+                                    type: array
+                                  selector:
+                                    description: 'Selector is a label selector. Label
+                                      keys and values in `matchLabels` support the
+                                      wildcard characters `*` (matches zero or many
+                                      characters) and `?` (matches one character).
+                                      Wildcards allows writing label selectors like
+                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                      : "*"] matches any key and value but does not
+                                      match an empty label set.'
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              roles:
+                                description: Roles is the list of namespaced role
+                                  names for the user.
+                                items:
+                                  type: string
+                                type: array
+                              subjects:
+                                description: Subjects is the list of subject names
+                                  like users, user groups, and service accounts.
+                                items:
+                                  description: Subject contains a reference to the
+                                    object or user identities a role binding applies
+                                    to.  This can either hold a direct API object
+                                    reference, or a value for non-objects such as
+                                    user and group names.
+                                  properties:
+                                    apiGroup:
+                                      description: APIGroup holds the API group of
+                                        the referenced subject. Defaults to "" for
+                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
+                                        for User and Group subjects.
+                                      type: string
+                                    kind:
+                                      description: Kind of object being referenced.
+                                        Values defined by this API group are "User",
+                                        "Group", and "ServiceAccount". If the Authorizer
+                                        does not recognized the kind value, the Authorizer
+                                        should report an error.
+                                      type: string
+                                    name:
+                                      description: Name of the object being referenced.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the referenced object.  If
+                                        the object kind is non-namespace, such as
+                                        "User" or "Group", and this value is not empty
+                                        the Authorizer should report an error.
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                type: array
+                            type: object
+                          type: array
+                        clusterRoles:
+                          description: ClusterRoles is the list of cluster-wide role
+                            names for the user.
+                          items:
+                            type: string
+                          type: array
+                        resources:
+                          description: ResourceDescription contains information about
+                            the resource being created or modified. Requires at least
+                            one tag to be specified when under MatchResources. Specifying
+                            ResourceDescription directly under match is being deprecated.
+                            Please specify under "any" or "all" instead.
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a  map of annotations (key-value
+                                pairs of type string). Annotation keys and values
+                                support the wildcard characters "*" (matches zero
+                                or many characters) and "?" (matches at least one
+                                character).
+                              type: object
+                            kinds:
+                              description: Kinds is a list of resource kinds.
+                              items:
+                                type: string
+                              type: array
+                            name:
+                              description: 'Name is the name of the resource. The
+                                name supports wildcard characters "*" (matches zero
+                                or many characters) and "?" (at least one character).
+                                NOTE: "Name" is being deprecated in favor of "Names".'
+                              type: string
+                            names:
+                              description: Names are the names of the resources. Each
+                                name supports wildcard characters "*" (matches zero
+                                or many characters) and "?" (at least one character).
+                              items:
+                                type: string
+                              type: array
+                            namespaceSelector:
+                              description: 'NamespaceSelector is a label selector
+                                for the resource namespace. Label keys and values
+                                in `matchLabels` support the wildcard characters `*`
+                                (matches zero or many characters) and `?` (matches
+                                one character).Wildcards allows writing label selectors
+                                like ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                : "*"] matches any key and value but does not match
+                                an empty label set.'
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            namespaces:
+                              description: Namespaces is a list of namespaces names.
+                                Each name supports wildcard characters "*" (matches
+                                zero or many characters) and "?" (at least one character).
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: 'Selector is a label selector. Label keys
+                                and values in `matchLabels` support the wildcard characters
+                                `*` (matches zero or many characters) and `?` (matches
+                                one character). Wildcards allows writing label selectors
+                                like ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                : "*"] matches any key and value but does not match
+                                an empty label set.'
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        roles:
+                          description: Roles is the list of namespaced role names
+                            for the user.
+                          items:
+                            type: string
+                          type: array
+                        subjects:
+                          description: Subjects is the list of subject names like
+                            users, user groups, and service accounts.
+                          items:
+                            description: Subject contains a reference to the object
+                              or user identities a role binding applies to.  This
+                              can either hold a direct API object reference, or a
+                              value for non-objects such as user and group names.
+                            properties:
+                              apiGroup:
+                                description: APIGroup holds the API group of the referenced
+                                  subject. Defaults to "" for ServiceAccount subjects.
+                                  Defaults to "rbac.authorization.k8s.io" for User
+                                  and Group subjects.
+                                type: string
+                              kind:
+                                description: Kind of object being referenced. Values
+                                  defined by this API group are "User", "Group", and
+                                  "ServiceAccount". If the Authorizer does not recognized
+                                  the kind value, the Authorizer should report an
+                                  error.
+                                type: string
+                              name:
+                                description: Name of the object being referenced.
+                                type: string
+                              namespace:
+                                description: Namespace of the referenced object.  If
+                                  the object kind is non-namespace, such as "User"
+                                  or "Group", and this value is not empty the Authorizer
+                                  should report an error.
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          type: array
+                      type: object
+                    generate:
+                      description: Generation is used to create new resources.
+                      properties:
+                        apiVersion:
+                          description: APIVersion specifies resource apiVersion.
+                          type: string
+                        clone:
+                          description: Clone specifies the source resource used to
+                            populate each generated resource. At most one of Data
+                            or Clone can be specified. If neither are provided, the
+                            generated resource will be created with default data only.
+                          properties:
+                            name:
+                              description: Name specifies name of the resource.
+                              type: string
+                            namespace:
+                              description: Namespace specifies source resource namespace.
+                              type: string
+                          type: object
+                        cloneList:
+                          description: CloneList specifies the list of source resource
+                            used to populate each generated resource.
+                          properties:
+                            kinds:
+                              description: Kinds is a list of resource kinds.
+                              items:
+                                type: string
+                              type: array
+                            namespace:
+                              description: Namespace specifies source resource namespace.
+                              type: string
+                            selector:
+                              description: Selector is a label selector. Label keys
+                                and values in `matchLabels`. wildcard characters are
+                                not supported.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        data:
+                          description: Data provides the resource declaration used
+                            to populate each generated resource. At most one of Data
+                            or Clone must be specified. If neither are provided, the
+                            generated resource will be created with default data only.
+                          x-kubernetes-preserve-unknown-fields: true
+                        kind:
+                          description: Kind specifies resource kind.
+                          type: string
+                        name:
+                          description: Name specifies the resource name.
+                          type: string
+                        namespace:
+                          description: Namespace specifies resource namespace.
+                          type: string
+                        synchronize:
+                          description: Synchronize controls if generated resources
+                            should be kept in-sync with their source resource. If
+                            Synchronize is set to "true" changes to generated resources
+                            will be overwritten with resource data from Data or the
+                            resource specified in the Clone declaration. Optional.
+                            Defaults to "false" if not specified.
+                          type: boolean
+                      type: object
+                    imageExtractors:
+                      additionalProperties:
+                        items:
+                          properties:
+                            key:
+                              description: Key is an optional name of the field within
+                                'path' that will be used to uniquely identify an image.
+                                Note - this field MUST be unique.
+                              type: string
+                            name:
+                              description: Name is the entry the image will be available
+                                under 'images.<name>' in the context. If this field
+                                is not defined, image entries will appear under 'images.custom'.
+                              type: string
+                            path:
+                              description: Path is the path to the object containing
+                                the image field in a custom resource. It should be
+                                slash-separated. Each slash-separated key must be
+                                a valid YAML key or a wildcard '*'. Wildcard keys
+                                are expanded in case of arrays or objects.
+                              type: string
+                            value:
+                              description: Value is an optional name of the field
+                                within 'path' that points to the image URI. This is
+                                useful when a custom 'key' is also defined.
+                              type: string
+                          required:
+                          - path
+                          type: object
+                        type: array
+                      description: ImageExtractors defines a mapping from kinds to
+                        ImageExtractorConfigs. This config is only valid for verifyImages
+                        rules.
+                      type: object
+                    match:
+                      description: MatchResources defines when this policy rule should
+                        be applied. The match criteria can include resource information
+                        (e.g. kind, name, namespace, labels) and admission review
+                        request information like the user name or role. At least one
+                        kind is required.
+                      properties:
+                        all:
+                          description: All allows specifying resources which will
+                            be ANDed
+                          items:
+                            description: ResourceFilter allow users to "AND" or "OR"
+                              between resources
+                            properties:
+                              clusterRoles:
+                                description: ClusterRoles is the list of cluster-wide
+                                  role names for the user.
+                                items:
+                                  type: string
+                                type: array
+                              resources:
+                                description: ResourceDescription contains information
+                                  about the resource being created or modified.
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations is a  map of annotations
+                                      (key-value pairs of type string). Annotation
+                                      keys and values support the wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (matches at least one character).
+                                    type: object
+                                  kinds:
+                                    description: Kinds is a list of resource kinds.
+                                    items:
+                                      type: string
+                                    type: array
+                                  name:
+                                    description: 'Name is the name of the resource.
+                                      The name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character). NOTE: "Name" is being deprecated
+                                      in favor of "Names".'
+                                    type: string
+                                  names:
+                                    description: Names are the names of the resources.
+                                      Each name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character).
+                                    items:
+                                      type: string
+                                    type: array
+                                  namespaceSelector:
+                                    description: 'NamespaceSelector is a label selector
+                                      for the resource namespace. Label keys and values
+                                      in `matchLabels` support the wildcard characters
+                                      `*` (matches zero or many characters) and `?`
+                                      (matches one character).Wildcards allows writing
+                                      label selectors like ["storage.k8s.io/*": "*"].
+                                      Note that using ["*" : "*"] matches any key
+                                      and value but does not match an empty label
+                                      set.'
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaces:
+                                    description: Namespaces is a list of namespaces
+                                      names. Each name supports wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (at least one character).
+                                    items:
+                                      type: string
+                                    type: array
+                                  selector:
+                                    description: 'Selector is a label selector. Label
+                                      keys and values in `matchLabels` support the
+                                      wildcard characters `*` (matches zero or many
+                                      characters) and `?` (matches one character).
+                                      Wildcards allows writing label selectors like
+                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                      : "*"] matches any key and value but does not
+                                      match an empty label set.'
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              roles:
+                                description: Roles is the list of namespaced role
+                                  names for the user.
+                                items:
+                                  type: string
+                                type: array
+                              subjects:
+                                description: Subjects is the list of subject names
+                                  like users, user groups, and service accounts.
+                                items:
+                                  description: Subject contains a reference to the
+                                    object or user identities a role binding applies
+                                    to.  This can either hold a direct API object
+                                    reference, or a value for non-objects such as
+                                    user and group names.
+                                  properties:
+                                    apiGroup:
+                                      description: APIGroup holds the API group of
+                                        the referenced subject. Defaults to "" for
+                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
+                                        for User and Group subjects.
+                                      type: string
+                                    kind:
+                                      description: Kind of object being referenced.
+                                        Values defined by this API group are "User",
+                                        "Group", and "ServiceAccount". If the Authorizer
+                                        does not recognized the kind value, the Authorizer
+                                        should report an error.
+                                      type: string
+                                    name:
+                                      description: Name of the object being referenced.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the referenced object.  If
+                                        the object kind is non-namespace, such as
+                                        "User" or "Group", and this value is not empty
+                                        the Authorizer should report an error.
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                type: array
+                            type: object
+                          type: array
+                        any:
+                          description: Any allows specifying resources which will
+                            be ORed
+                          items:
+                            description: ResourceFilter allow users to "AND" or "OR"
+                              between resources
+                            properties:
+                              clusterRoles:
+                                description: ClusterRoles is the list of cluster-wide
+                                  role names for the user.
+                                items:
+                                  type: string
+                                type: array
+                              resources:
+                                description: ResourceDescription contains information
+                                  about the resource being created or modified.
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations is a  map of annotations
+                                      (key-value pairs of type string). Annotation
+                                      keys and values support the wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (matches at least one character).
+                                    type: object
+                                  kinds:
+                                    description: Kinds is a list of resource kinds.
+                                    items:
+                                      type: string
+                                    type: array
+                                  name:
+                                    description: 'Name is the name of the resource.
+                                      The name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character). NOTE: "Name" is being deprecated
+                                      in favor of "Names".'
+                                    type: string
+                                  names:
+                                    description: Names are the names of the resources.
+                                      Each name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character).
+                                    items:
+                                      type: string
+                                    type: array
+                                  namespaceSelector:
+                                    description: 'NamespaceSelector is a label selector
+                                      for the resource namespace. Label keys and values
+                                      in `matchLabels` support the wildcard characters
+                                      `*` (matches zero or many characters) and `?`
+                                      (matches one character).Wildcards allows writing
+                                      label selectors like ["storage.k8s.io/*": "*"].
+                                      Note that using ["*" : "*"] matches any key
+                                      and value but does not match an empty label
+                                      set.'
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaces:
+                                    description: Namespaces is a list of namespaces
+                                      names. Each name supports wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (at least one character).
+                                    items:
+                                      type: string
+                                    type: array
+                                  selector:
+                                    description: 'Selector is a label selector. Label
+                                      keys and values in `matchLabels` support the
+                                      wildcard characters `*` (matches zero or many
+                                      characters) and `?` (matches one character).
+                                      Wildcards allows writing label selectors like
+                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                      : "*"] matches any key and value but does not
+                                      match an empty label set.'
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              roles:
+                                description: Roles is the list of namespaced role
+                                  names for the user.
+                                items:
+                                  type: string
+                                type: array
+                              subjects:
+                                description: Subjects is the list of subject names
+                                  like users, user groups, and service accounts.
+                                items:
+                                  description: Subject contains a reference to the
+                                    object or user identities a role binding applies
+                                    to.  This can either hold a direct API object
+                                    reference, or a value for non-objects such as
+                                    user and group names.
+                                  properties:
+                                    apiGroup:
+                                      description: APIGroup holds the API group of
+                                        the referenced subject. Defaults to "" for
+                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
+                                        for User and Group subjects.
+                                      type: string
+                                    kind:
+                                      description: Kind of object being referenced.
+                                        Values defined by this API group are "User",
+                                        "Group", and "ServiceAccount". If the Authorizer
+                                        does not recognized the kind value, the Authorizer
+                                        should report an error.
+                                      type: string
+                                    name:
+                                      description: Name of the object being referenced.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the referenced object.  If
+                                        the object kind is non-namespace, such as
+                                        "User" or "Group", and this value is not empty
+                                        the Authorizer should report an error.
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                type: array
+                            type: object
+                          type: array
+                        clusterRoles:
+                          description: ClusterRoles is the list of cluster-wide role
+                            names for the user.
+                          items:
+                            type: string
+                          type: array
+                        resources:
+                          description: ResourceDescription contains information about
+                            the resource being created or modified. Requires at least
+                            one tag to be specified when under MatchResources. Specifying
+                            ResourceDescription directly under match is being deprecated.
+                            Please specify under "any" or "all" instead.
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a  map of annotations (key-value
+                                pairs of type string). Annotation keys and values
+                                support the wildcard characters "*" (matches zero
+                                or many characters) and "?" (matches at least one
+                                character).
+                              type: object
+                            kinds:
+                              description: Kinds is a list of resource kinds.
+                              items:
+                                type: string
+                              type: array
+                            name:
+                              description: 'Name is the name of the resource. The
+                                name supports wildcard characters "*" (matches zero
+                                or many characters) and "?" (at least one character).
+                                NOTE: "Name" is being deprecated in favor of "Names".'
+                              type: string
+                            names:
+                              description: Names are the names of the resources. Each
+                                name supports wildcard characters "*" (matches zero
+                                or many characters) and "?" (at least one character).
+                              items:
+                                type: string
+                              type: array
+                            namespaceSelector:
+                              description: 'NamespaceSelector is a label selector
+                                for the resource namespace. Label keys and values
+                                in `matchLabels` support the wildcard characters `*`
+                                (matches zero or many characters) and `?` (matches
+                                one character).Wildcards allows writing label selectors
+                                like ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                : "*"] matches any key and value but does not match
+                                an empty label set.'
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            namespaces:
+                              description: Namespaces is a list of namespaces names.
+                                Each name supports wildcard characters "*" (matches
+                                zero or many characters) and "?" (at least one character).
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: 'Selector is a label selector. Label keys
+                                and values in `matchLabels` support the wildcard characters
+                                `*` (matches zero or many characters) and `?` (matches
+                                one character). Wildcards allows writing label selectors
+                                like ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                : "*"] matches any key and value but does not match
+                                an empty label set.'
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        roles:
+                          description: Roles is the list of namespaced role names
+                            for the user.
+                          items:
+                            type: string
+                          type: array
+                        subjects:
+                          description: Subjects is the list of subject names like
+                            users, user groups, and service accounts.
+                          items:
+                            description: Subject contains a reference to the object
+                              or user identities a role binding applies to.  This
+                              can either hold a direct API object reference, or a
+                              value for non-objects such as user and group names.
+                            properties:
+                              apiGroup:
+                                description: APIGroup holds the API group of the referenced
+                                  subject. Defaults to "" for ServiceAccount subjects.
+                                  Defaults to "rbac.authorization.k8s.io" for User
+                                  and Group subjects.
+                                type: string
+                              kind:
+                                description: Kind of object being referenced. Values
+                                  defined by this API group are "User", "Group", and
+                                  "ServiceAccount". If the Authorizer does not recognized
+                                  the kind value, the Authorizer should report an
+                                  error.
+                                type: string
+                              name:
+                                description: Name of the object being referenced.
+                                type: string
+                              namespace:
+                                description: Namespace of the referenced object.  If
+                                  the object kind is non-namespace, such as "User"
+                                  or "Group", and this value is not empty the Authorizer
+                                  should report an error.
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          type: array
+                      type: object
+                    mutate:
+                      description: Mutation is used to modify matching resources.
+                      properties:
+                        foreach:
+                          description: ForEach applies mutation rules to a list of
+                            sub-elements by creating a context for each entry in the
+                            list and looping over it to apply the specified logic.
+                          items:
+                            description: ForEach applies mutation rules to a list
+                              of sub-elements by creating a context for each entry
+                              in the list and looping over it to apply the specified
+                              logic.
+                            properties:
+                              context:
+                                description: Context defines variables and data sources
+                                  that can be used during rule execution.
+                                items:
+                                  description: ContextEntry adds variables and data
+                                    sources to a rule Context. Either a ConfigMap
+                                    reference or a APILookup must be provided.
+                                  properties:
+                                    apiCall:
+                                      description: APICall defines an HTTP request
+                                        to the Kubernetes API server. The JSON data
+                                        retrieved is stored in the context.
+                                      properties:
+                                        jmesPath:
+                                          description: JMESPath is an optional JSON
+                                            Match Expression that can be used to transform
+                                            the JSON response returned from the API
+                                            server. For example a JMESPath of "items
+                                            | length(@)" applied to the API server
+                                            response to the URLPath "/apis/apps/v1/deployments"
+                                            will return the total count of deployments
+                                            across all namespaces.
+                                          type: string
+                                        urlPath:
+                                          description: URLPath is the URL path to
+                                            be used in the HTTP GET request to the
+                                            Kubernetes API server (e.g. "/api/v1/namespaces"
+                                            or  "/apis/apps/v1/deployments"). The
+                                            format required is the same format used
+                                            by the `kubectl get --raw` command.
+                                          type: string
+                                      required:
+                                      - urlPath
+                                      type: object
+                                    configMap:
+                                      description: ConfigMap is the ConfigMap reference.
+                                      properties:
+                                        name:
+                                          description: Name is the ConfigMap name.
+                                          type: string
+                                        namespace:
+                                          description: Namespace is the ConfigMap
+                                            namespace.
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    imageRegistry:
+                                      description: ImageRegistry defines requests
+                                        to an OCI/Docker V2 registry to fetch image
+                                        details.
+                                      properties:
+                                        jmesPath:
+                                          description: JMESPath is an optional JSON
+                                            Match Expression that can be used to transform
+                                            the ImageData struct returned as a result
+                                            of processing the image reference.
+                                          type: string
+                                        reference:
+                                          description: 'Reference is image reference
+                                            to a container image in the registry.
+                                            Example: ghcr.io/kyverno/kyverno:latest'
+                                          type: string
+                                      required:
+                                      - reference
+                                      type: object
+                                    name:
+                                      description: Name is the variable name.
+                                      type: string
+                                    variable:
+                                      description: Variable defines an arbitrary JMESPath
+                                        context variable that can be defined inline.
+                                      properties:
+                                        default:
+                                          description: Default is an optional arbitrary
+                                            JSON object that the variable may take
+                                            if the JMESPath expression evaluates to
+                                            nil
+                                          x-kubernetes-preserve-unknown-fields: true
+                                        jmesPath:
+                                          description: JMESPath is an optional JMESPath
+                                            Expression that can be used to transform
+                                            the variable.
+                                          type: string
+                                        value:
+                                          description: Value is any arbitrary JSON
+                                            object representable in YAML or JSON form.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                  type: object
+                                type: array
+                              list:
+                                description: List specifies a JMESPath expression
+                                  that results in one or more elements to which the
+                                  validation logic is applied.
+                                type: string
+                              patchStrategicMerge:
+                                description: PatchStrategicMerge is a strategic merge
+                                  patch used to modify resources. See https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/
+                                  and https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.
+                                x-kubernetes-preserve-unknown-fields: true
+                              patchesJson6902:
+                                description: PatchesJSON6902 is a list of RFC 6902
+                                  JSON Patch declarations used to modify resources.
+                                  See https://tools.ietf.org/html/rfc6902 and https://kubectl.docs.kubernetes.io/references/kustomize/patchesjson6902/.
+                                type: string
+                              preconditions:
+                                description: 'AnyAllConditions are used to determine
+                                  if a policy rule should be applied by evaluating
+                                  a set of conditions. The declaration can contain
+                                  nested `any` or `all` statements. See: https://kyverno.io/docs/writing-policies/preconditions/'
+                                properties:
+                                  all:
+                                    description: AllConditions enable variable-based
+                                      conditional rule execution. This is useful for
+                                      finer control of when an rule is applied. A
+                                      condition can reference object data using JMESPath
+                                      notation. Here, all of the conditions need to
+                                      pass
+                                    items:
+                                      description: Condition defines variable-based
+                                        conditional criteria for rule execution.
+                                      properties:
+                                        key:
+                                          description: Key is the context entry (using
+                                            JMESPath) for conditional rule evaluation.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                        operator:
+                                          description: 'Operator is the conditional
+                                            operation to perform. Valid operators
+                                            are: Equals, NotEquals, In, AnyIn, AllIn,
+                                            NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,
+                                            GreaterThan, LessThanOrEquals, LessThan,
+                                            DurationGreaterThanOrEquals, DurationGreaterThan,
+                                            DurationLessThanOrEquals, DurationLessThan'
+                                          enum:
+                                          - Equals
+                                          - NotEquals
+                                          - In
+                                          - AnyIn
+                                          - AllIn
+                                          - NotIn
+                                          - AnyNotIn
+                                          - AllNotIn
+                                          - GreaterThanOrEquals
+                                          - GreaterThan
+                                          - LessThanOrEquals
+                                          - LessThan
+                                          - DurationGreaterThanOrEquals
+                                          - DurationGreaterThan
+                                          - DurationLessThanOrEquals
+                                          - DurationLessThan
+                                          type: string
+                                        value:
+                                          description: Value is the conditional value,
+                                            or set of values. The values can be fixed
+                                            set or can be variables declared using
+                                            JMESPath.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                    type: array
+                                  any:
+                                    description: AnyConditions enable variable-based
+                                      conditional rule execution. This is useful for
+                                      finer control of when an rule is applied. A
+                                      condition can reference object data using JMESPath
+                                      notation. Here, at least one of the conditions
+                                      need to pass
+                                    items:
+                                      description: Condition defines variable-based
+                                        conditional criteria for rule execution.
+                                      properties:
+                                        key:
+                                          description: Key is the context entry (using
+                                            JMESPath) for conditional rule evaluation.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                        operator:
+                                          description: 'Operator is the conditional
+                                            operation to perform. Valid operators
+                                            are: Equals, NotEquals, In, AnyIn, AllIn,
+                                            NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,
+                                            GreaterThan, LessThanOrEquals, LessThan,
+                                            DurationGreaterThanOrEquals, DurationGreaterThan,
+                                            DurationLessThanOrEquals, DurationLessThan'
+                                          enum:
+                                          - Equals
+                                          - NotEquals
+                                          - In
+                                          - AnyIn
+                                          - AllIn
+                                          - NotIn
+                                          - AnyNotIn
+                                          - AllNotIn
+                                          - GreaterThanOrEquals
+                                          - GreaterThan
+                                          - LessThanOrEquals
+                                          - LessThan
+                                          - DurationGreaterThanOrEquals
+                                          - DurationGreaterThan
+                                          - DurationLessThanOrEquals
+                                          - DurationLessThan
+                                          type: string
+                                        value:
+                                          description: Value is the conditional value,
+                                            or set of values. The values can be fixed
+                                            set or can be variables declared using
+                                            JMESPath.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                    type: array
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          type: array
+                        patchStrategicMerge:
+                          description: PatchStrategicMerge is a strategic merge patch
+                            used to modify resources. See https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/
+                            and https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.
+                          x-kubernetes-preserve-unknown-fields: true
+                        patchesJson6902:
+                          description: PatchesJSON6902 is a list of RFC 6902 JSON
+                            Patch declarations used to modify resources. See https://tools.ietf.org/html/rfc6902
+                            and https://kubectl.docs.kubernetes.io/references/kustomize/patchesjson6902/.
+                          type: string
+                        targets:
+                          description: Targets defines the target resources to be
+                            mutated.
+                          items:
+                            properties:
+                              apiVersion:
+                                description: APIVersion specifies resource apiVersion.
+                                type: string
+                              kind:
+                                description: Kind specifies resource kind.
+                                type: string
+                              name:
+                                description: Name specifies the resource name.
+                                type: string
+                              namespace:
+                                description: Namespace specifies resource namespace.
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    name:
+                      description: Name is a label to identify the rule, It must be
+                        unique within the policy.
+                      maxLength: 63
+                      type: string
+                    preconditions:
+                      description: 'Preconditions are used to determine if a policy
+                        rule should be applied by evaluating a set of conditions.
+                        The declaration can contain nested `any` or `all` statements.
+                        A direct list of conditions (without `any` or `all` statements
+                        is supported for backwards compatibility but will be deprecated
+                        in the next major release. See: https://kyverno.io/docs/writing-policies/preconditions/'
+                      x-kubernetes-preserve-unknown-fields: true
+                    validate:
+                      description: Validation is used to validate matching resources.
+                      properties:
+                        anyPattern:
+                          description: AnyPattern specifies list of validation patterns.
+                            At least one of the patterns must be satisfied for the
+                            validation rule to succeed.
+                          x-kubernetes-preserve-unknown-fields: true
+                        deny:
+                          description: Deny defines conditions used to pass or fail
+                            a validation rule.
+                          properties:
+                            conditions:
+                              description: 'Multiple conditions can be declared under
+                                an `any` or `all` statement. A direct list of conditions
+                                (without `any` or `all` statements) is also supported
+                                for backwards compatibility but will be deprecated
+                                in the next major release. See: https://kyverno.io/docs/writing-policies/validate/#deny-rules'
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                        foreach:
+                          description: ForEach applies validate rules to a list of
+                            sub-elements by creating a context for each entry in the
+                            list and looping over it to apply the specified logic.
+                          items:
+                            description: ForEach applies validate rules to a list
+                              of sub-elements by creating a context for each entry
+                              in the list and looping over it to apply the specified
+                              logic.
+                            properties:
+                              anyPattern:
+                                description: AnyPattern specifies list of validation
+                                  patterns. At least one of the patterns must be satisfied
+                                  for the validation rule to succeed.
+                                x-kubernetes-preserve-unknown-fields: true
+                              context:
+                                description: Context defines variables and data sources
+                                  that can be used during rule execution.
+                                items:
+                                  description: ContextEntry adds variables and data
+                                    sources to a rule Context. Either a ConfigMap
+                                    reference or a APILookup must be provided.
+                                  properties:
+                                    apiCall:
+                                      description: APICall defines an HTTP request
+                                        to the Kubernetes API server. The JSON data
+                                        retrieved is stored in the context.
+                                      properties:
+                                        jmesPath:
+                                          description: JMESPath is an optional JSON
+                                            Match Expression that can be used to transform
+                                            the JSON response returned from the API
+                                            server. For example a JMESPath of "items
+                                            | length(@)" applied to the API server
+                                            response to the URLPath "/apis/apps/v1/deployments"
+                                            will return the total count of deployments
+                                            across all namespaces.
+                                          type: string
+                                        urlPath:
+                                          description: URLPath is the URL path to
+                                            be used in the HTTP GET request to the
+                                            Kubernetes API server (e.g. "/api/v1/namespaces"
+                                            or  "/apis/apps/v1/deployments"). The
+                                            format required is the same format used
+                                            by the `kubectl get --raw` command.
+                                          type: string
+                                      required:
+                                      - urlPath
+                                      type: object
+                                    configMap:
+                                      description: ConfigMap is the ConfigMap reference.
+                                      properties:
+                                        name:
+                                          description: Name is the ConfigMap name.
+                                          type: string
+                                        namespace:
+                                          description: Namespace is the ConfigMap
+                                            namespace.
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    imageRegistry:
+                                      description: ImageRegistry defines requests
+                                        to an OCI/Docker V2 registry to fetch image
+                                        details.
+                                      properties:
+                                        jmesPath:
+                                          description: JMESPath is an optional JSON
+                                            Match Expression that can be used to transform
+                                            the ImageData struct returned as a result
+                                            of processing the image reference.
+                                          type: string
+                                        reference:
+                                          description: 'Reference is image reference
+                                            to a container image in the registry.
+                                            Example: ghcr.io/kyverno/kyverno:latest'
+                                          type: string
+                                      required:
+                                      - reference
+                                      type: object
+                                    name:
+                                      description: Name is the variable name.
+                                      type: string
+                                    variable:
+                                      description: Variable defines an arbitrary JMESPath
+                                        context variable that can be defined inline.
+                                      properties:
+                                        default:
+                                          description: Default is an optional arbitrary
+                                            JSON object that the variable may take
+                                            if the JMESPath expression evaluates to
+                                            nil
+                                          x-kubernetes-preserve-unknown-fields: true
+                                        jmesPath:
+                                          description: JMESPath is an optional JMESPath
+                                            Expression that can be used to transform
+                                            the variable.
+                                          type: string
+                                        value:
+                                          description: Value is any arbitrary JSON
+                                            object representable in YAML or JSON form.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                  type: object
+                                type: array
+                              deny:
+                                description: Deny defines conditions used to pass
+                                  or fail a validation rule.
+                                properties:
+                                  conditions:
+                                    description: 'Multiple conditions can be declared
+                                      under an `any` or `all` statement. A direct
+                                      list of conditions (without `any` or `all` statements)
+                                      is also supported for backwards compatibility
+                                      but will be deprecated in the next major release.
+                                      See: https://kyverno.io/docs/writing-policies/validate/#deny-rules'
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              elementScope:
+                                description: ElementScope specifies whether to use
+                                  the current list element as the scope for validation.
+                                  Defaults to "true" if not specified. When set to
+                                  "false", "request.object" is used as the validation
+                                  scope within the foreach block to allow referencing
+                                  other elements in the subtree.
+                                type: boolean
+                              list:
+                                description: List specifies a JMESPath expression
+                                  that results in one or more elements to which the
+                                  validation logic is applied.
+                                type: string
+                              pattern:
+                                description: Pattern specifies an overlay-style pattern
+                                  used to check resources.
+                                x-kubernetes-preserve-unknown-fields: true
+                              preconditions:
+                                description: 'AnyAllConditions are used to determine
+                                  if a policy rule should be applied by evaluating
+                                  a set of conditions. The declaration can contain
+                                  nested `any` or `all` statements. See: https://kyverno.io/docs/writing-policies/preconditions/'
+                                properties:
+                                  all:
+                                    description: AllConditions enable variable-based
+                                      conditional rule execution. This is useful for
+                                      finer control of when an rule is applied. A
+                                      condition can reference object data using JMESPath
+                                      notation. Here, all of the conditions need to
+                                      pass
+                                    items:
+                                      description: Condition defines variable-based
+                                        conditional criteria for rule execution.
+                                      properties:
+                                        key:
+                                          description: Key is the context entry (using
+                                            JMESPath) for conditional rule evaluation.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                        operator:
+                                          description: 'Operator is the conditional
+                                            operation to perform. Valid operators
+                                            are: Equals, NotEquals, In, AnyIn, AllIn,
+                                            NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,
+                                            GreaterThan, LessThanOrEquals, LessThan,
+                                            DurationGreaterThanOrEquals, DurationGreaterThan,
+                                            DurationLessThanOrEquals, DurationLessThan'
+                                          enum:
+                                          - Equals
+                                          - NotEquals
+                                          - In
+                                          - AnyIn
+                                          - AllIn
+                                          - NotIn
+                                          - AnyNotIn
+                                          - AllNotIn
+                                          - GreaterThanOrEquals
+                                          - GreaterThan
+                                          - LessThanOrEquals
+                                          - LessThan
+                                          - DurationGreaterThanOrEquals
+                                          - DurationGreaterThan
+                                          - DurationLessThanOrEquals
+                                          - DurationLessThan
+                                          type: string
+                                        value:
+                                          description: Value is the conditional value,
+                                            or set of values. The values can be fixed
+                                            set or can be variables declared using
+                                            JMESPath.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                    type: array
+                                  any:
+                                    description: AnyConditions enable variable-based
+                                      conditional rule execution. This is useful for
+                                      finer control of when an rule is applied. A
+                                      condition can reference object data using JMESPath
+                                      notation. Here, at least one of the conditions
+                                      need to pass
+                                    items:
+                                      description: Condition defines variable-based
+                                        conditional criteria for rule execution.
+                                      properties:
+                                        key:
+                                          description: Key is the context entry (using
+                                            JMESPath) for conditional rule evaluation.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                        operator:
+                                          description: 'Operator is the conditional
+                                            operation to perform. Valid operators
+                                            are: Equals, NotEquals, In, AnyIn, AllIn,
+                                            NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,
+                                            GreaterThan, LessThanOrEquals, LessThan,
+                                            DurationGreaterThanOrEquals, DurationGreaterThan,
+                                            DurationLessThanOrEquals, DurationLessThan'
+                                          enum:
+                                          - Equals
+                                          - NotEquals
+                                          - In
+                                          - AnyIn
+                                          - AllIn
+                                          - NotIn
+                                          - AnyNotIn
+                                          - AllNotIn
+                                          - GreaterThanOrEquals
+                                          - GreaterThan
+                                          - LessThanOrEquals
+                                          - LessThan
+                                          - DurationGreaterThanOrEquals
+                                          - DurationGreaterThan
+                                          - DurationLessThanOrEquals
+                                          - DurationLessThan
+                                          type: string
+                                        value:
+                                          description: Value is the conditional value,
+                                            or set of values. The values can be fixed
+                                            set or can be variables declared using
+                                            JMESPath.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                    type: array
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          type: array
+                        manifests:
+                          description: Manifest specifies conditions for manifest
+                            verification
+                          properties:
+                            annotationDomain:
+                              description: AnnotationDomain is custom domain of annotation
+                                for message and signature. Default is "cosign.sigstore.dev".
+                              type: string
+                            attestors:
+                              description: Attestors specified the required attestors
+                                (i.e. authorities)
+                              items:
+                                properties:
+                                  count:
+                                    description: Count specifies the required number
+                                      of entries that must match. If the count is
+                                      null, all entries must match (a logical AND).
+                                      If the count is 1, at least one entry must match
+                                      (a logical OR). If the count contains a value
+                                      N, then N must be less than or equal to the
+                                      size of entries, and at least N entries must
+                                      match.
+                                    minimum: 1
+                                    type: integer
+                                  entries:
+                                    description: Entries contains the available attestors.
+                                      An attestor can be a static key, attributes
+                                      for keyless verification, or a nested attestor
+                                      declaration.
+                                    items:
+                                      properties:
+                                        annotations:
+                                          additionalProperties:
+                                            type: string
+                                          description: Annotations are used for image
+                                            verification. Every specified key-value
+                                            pair must exist and match in the verified
+                                            payload. The payload may contain other
+                                            key-value pairs.
+                                          type: object
+                                        attestor:
+                                          description: Attestor is a nested AttestorSet
+                                            used to specify a more complex set of
+                                            match authorities
+                                          x-kubernetes-preserve-unknown-fields: true
+                                        certificates:
+                                          description: Certificates specifies one
+                                            or more certificates
+                                          properties:
+                                            cert:
+                                              description: Certificate is an optional
+                                                PEM encoded public certificate.
+                                              type: string
+                                            certChain:
+                                              description: CertificateChain is an
+                                                optional PEM encoded set of certificates
+                                                used to verify
+                                              type: string
+                                            rekor:
+                                              description: Rekor provides configuration
+                                                for the Rekor transparency log service.
+                                                If the value is nil, Rekor is not
+                                                checked. If an empty object is provided
+                                                the public instance of Rekor (https://rekor.sigstore.dev)
+                                                is used.
+                                              properties:
+                                                url:
+                                                  description: URL is the address
+                                                    of the transparency log. Defaults
+                                                    to the public log https://rekor.sigstore.dev.
+                                                  type: string
+                                              required:
+                                              - url
+                                              type: object
+                                          type: object
+                                        keyless:
+                                          description: Keyless is a set of attribute
+                                            used to verify a Sigstore keyless attestor.
+                                            See https://github.com/sigstore/cosign/blob/main/KEYLESS.md.
+                                          properties:
+                                            additionalExtensions:
+                                              additionalProperties:
+                                                type: string
+                                              description: AdditionalExtensions are
+                                                certificate-extensions used for keyless
+                                                signing.
+                                              type: object
+                                            issuer:
+                                              description: Issuer is the certificate
+                                                issuer used for keyless signing.
+                                              type: string
+                                            rekor:
+                                              description: Rekor provides configuration
+                                                for the Rekor transparency log service.
+                                                If the value is nil, Rekor is not
+                                                checked and a root certificate chain
+                                                is expected instead. If an empty object
+                                                is provided the public instance of
+                                                Rekor (https://rekor.sigstore.dev)
+                                                is used.
+                                              properties:
+                                                url:
+                                                  description: URL is the address
+                                                    of the transparency log. Defaults
+                                                    to the public log https://rekor.sigstore.dev.
+                                                  type: string
+                                              required:
+                                              - url
+                                              type: object
+                                            roots:
+                                              description: Roots is an optional set
+                                                of PEM encoded trusted root certificates.
+                                                If not provided, the system roots
+                                                are used.
+                                              type: string
+                                            subject:
+                                              description: Subject is the verified
+                                                identity used for keyless signing,
+                                                for example the email address
+                                              type: string
+                                          type: object
+                                        keys:
+                                          description: Keys specifies one or more
+                                            public keys
+                                          properties:
+                                            publicKeys:
+                                              description: Keys is a set of X.509
+                                                public keys used to verify image signatures.
+                                                The keys can be directly specified
+                                                or can be a variable reference to
+                                                a key specified in a ConfigMap (see
+                                                https://kyverno.io/docs/writing-policies/variables/).
+                                                When multiple keys are specified each
+                                                key is processed as a separate staticKey
+                                                entry (.attestors[*].entries.keys)
+                                                within the set of attestors and the
+                                                count is applied across the keys.
+                                              type: string
+                                            rekor:
+                                              description: Rekor provides configuration
+                                                for the Rekor transparency log service.
+                                                If the value is nil, Rekor is not
+                                                checked. If an empty object is provided
+                                                the public instance of Rekor (https://rekor.sigstore.dev)
+                                                is used.
+                                              properties:
+                                                url:
+                                                  description: URL is the address
+                                                    of the transparency log. Defaults
+                                                    to the public log https://rekor.sigstore.dev.
+                                                  type: string
+                                              required:
+                                              - url
+                                              type: object
+                                          type: object
+                                        repository:
+                                          description: Repository is an optional alternate
+                                            OCI repository to use for signatures and
+                                            attestations that match this rule. If
+                                            specified Repository will override other
+                                            OCI image repository locations for this
+                                            Attestor.
+                                          type: string
+                                      type: object
+                                    type: array
+                                type: object
+                              type: array
+                            dryRun:
+                              description: DryRun configuration
+                              properties:
+                                enable:
+                                  type: boolean
+                                namespace:
+                                  type: string
+                              type: object
+                            ignoreFields:
+                              description: Fields which will be ignored while comparing
+                                manifests.
+                              items:
+                                properties:
+                                  fields:
+                                    items:
+                                      type: string
+                                    type: array
+                                  objects:
+                                    items:
+                                      properties:
+                                        group:
+                                          type: string
+                                        kind:
+                                          type: string
+                                        name:
+                                          type: string
+                                        namespace:
+                                          type: string
+                                        version:
+                                          type: string
+                                      type: object
+                                    type: array
+                                type: object
+                              type: array
+                            repository:
+                              description: Repository is an optional alternate OCI
+                                repository to use for resource bundle reference. The
+                                repository can be overridden per Attestor or Attestation.
+                              type: string
+                          type: object
+                        message:
+                          description: Message specifies a custom message to be displayed
+                            on failure.
+                          type: string
+                        pattern:
+                          description: Pattern specifies an overlay-style pattern
+                            used to check resources.
+                          x-kubernetes-preserve-unknown-fields: true
+                        podSecurity:
+                          description: PodSecurity applies exemptions for Kubernetes
+                            Pod Security admission by specifying exclusions for Pod
+                            Security Standards controls.
+                          properties:
+                            exclude:
+                              description: Exclude specifies the Pod Security Standard
+                                controls to be excluded.
+                              items:
+                                description: PodSecurityStandard specifies the Pod
+                                  Security Standard controls to be excluded.
+                                properties:
+                                  controlName:
+                                    description: 'ControlName specifies the name of
+                                      the Pod Security Standard control. See: https://kubernetes.io/docs/concepts/security/pod-security-standards/'
+                                    enum:
+                                    - HostProcess
+                                    - Host Namespaces
+                                    - Privileged Containers
+                                    - Capabilities
+                                    - HostPath Volumes
+                                    - Host Ports
+                                    - AppArmor
+                                    - SELinux
+                                    - /proc Mount Type
+                                    - Seccomp
+                                    - Sysctls
+                                    - Volume Types
+                                    - Privilege Escalation
+                                    - Running as Non-root
+                                    - Running as Non-root user
+                                    type: string
+                                  images:
+                                    description: 'Images selects matching containers
+                                      and applies the container level PSS. Each image
+                                      is the image name consisting of the registry
+                                      address, repository, image, and tag. Empty list
+                                      matches no containers, PSS checks are applied
+                                      at the pod level only. Wildcards (''*'' and
+                                      ''?'') are allowed. See: https://kubernetes.io/docs/concepts/containers/images.'
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - controlName
+                                type: object
+                              type: array
+                            level:
+                              description: Level defines the Pod Security Standard
+                                level to be applied to workloads. Allowed values are
+                                privileged, baseline, and restricted.
+                              enum:
+                              - privileged
+                              - baseline
+                              - restricted
+                              type: string
+                            version:
+                              description: Version defines the Pod Security Standard
+                                versions that Kubernetes supports. Allowed values
+                                are v1.19, v1.20, v1.21, v1.22, v1.23, v1.24, v1.25,
+                                latest. Defaults to latest.
+                              enum:
+                              - v1.19
+                              - v1.20
+                              - v1.21
+                              - v1.22
+                              - v1.23
+                              - v1.24
+                              - v1.25
+                              - latest
+                              type: string
+                          type: object
+                      type: object
+                    verifyImages:
+                      description: VerifyImages is used to verify image signatures
+                        and mutate them to add a digest
+                      items:
+                        description: ImageVerification validates that images that
+                          match the specified pattern are signed with the supplied
+                          public key. Once the image is verified it is mutated to
+                          include the SHA digest retrieved during the registration.
+                        properties:
+                          additionalExtensions:
+                            additionalProperties:
+                              type: string
+                            description: AdditionalExtensions are certificate-extensions
+                              used for keyless signing. Deprecated.
+                            type: object
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: Annotations are used for image verification.
+                              Every specified key-value pair must exist and match
+                              in the verified payload. The payload may contain other
+                              key-value pairs. Deprecated. Use annotations per Attestor
+                              instead.
+                            type: object
+                          attestations:
+                            description: Attestations are optional checks for signed
+                              in-toto Statements used to verify the image. See https://github.com/in-toto/attestation.
+                              Kyverno fetches signed attestations from the OCI registry
+                              and decodes them into a list of Statement declarations.
+                            items:
+                              description: Attestation are checks for signed in-toto
+                                Statements that are used to verify the image. See
+                                https://github.com/in-toto/attestation. Kyverno fetches
+                                signed attestations from the OCI registry and decodes
+                                them into a list of Statements.
+                              properties:
+                                conditions:
+                                  description: Conditions are used to verify attributes
+                                    within a Predicate. If no Conditions are specified
+                                    the attestation check is satisfied as long there
+                                    are predicates that match the predicate type.
+                                  items:
+                                    description: AnyAllConditions consists of conditions
+                                      wrapped denoting a logical criteria to be fulfilled.
+                                      AnyConditions get fulfilled when at least one
+                                      of its sub-conditions passes. AllConditions
+                                      get fulfilled only when all of its sub-conditions
+                                      pass.
+                                    properties:
+                                      all:
+                                        description: AllConditions enable variable-based
+                                          conditional rule execution. This is useful
+                                          for finer control of when an rule is applied.
+                                          A condition can reference object data using
+                                          JMESPath notation. Here, all of the conditions
+                                          need to pass
+                                        items:
+                                          description: Condition defines variable-based
+                                            conditional criteria for rule execution.
+                                          properties:
+                                            key:
+                                              description: Key is the context entry
+                                                (using JMESPath) for conditional rule
+                                                evaluation.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            operator:
+                                              description: 'Operator is the conditional
+                                                operation to perform. Valid operators
+                                                are: Equals, NotEquals, In, AnyIn,
+                                                AllIn, NotIn, AnyNotIn, AllNotIn,
+                                                GreaterThanOrEquals, GreaterThan,
+                                                LessThanOrEquals, LessThan, DurationGreaterThanOrEquals,
+                                                DurationGreaterThan, DurationLessThanOrEquals,
+                                                DurationLessThan'
+                                              enum:
+                                              - Equals
+                                              - NotEquals
+                                              - In
+                                              - AnyIn
+                                              - AllIn
+                                              - NotIn
+                                              - AnyNotIn
+                                              - AllNotIn
+                                              - GreaterThanOrEquals
+                                              - GreaterThan
+                                              - LessThanOrEquals
+                                              - LessThan
+                                              - DurationGreaterThanOrEquals
+                                              - DurationGreaterThan
+                                              - DurationLessThanOrEquals
+                                              - DurationLessThan
+                                              type: string
+                                            value:
+                                              description: Value is the conditional
+                                                value, or set of values. The values
+                                                can be fixed set or can be variables
+                                                declared using JMESPath.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                        type: array
+                                      any:
+                                        description: AnyConditions enable variable-based
+                                          conditional rule execution. This is useful
+                                          for finer control of when an rule is applied.
+                                          A condition can reference object data using
+                                          JMESPath notation. Here, at least one of
+                                          the conditions need to pass
+                                        items:
+                                          description: Condition defines variable-based
+                                            conditional criteria for rule execution.
+                                          properties:
+                                            key:
+                                              description: Key is the context entry
+                                                (using JMESPath) for conditional rule
+                                                evaluation.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            operator:
+                                              description: 'Operator is the conditional
+                                                operation to perform. Valid operators
+                                                are: Equals, NotEquals, In, AnyIn,
+                                                AllIn, NotIn, AnyNotIn, AllNotIn,
+                                                GreaterThanOrEquals, GreaterThan,
+                                                LessThanOrEquals, LessThan, DurationGreaterThanOrEquals,
+                                                DurationGreaterThan, DurationLessThanOrEquals,
+                                                DurationLessThan'
+                                              enum:
+                                              - Equals
+                                              - NotEquals
+                                              - In
+                                              - AnyIn
+                                              - AllIn
+                                              - NotIn
+                                              - AnyNotIn
+                                              - AllNotIn
+                                              - GreaterThanOrEquals
+                                              - GreaterThan
+                                              - LessThanOrEquals
+                                              - LessThan
+                                              - DurationGreaterThanOrEquals
+                                              - DurationGreaterThan
+                                              - DurationLessThanOrEquals
+                                              - DurationLessThan
+                                              type: string
+                                            value:
+                                              description: Value is the conditional
+                                                value, or set of values. The values
+                                                can be fixed set or can be variables
+                                                declared using JMESPath.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                        type: array
+                                    type: object
+                                  type: array
+                                predicateType:
+                                  description: PredicateType defines the type of Predicate
+                                    contained within the Statement.
+                                  type: string
+                              type: object
+                            type: array
+                          attestors:
+                            description: Attestors specified the required attestors
+                              (i.e. authorities)
+                            items:
+                              properties:
+                                count:
+                                  description: Count specifies the required number
+                                    of entries that must match. If the count is null,
+                                    all entries must match (a logical AND). If the
+                                    count is 1, at least one entry must match (a logical
+                                    OR). If the count contains a value N, then N must
+                                    be less than or equal to the size of entries,
+                                    and at least N entries must match.
+                                  minimum: 1
+                                  type: integer
+                                entries:
+                                  description: Entries contains the available attestors.
+                                    An attestor can be a static key, attributes for
+                                    keyless verification, or a nested attestor declaration.
+                                  items:
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations are used for image
+                                          verification. Every specified key-value
+                                          pair must exist and match in the verified
+                                          payload. The payload may contain other key-value
+                                          pairs.
+                                        type: object
+                                      attestor:
+                                        description: Attestor is a nested AttestorSet
+                                          used to specify a more complex set of match
+                                          authorities
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      certificates:
+                                        description: Certificates specifies one or
+                                          more certificates
+                                        properties:
+                                          cert:
+                                            description: Certificate is an optional
+                                              PEM encoded public certificate.
+                                            type: string
+                                          certChain:
+                                            description: CertificateChain is an optional
+                                              PEM encoded set of certificates used
+                                              to verify
+                                            type: string
+                                          rekor:
+                                            description: Rekor provides configuration
+                                              for the Rekor transparency log service.
+                                              If the value is nil, Rekor is not checked.
+                                              If an empty object is provided the public
+                                              instance of Rekor (https://rekor.sigstore.dev)
+                                              is used.
+                                            properties:
+                                              url:
+                                                description: URL is the address of
+                                                  the transparency log. Defaults to
+                                                  the public log https://rekor.sigstore.dev.
+                                                type: string
+                                            required:
+                                            - url
+                                            type: object
+                                        type: object
+                                      keyless:
+                                        description: Keyless is a set of attribute
+                                          used to verify a Sigstore keyless attestor.
+                                          See https://github.com/sigstore/cosign/blob/main/KEYLESS.md.
+                                        properties:
+                                          additionalExtensions:
+                                            additionalProperties:
+                                              type: string
+                                            description: AdditionalExtensions are
+                                              certificate-extensions used for keyless
+                                              signing.
+                                            type: object
+                                          issuer:
+                                            description: Issuer is the certificate
+                                              issuer used for keyless signing.
+                                            type: string
+                                          rekor:
+                                            description: Rekor provides configuration
+                                              for the Rekor transparency log service.
+                                              If the value is nil, Rekor is not checked
+                                              and a root certificate chain is expected
+                                              instead. If an empty object is provided
+                                              the public instance of Rekor (https://rekor.sigstore.dev)
+                                              is used.
+                                            properties:
+                                              url:
+                                                description: URL is the address of
+                                                  the transparency log. Defaults to
+                                                  the public log https://rekor.sigstore.dev.
+                                                type: string
+                                            required:
+                                            - url
+                                            type: object
+                                          roots:
+                                            description: Roots is an optional set
+                                              of PEM encoded trusted root certificates.
+                                              If not provided, the system roots are
+                                              used.
+                                            type: string
+                                          subject:
+                                            description: Subject is the verified identity
+                                              used for keyless signing, for example
+                                              the email address
+                                            type: string
+                                        type: object
+                                      keys:
+                                        description: Keys specifies one or more public
+                                          keys
+                                        properties:
+                                          publicKeys:
+                                            description: Keys is a set of X.509 public
+                                              keys used to verify image signatures.
+                                              The keys can be directly specified or
+                                              can be a variable reference to a key
+                                              specified in a ConfigMap (see https://kyverno.io/docs/writing-policies/variables/).
+                                              When multiple keys are specified each
+                                              key is processed as a separate staticKey
+                                              entry (.attestors[*].entries.keys) within
+                                              the set of attestors and the count is
+                                              applied across the keys.
+                                            type: string
+                                          rekor:
+                                            description: Rekor provides configuration
+                                              for the Rekor transparency log service.
+                                              If the value is nil, Rekor is not checked.
+                                              If an empty object is provided the public
+                                              instance of Rekor (https://rekor.sigstore.dev)
+                                              is used.
+                                            properties:
+                                              url:
+                                                description: URL is the address of
+                                                  the transparency log. Defaults to
+                                                  the public log https://rekor.sigstore.dev.
+                                                type: string
+                                            required:
+                                            - url
+                                            type: object
+                                        type: object
+                                      repository:
+                                        description: Repository is an optional alternate
+                                          OCI repository to use for signatures and
+                                          attestations that match this rule. If specified
+                                          Repository will override other OCI image
+                                          repository locations for this Attestor.
+                                        type: string
+                                    type: object
+                                  type: array
+                              type: object
+                            type: array
+                          image:
+                            description: 'Image is the image name consisting of the
+                              registry address, repository, image, and tag. Wildcards
+                              (''*'' and ''?'') are allowed. See: https://kubernetes.io/docs/concepts/containers/images.
+                              Deprecated. Use ImageReferences instead.'
+                            type: string
+                          imageReferences:
+                            description: 'ImageReferences is a list of matching image
+                              reference patterns. At least one pattern in the list
+                              must match the image for the rule to apply. Each image
+                              reference consists of a registry address (defaults to
+                              docker.io), repository, image, and tag (defaults to
+                              latest). Wildcards (''*'' and ''?'') are allowed. See:
+                              https://kubernetes.io/docs/concepts/containers/images.'
+                            items:
+                              type: string
+                            type: array
+                          issuer:
+                            description: Issuer is the certificate issuer used for
+                              keyless signing. Deprecated. Use KeylessAttestor instead.
+                            type: string
+                          key:
+                            description: Key is the PEM encoded public key that the
+                              image or attestation is signed with. Deprecated. Use
+                              StaticKeyAttestor instead.
+                            type: string
+                          mutateDigest:
+                            default: true
+                            description: MutateDigest enables replacement of image
+                              tags with digests. Defaults to true.
+                            type: boolean
+                          repository:
+                            description: Repository is an optional alternate OCI repository
+                              to use for image signatures and attestations that match
+                              this rule. If specified Repository will override the
+                              default OCI image repository configured for the installation.
+                              The repository can also be overridden per Attestor or
+                              Attestation.
+                            type: string
+                          required:
+                            default: true
+                            description: Required validates that images are verified
+                              i.e. have matched passed a signature or attestation
+                              check.
+                            type: boolean
+                          roots:
+                            description: Roots is the PEM encoded Root certificate
+                              chain used for keyless signing Deprecated. Use KeylessAttestor
+                              instead.
+                            type: string
+                          subject:
+                            description: Subject is the identity used for keyless
+                              signing, for example an email address Deprecated. Use
+                              KeylessAttestor instead.
+                            type: string
+                          verifyDigest:
+                            default: true
+                            description: VerifyDigest validates that images have a
+                              digest.
+                            type: boolean
+                        type: object
+                      type: array
+                  type: object
+                type: array
+              schemaValidation:
+                description: SchemaValidation skips policy validation checks. Optional.
+                  The default value is set to "true", it must be set to "false" to
+                  disable the validation checks.
+                type: boolean
+              validationFailureAction:
+                default: audit
+                description: ValidationFailureAction defines if a validation policy
+                  rule violation should block the admission review request (enforce),
+                  or allow (audit) the admission review request and report an error
+                  in a policy report. Optional. Allowed values are audit or enforce.
+                  The default value is "audit".
+                enum:
+                - audit
+                - enforce
+                type: string
+              validationFailureActionOverrides:
+                description: ValidationFailureActionOverrides is a Cluster Policy
+                  attribute that specifies ValidationFailureAction namespace-wise.
+                  It overrides ValidationFailureAction for the specified namespaces.
+                items:
+                  properties:
+                    action:
+                      description: ValidationFailureAction defines the policy validation
+                        failure action
+                      enum:
+                      - audit
+                      - enforce
+                      type: string
+                    namespaces:
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                type: array
+              webhookTimeoutSeconds:
+                description: WebhookTimeoutSeconds specifies the maximum time in seconds
+                  allowed to apply this policy. After the configured time expires,
+                  the admission request may fail, or may simply ignore the policy
+                  results, based on the failure policy. The default timeout is 10s,
+                  the value must be between 1 and 30 seconds.
+                format: int32
+                type: integer
+            type: object
+          status:
+            description: Status contains policy runtime information. Deprecated. Policy
+              metrics are available via the metrics endpoint
+            properties:
+              autogen:
+                description: Autogen contains autogen status information
+                properties:
+                  rules:
+                    description: Rules is a list of Rule instances. It contains auto
+                      generated rules added for pod controllers
+                    items:
+                      description: Rule defines a validation, mutation, or generation
+                        control for matching resources. Each rules contains a match
+                        declaration to select resources, and an optional exclude declaration
+                        to specify which resources to exclude.
+                      properties:
+                        context:
+                          description: Context defines variables and data sources
+                            that can be used during rule execution.
+                          items:
+                            description: ContextEntry adds variables and data sources
+                              to a rule Context. Either a ConfigMap reference or a
+                              APILookup must be provided.
+                            properties:
+                              apiCall:
+                                description: APICall defines an HTTP request to the
+                                  Kubernetes API server. The JSON data retrieved is
+                                  stored in the context.
+                                properties:
+                                  jmesPath:
+                                    description: JMESPath is an optional JSON Match
+                                      Expression that can be used to transform the
+                                      JSON response returned from the API server.
+                                      For example a JMESPath of "items | length(@)"
+                                      applied to the API server response to the URLPath
+                                      "/apis/apps/v1/deployments" will return the
+                                      total count of deployments across all namespaces.
+                                    type: string
+                                  urlPath:
+                                    description: URLPath is the URL path to be used
+                                      in the HTTP GET request to the Kubernetes API
+                                      server (e.g. "/api/v1/namespaces" or  "/apis/apps/v1/deployments").
+                                      The format required is the same format used
+                                      by the `kubectl get --raw` command.
+                                    type: string
+                                required:
+                                - urlPath
+                                type: object
+                              configMap:
+                                description: ConfigMap is the ConfigMap reference.
+                                properties:
+                                  name:
+                                    description: Name is the ConfigMap name.
+                                    type: string
+                                  namespace:
+                                    description: Namespace is the ConfigMap namespace.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              imageRegistry:
+                                description: ImageRegistry defines requests to an
+                                  OCI/Docker V2 registry to fetch image details.
+                                properties:
+                                  jmesPath:
+                                    description: JMESPath is an optional JSON Match
+                                      Expression that can be used to transform the
+                                      ImageData struct returned as a result of processing
+                                      the image reference.
+                                    type: string
+                                  reference:
+                                    description: 'Reference is image reference to
+                                      a container image in the registry. Example:
+                                      ghcr.io/kyverno/kyverno:latest'
+                                    type: string
+                                required:
+                                - reference
+                                type: object
+                              name:
+                                description: Name is the variable name.
+                                type: string
+                              variable:
+                                description: Variable defines an arbitrary JMESPath
+                                  context variable that can be defined inline.
+                                properties:
+                                  default:
+                                    description: Default is an optional arbitrary
+                                      JSON object that the variable may take if the
+                                      JMESPath expression evaluates to nil
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  jmesPath:
+                                    description: JMESPath is an optional JMESPath
+                                      Expression that can be used to transform the
+                                      variable.
+                                    type: string
+                                  value:
+                                    description: Value is any arbitrary JSON object
+                                      representable in YAML or JSON form.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                            type: object
+                          type: array
+                        exclude:
+                          description: ExcludeResources defines when this policy rule
+                            should not be applied. The exclude criteria can include
+                            resource information (e.g. kind, name, namespace, labels)
+                            and admission review request information like the name
+                            or role.
+                          properties:
+                            all:
+                              description: All allows specifying resources which will
+                                be ANDed
+                              items:
+                                description: ResourceFilter allow users to "AND" or
+                                  "OR" between resources
+                                properties:
+                                  clusterRoles:
+                                    description: ClusterRoles is the list of cluster-wide
+                                      role names for the user.
+                                    items:
+                                      type: string
+                                    type: array
+                                  resources:
+                                    description: ResourceDescription contains information
+                                      about the resource being created or modified.
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations is a  map of annotations
+                                          (key-value pairs of type string). Annotation
+                                          keys and values support the wildcard characters
+                                          "*" (matches zero or many characters) and
+                                          "?" (matches at least one character).
+                                        type: object
+                                      kinds:
+                                        description: Kinds is a list of resource kinds.
+                                        items:
+                                          type: string
+                                        type: array
+                                      name:
+                                        description: 'Name is the name of the resource.
+                                          The name supports wildcard characters "*"
+                                          (matches zero or many characters) and "?"
+                                          (at least one character). NOTE: "Name" is
+                                          being deprecated in favor of "Names".'
+                                        type: string
+                                      names:
+                                        description: Names are the names of the resources.
+                                          Each name supports wildcard characters "*"
+                                          (matches zero or many characters) and "?"
+                                          (at least one character).
+                                        items:
+                                          type: string
+                                        type: array
+                                      namespaceSelector:
+                                        description: 'NamespaceSelector is a label
+                                          selector for the resource namespace. Label
+                                          keys and values in `matchLabels` support
+                                          the wildcard characters `*` (matches zero
+                                          or many characters) and `?` (matches one
+                                          character).Wildcards allows writing label
+                                          selectors like ["storage.k8s.io/*": "*"].
+                                          Note that using ["*" : "*"] matches any
+                                          key and value but does not match an empty
+                                          label set.'
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      namespaces:
+                                        description: Namespaces is a list of namespaces
+                                          names. Each name supports wildcard characters
+                                          "*" (matches zero or many characters) and
+                                          "?" (at least one character).
+                                        items:
+                                          type: string
+                                        type: array
+                                      selector:
+                                        description: 'Selector is a label selector.
+                                          Label keys and values in `matchLabels` support
+                                          the wildcard characters `*` (matches zero
+                                          or many characters) and `?` (matches one
+                                          character). Wildcards allows writing label
+                                          selectors like ["storage.k8s.io/*": "*"].
+                                          Note that using ["*" : "*"] matches any
+                                          key and value but does not match an empty
+                                          label set.'
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  roles:
+                                    description: Roles is the list of namespaced role
+                                      names for the user.
+                                    items:
+                                      type: string
+                                    type: array
+                                  subjects:
+                                    description: Subjects is the list of subject names
+                                      like users, user groups, and service accounts.
+                                    items:
+                                      description: Subject contains a reference to
+                                        the object or user identities a role binding
+                                        applies to.  This can either hold a direct
+                                        API object reference, or a value for non-objects
+                                        such as user and group names.
+                                      properties:
+                                        apiGroup:
+                                          description: APIGroup holds the API group
+                                            of the referenced subject. Defaults to
+                                            "" for ServiceAccount subjects. Defaults
+                                            to "rbac.authorization.k8s.io" for User
+                                            and Group subjects.
+                                          type: string
+                                        kind:
+                                          description: Kind of object being referenced.
+                                            Values defined by this API group are "User",
+                                            "Group", and "ServiceAccount". If the
+                                            Authorizer does not recognized the kind
+                                            value, the Authorizer should report an
+                                            error.
+                                          type: string
+                                        name:
+                                          description: Name of the object being referenced.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the referenced
+                                            object.  If the object kind is non-namespace,
+                                            such as "User" or "Group", and this value
+                                            is not empty the Authorizer should report
+                                            an error.
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    type: array
+                                type: object
+                              type: array
+                            any:
+                              description: Any allows specifying resources which will
+                                be ORed
+                              items:
+                                description: ResourceFilter allow users to "AND" or
+                                  "OR" between resources
+                                properties:
+                                  clusterRoles:
+                                    description: ClusterRoles is the list of cluster-wide
+                                      role names for the user.
+                                    items:
+                                      type: string
+                                    type: array
+                                  resources:
+                                    description: ResourceDescription contains information
+                                      about the resource being created or modified.
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations is a  map of annotations
+                                          (key-value pairs of type string). Annotation
+                                          keys and values support the wildcard characters
+                                          "*" (matches zero or many characters) and
+                                          "?" (matches at least one character).
+                                        type: object
+                                      kinds:
+                                        description: Kinds is a list of resource kinds.
+                                        items:
+                                          type: string
+                                        type: array
+                                      name:
+                                        description: 'Name is the name of the resource.
+                                          The name supports wildcard characters "*"
+                                          (matches zero or many characters) and "?"
+                                          (at least one character). NOTE: "Name" is
+                                          being deprecated in favor of "Names".'
+                                        type: string
+                                      names:
+                                        description: Names are the names of the resources.
+                                          Each name supports wildcard characters "*"
+                                          (matches zero or many characters) and "?"
+                                          (at least one character).
+                                        items:
+                                          type: string
+                                        type: array
+                                      namespaceSelector:
+                                        description: 'NamespaceSelector is a label
+                                          selector for the resource namespace. Label
+                                          keys and values in `matchLabels` support
+                                          the wildcard characters `*` (matches zero
+                                          or many characters) and `?` (matches one
+                                          character).Wildcards allows writing label
+                                          selectors like ["storage.k8s.io/*": "*"].
+                                          Note that using ["*" : "*"] matches any
+                                          key and value but does not match an empty
+                                          label set.'
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      namespaces:
+                                        description: Namespaces is a list of namespaces
+                                          names. Each name supports wildcard characters
+                                          "*" (matches zero or many characters) and
+                                          "?" (at least one character).
+                                        items:
+                                          type: string
+                                        type: array
+                                      selector:
+                                        description: 'Selector is a label selector.
+                                          Label keys and values in `matchLabels` support
+                                          the wildcard characters `*` (matches zero
+                                          or many characters) and `?` (matches one
+                                          character). Wildcards allows writing label
+                                          selectors like ["storage.k8s.io/*": "*"].
+                                          Note that using ["*" : "*"] matches any
+                                          key and value but does not match an empty
+                                          label set.'
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  roles:
+                                    description: Roles is the list of namespaced role
+                                      names for the user.
+                                    items:
+                                      type: string
+                                    type: array
+                                  subjects:
+                                    description: Subjects is the list of subject names
+                                      like users, user groups, and service accounts.
+                                    items:
+                                      description: Subject contains a reference to
+                                        the object or user identities a role binding
+                                        applies to.  This can either hold a direct
+                                        API object reference, or a value for non-objects
+                                        such as user and group names.
+                                      properties:
+                                        apiGroup:
+                                          description: APIGroup holds the API group
+                                            of the referenced subject. Defaults to
+                                            "" for ServiceAccount subjects. Defaults
+                                            to "rbac.authorization.k8s.io" for User
+                                            and Group subjects.
+                                          type: string
+                                        kind:
+                                          description: Kind of object being referenced.
+                                            Values defined by this API group are "User",
+                                            "Group", and "ServiceAccount". If the
+                                            Authorizer does not recognized the kind
+                                            value, the Authorizer should report an
+                                            error.
+                                          type: string
+                                        name:
+                                          description: Name of the object being referenced.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the referenced
+                                            object.  If the object kind is non-namespace,
+                                            such as "User" or "Group", and this value
+                                            is not empty the Authorizer should report
+                                            an error.
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    type: array
+                                type: object
+                              type: array
+                            clusterRoles:
+                              description: ClusterRoles is the list of cluster-wide
+                                role names for the user.
+                              items:
+                                type: string
+                              type: array
+                            resources:
+                              description: ResourceDescription contains information
+                                about the resource being created or modified. Requires
+                                at least one tag to be specified when under MatchResources.
+                                Specifying ResourceDescription directly under match
+                                is being deprecated. Please specify under "any" or
+                                "all" instead.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  description: Annotations is a  map of annotations
+                                    (key-value pairs of type string). Annotation keys
+                                    and values support the wildcard characters "*"
+                                    (matches zero or many characters) and "?" (matches
+                                    at least one character).
+                                  type: object
+                                kinds:
+                                  description: Kinds is a list of resource kinds.
+                                  items:
+                                    type: string
+                                  type: array
+                                name:
+                                  description: 'Name is the name of the resource.
+                                    The name supports wildcard characters "*" (matches
+                                    zero or many characters) and "?" (at least one
+                                    character). NOTE: "Name" is being deprecated in
+                                    favor of "Names".'
+                                  type: string
+                                names:
+                                  description: Names are the names of the resources.
+                                    Each name supports wildcard characters "*" (matches
+                                    zero or many characters) and "?" (at least one
+                                    character).
+                                  items:
+                                    type: string
+                                  type: array
+                                namespaceSelector:
+                                  description: 'NamespaceSelector is a label selector
+                                    for the resource namespace. Label keys and values
+                                    in `matchLabels` support the wildcard characters
+                                    `*` (matches zero or many characters) and `?`
+                                    (matches one character).Wildcards allows writing
+                                    label selectors like ["storage.k8s.io/*": "*"].
+                                    Note that using ["*" : "*"] matches any key and
+                                    value but does not match an empty label set.'
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: Namespaces is a list of namespaces
+                                    names. Each name supports wildcard characters
+                                    "*" (matches zero or many characters) and "?"
+                                    (at least one character).
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: 'Selector is a label selector. Label
+                                    keys and values in `matchLabels` support the wildcard
+                                    characters `*` (matches zero or many characters)
+                                    and `?` (matches one character). Wildcards allows
+                                    writing label selectors like ["storage.k8s.io/*":
+                                    "*"]. Note that using ["*" : "*"] matches any
+                                    key and value but does not match an empty label
+                                    set.'
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            roles:
+                              description: Roles is the list of namespaced role names
+                                for the user.
+                              items:
+                                type: string
+                              type: array
+                            subjects:
+                              description: Subjects is the list of subject names like
+                                users, user groups, and service accounts.
+                              items:
+                                description: Subject contains a reference to the object
+                                  or user identities a role binding applies to.  This
+                                  can either hold a direct API object reference, or
+                                  a value for non-objects such as user and group names.
+                                properties:
+                                  apiGroup:
+                                    description: APIGroup holds the API group of the
+                                      referenced subject. Defaults to "" for ServiceAccount
+                                      subjects. Defaults to "rbac.authorization.k8s.io"
+                                      for User and Group subjects.
+                                    type: string
+                                  kind:
+                                    description: Kind of object being referenced.
+                                      Values defined by this API group are "User",
+                                      "Group", and "ServiceAccount". If the Authorizer
+                                      does not recognized the kind value, the Authorizer
+                                      should report an error.
+                                    type: string
+                                  name:
+                                    description: Name of the object being referenced.
+                                    type: string
+                                  namespace:
+                                    description: Namespace of the referenced object.  If
+                                      the object kind is non-namespace, such as "User"
+                                      or "Group", and this value is not empty the
+                                      Authorizer should report an error.
+                                    type: string
+                                required:
+                                - kind
+                                - name
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              type: array
+                          type: object
+                        generate:
+                          description: Generation is used to create new resources.
+                          properties:
+                            apiVersion:
+                              description: APIVersion specifies resource apiVersion.
+                              type: string
+                            clone:
+                              description: Clone specifies the source resource used
+                                to populate each generated resource. At most one of
+                                Data or Clone can be specified. If neither are provided,
+                                the generated resource will be created with default
+                                data only.
+                              properties:
+                                name:
+                                  description: Name specifies name of the resource.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies source resource
+                                    namespace.
+                                  type: string
+                              type: object
+                            cloneList:
+                              description: CloneList specifies the list of source
+                                resource used to populate each generated resource.
+                              properties:
+                                kinds:
+                                  description: Kinds is a list of resource kinds.
+                                  items:
+                                    type: string
+                                  type: array
+                                namespace:
+                                  description: Namespace specifies source resource
+                                    namespace.
+                                  type: string
+                                selector:
+                                  description: Selector is a label selector. Label
+                                    keys and values in `matchLabels`. wildcard characters
+                                    are not supported.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            data:
+                              description: Data provides the resource declaration
+                                used to populate each generated resource. At most
+                                one of Data or Clone must be specified. If neither
+                                are provided, the generated resource will be created
+                                with default data only.
+                              x-kubernetes-preserve-unknown-fields: true
+                            kind:
+                              description: Kind specifies resource kind.
+                              type: string
+                            name:
+                              description: Name specifies the resource name.
+                              type: string
+                            namespace:
+                              description: Namespace specifies resource namespace.
+                              type: string
+                            synchronize:
+                              description: Synchronize controls if generated resources
+                                should be kept in-sync with their source resource.
+                                If Synchronize is set to "true" changes to generated
+                                resources will be overwritten with resource data from
+                                Data or the resource specified in the Clone declaration.
+                                Optional. Defaults to "false" if not specified.
+                              type: boolean
+                          type: object
+                        imageExtractors:
+                          additionalProperties:
+                            items:
+                              properties:
+                                key:
+                                  description: Key is an optional name of the field
+                                    within 'path' that will be used to uniquely identify
+                                    an image. Note - this field MUST be unique.
+                                  type: string
+                                name:
+                                  description: Name is the entry the image will be
+                                    available under 'images.<name>' in the context.
+                                    If this field is not defined, image entries will
+                                    appear under 'images.custom'.
+                                  type: string
+                                path:
+                                  description: Path is the path to the object containing
+                                    the image field in a custom resource. It should
+                                    be slash-separated. Each slash-separated key must
+                                    be a valid YAML key or a wildcard '*'. Wildcard
+                                    keys are expanded in case of arrays or objects.
+                                  type: string
+                                value:
+                                  description: Value is an optional name of the field
+                                    within 'path' that points to the image URI. This
+                                    is useful when a custom 'key' is also defined.
+                                  type: string
+                              required:
+                              - path
+                              type: object
+                            type: array
+                          description: ImageExtractors defines a mapping from kinds
+                            to ImageExtractorConfigs. This config is only valid for
+                            verifyImages rules.
+                          type: object
+                        match:
+                          description: MatchResources defines when this policy rule
+                            should be applied. The match criteria can include resource
+                            information (e.g. kind, name, namespace, labels) and admission
+                            review request information like the user name or role.
+                            At least one kind is required.
+                          properties:
+                            all:
+                              description: All allows specifying resources which will
+                                be ANDed
+                              items:
+                                description: ResourceFilter allow users to "AND" or
+                                  "OR" between resources
+                                properties:
+                                  clusterRoles:
+                                    description: ClusterRoles is the list of cluster-wide
+                                      role names for the user.
+                                    items:
+                                      type: string
+                                    type: array
+                                  resources:
+                                    description: ResourceDescription contains information
+                                      about the resource being created or modified.
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations is a  map of annotations
+                                          (key-value pairs of type string). Annotation
+                                          keys and values support the wildcard characters
+                                          "*" (matches zero or many characters) and
+                                          "?" (matches at least one character).
+                                        type: object
+                                      kinds:
+                                        description: Kinds is a list of resource kinds.
+                                        items:
+                                          type: string
+                                        type: array
+                                      name:
+                                        description: 'Name is the name of the resource.
+                                          The name supports wildcard characters "*"
+                                          (matches zero or many characters) and "?"
+                                          (at least one character). NOTE: "Name" is
+                                          being deprecated in favor of "Names".'
+                                        type: string
+                                      names:
+                                        description: Names are the names of the resources.
+                                          Each name supports wildcard characters "*"
+                                          (matches zero or many characters) and "?"
+                                          (at least one character).
+                                        items:
+                                          type: string
+                                        type: array
+                                      namespaceSelector:
+                                        description: 'NamespaceSelector is a label
+                                          selector for the resource namespace. Label
+                                          keys and values in `matchLabels` support
+                                          the wildcard characters `*` (matches zero
+                                          or many characters) and `?` (matches one
+                                          character).Wildcards allows writing label
+                                          selectors like ["storage.k8s.io/*": "*"].
+                                          Note that using ["*" : "*"] matches any
+                                          key and value but does not match an empty
+                                          label set.'
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      namespaces:
+                                        description: Namespaces is a list of namespaces
+                                          names. Each name supports wildcard characters
+                                          "*" (matches zero or many characters) and
+                                          "?" (at least one character).
+                                        items:
+                                          type: string
+                                        type: array
+                                      selector:
+                                        description: 'Selector is a label selector.
+                                          Label keys and values in `matchLabels` support
+                                          the wildcard characters `*` (matches zero
+                                          or many characters) and `?` (matches one
+                                          character). Wildcards allows writing label
+                                          selectors like ["storage.k8s.io/*": "*"].
+                                          Note that using ["*" : "*"] matches any
+                                          key and value but does not match an empty
+                                          label set.'
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  roles:
+                                    description: Roles is the list of namespaced role
+                                      names for the user.
+                                    items:
+                                      type: string
+                                    type: array
+                                  subjects:
+                                    description: Subjects is the list of subject names
+                                      like users, user groups, and service accounts.
+                                    items:
+                                      description: Subject contains a reference to
+                                        the object or user identities a role binding
+                                        applies to.  This can either hold a direct
+                                        API object reference, or a value for non-objects
+                                        such as user and group names.
+                                      properties:
+                                        apiGroup:
+                                          description: APIGroup holds the API group
+                                            of the referenced subject. Defaults to
+                                            "" for ServiceAccount subjects. Defaults
+                                            to "rbac.authorization.k8s.io" for User
+                                            and Group subjects.
+                                          type: string
+                                        kind:
+                                          description: Kind of object being referenced.
+                                            Values defined by this API group are "User",
+                                            "Group", and "ServiceAccount". If the
+                                            Authorizer does not recognized the kind
+                                            value, the Authorizer should report an
+                                            error.
+                                          type: string
+                                        name:
+                                          description: Name of the object being referenced.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the referenced
+                                            object.  If the object kind is non-namespace,
+                                            such as "User" or "Group", and this value
+                                            is not empty the Authorizer should report
+                                            an error.
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    type: array
+                                type: object
+                              type: array
+                            any:
+                              description: Any allows specifying resources which will
+                                be ORed
+                              items:
+                                description: ResourceFilter allow users to "AND" or
+                                  "OR" between resources
+                                properties:
+                                  clusterRoles:
+                                    description: ClusterRoles is the list of cluster-wide
+                                      role names for the user.
+                                    items:
+                                      type: string
+                                    type: array
+                                  resources:
+                                    description: ResourceDescription contains information
+                                      about the resource being created or modified.
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations is a  map of annotations
+                                          (key-value pairs of type string). Annotation
+                                          keys and values support the wildcard characters
+                                          "*" (matches zero or many characters) and
+                                          "?" (matches at least one character).
+                                        type: object
+                                      kinds:
+                                        description: Kinds is a list of resource kinds.
+                                        items:
+                                          type: string
+                                        type: array
+                                      name:
+                                        description: 'Name is the name of the resource.
+                                          The name supports wildcard characters "*"
+                                          (matches zero or many characters) and "?"
+                                          (at least one character). NOTE: "Name" is
+                                          being deprecated in favor of "Names".'
+                                        type: string
+                                      names:
+                                        description: Names are the names of the resources.
+                                          Each name supports wildcard characters "*"
+                                          (matches zero or many characters) and "?"
+                                          (at least one character).
+                                        items:
+                                          type: string
+                                        type: array
+                                      namespaceSelector:
+                                        description: 'NamespaceSelector is a label
+                                          selector for the resource namespace. Label
+                                          keys and values in `matchLabels` support
+                                          the wildcard characters `*` (matches zero
+                                          or many characters) and `?` (matches one
+                                          character).Wildcards allows writing label
+                                          selectors like ["storage.k8s.io/*": "*"].
+                                          Note that using ["*" : "*"] matches any
+                                          key and value but does not match an empty
+                                          label set.'
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      namespaces:
+                                        description: Namespaces is a list of namespaces
+                                          names. Each name supports wildcard characters
+                                          "*" (matches zero or many characters) and
+                                          "?" (at least one character).
+                                        items:
+                                          type: string
+                                        type: array
+                                      selector:
+                                        description: 'Selector is a label selector.
+                                          Label keys and values in `matchLabels` support
+                                          the wildcard characters `*` (matches zero
+                                          or many characters) and `?` (matches one
+                                          character). Wildcards allows writing label
+                                          selectors like ["storage.k8s.io/*": "*"].
+                                          Note that using ["*" : "*"] matches any
+                                          key and value but does not match an empty
+                                          label set.'
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  roles:
+                                    description: Roles is the list of namespaced role
+                                      names for the user.
+                                    items:
+                                      type: string
+                                    type: array
+                                  subjects:
+                                    description: Subjects is the list of subject names
+                                      like users, user groups, and service accounts.
+                                    items:
+                                      description: Subject contains a reference to
+                                        the object or user identities a role binding
+                                        applies to.  This can either hold a direct
+                                        API object reference, or a value for non-objects
+                                        such as user and group names.
+                                      properties:
+                                        apiGroup:
+                                          description: APIGroup holds the API group
+                                            of the referenced subject. Defaults to
+                                            "" for ServiceAccount subjects. Defaults
+                                            to "rbac.authorization.k8s.io" for User
+                                            and Group subjects.
+                                          type: string
+                                        kind:
+                                          description: Kind of object being referenced.
+                                            Values defined by this API group are "User",
+                                            "Group", and "ServiceAccount". If the
+                                            Authorizer does not recognized the kind
+                                            value, the Authorizer should report an
+                                            error.
+                                          type: string
+                                        name:
+                                          description: Name of the object being referenced.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the referenced
+                                            object.  If the object kind is non-namespace,
+                                            such as "User" or "Group", and this value
+                                            is not empty the Authorizer should report
+                                            an error.
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    type: array
+                                type: object
+                              type: array
+                            clusterRoles:
+                              description: ClusterRoles is the list of cluster-wide
+                                role names for the user.
+                              items:
+                                type: string
+                              type: array
+                            resources:
+                              description: ResourceDescription contains information
+                                about the resource being created or modified. Requires
+                                at least one tag to be specified when under MatchResources.
+                                Specifying ResourceDescription directly under match
+                                is being deprecated. Please specify under "any" or
+                                "all" instead.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  description: Annotations is a  map of annotations
+                                    (key-value pairs of type string). Annotation keys
+                                    and values support the wildcard characters "*"
+                                    (matches zero or many characters) and "?" (matches
+                                    at least one character).
+                                  type: object
+                                kinds:
+                                  description: Kinds is a list of resource kinds.
+                                  items:
+                                    type: string
+                                  type: array
+                                name:
+                                  description: 'Name is the name of the resource.
+                                    The name supports wildcard characters "*" (matches
+                                    zero or many characters) and "?" (at least one
+                                    character). NOTE: "Name" is being deprecated in
+                                    favor of "Names".'
+                                  type: string
+                                names:
+                                  description: Names are the names of the resources.
+                                    Each name supports wildcard characters "*" (matches
+                                    zero or many characters) and "?" (at least one
+                                    character).
+                                  items:
+                                    type: string
+                                  type: array
+                                namespaceSelector:
+                                  description: 'NamespaceSelector is a label selector
+                                    for the resource namespace. Label keys and values
+                                    in `matchLabels` support the wildcard characters
+                                    `*` (matches zero or many characters) and `?`
+                                    (matches one character).Wildcards allows writing
+                                    label selectors like ["storage.k8s.io/*": "*"].
+                                    Note that using ["*" : "*"] matches any key and
+                                    value but does not match an empty label set.'
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: Namespaces is a list of namespaces
+                                    names. Each name supports wildcard characters
+                                    "*" (matches zero or many characters) and "?"
+                                    (at least one character).
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: 'Selector is a label selector. Label
+                                    keys and values in `matchLabels` support the wildcard
+                                    characters `*` (matches zero or many characters)
+                                    and `?` (matches one character). Wildcards allows
+                                    writing label selectors like ["storage.k8s.io/*":
+                                    "*"]. Note that using ["*" : "*"] matches any
+                                    key and value but does not match an empty label
+                                    set.'
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            roles:
+                              description: Roles is the list of namespaced role names
+                                for the user.
+                              items:
+                                type: string
+                              type: array
+                            subjects:
+                              description: Subjects is the list of subject names like
+                                users, user groups, and service accounts.
+                              items:
+                                description: Subject contains a reference to the object
+                                  or user identities a role binding applies to.  This
+                                  can either hold a direct API object reference, or
+                                  a value for non-objects such as user and group names.
+                                properties:
+                                  apiGroup:
+                                    description: APIGroup holds the API group of the
+                                      referenced subject. Defaults to "" for ServiceAccount
+                                      subjects. Defaults to "rbac.authorization.k8s.io"
+                                      for User and Group subjects.
+                                    type: string
+                                  kind:
+                                    description: Kind of object being referenced.
+                                      Values defined by this API group are "User",
+                                      "Group", and "ServiceAccount". If the Authorizer
+                                      does not recognized the kind value, the Authorizer
+                                      should report an error.
+                                    type: string
+                                  name:
+                                    description: Name of the object being referenced.
+                                    type: string
+                                  namespace:
+                                    description: Namespace of the referenced object.  If
+                                      the object kind is non-namespace, such as "User"
+                                      or "Group", and this value is not empty the
+                                      Authorizer should report an error.
+                                    type: string
+                                required:
+                                - kind
+                                - name
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              type: array
+                          type: object
+                        mutate:
+                          description: Mutation is used to modify matching resources.
+                          properties:
+                            foreach:
+                              description: ForEach applies mutation rules to a list
+                                of sub-elements by creating a context for each entry
+                                in the list and looping over it to apply the specified
+                                logic.
+                              items:
+                                description: ForEach applies mutation rules to a list
+                                  of sub-elements by creating a context for each entry
+                                  in the list and looping over it to apply the specified
+                                  logic.
+                                properties:
+                                  context:
+                                    description: Context defines variables and data
+                                      sources that can be used during rule execution.
+                                    items:
+                                      description: ContextEntry adds variables and
+                                        data sources to a rule Context. Either a ConfigMap
+                                        reference or a APILookup must be provided.
+                                      properties:
+                                        apiCall:
+                                          description: APICall defines an HTTP request
+                                            to the Kubernetes API server. The JSON
+                                            data retrieved is stored in the context.
+                                          properties:
+                                            jmesPath:
+                                              description: JMESPath is an optional
+                                                JSON Match Expression that can be
+                                                used to transform the JSON response
+                                                returned from the API server. For
+                                                example a JMESPath of "items | length(@)"
+                                                applied to the API server response
+                                                to the URLPath "/apis/apps/v1/deployments"
+                                                will return the total count of deployments
+                                                across all namespaces.
+                                              type: string
+                                            urlPath:
+                                              description: URLPath is the URL path
+                                                to be used in the HTTP GET request
+                                                to the Kubernetes API server (e.g.
+                                                "/api/v1/namespaces" or  "/apis/apps/v1/deployments").
+                                                The format required is the same format
+                                                used by the `kubectl get --raw` command.
+                                              type: string
+                                          required:
+                                          - urlPath
+                                          type: object
+                                        configMap:
+                                          description: ConfigMap is the ConfigMap
+                                            reference.
+                                          properties:
+                                            name:
+                                              description: Name is the ConfigMap name.
+                                              type: string
+                                            namespace:
+                                              description: Namespace is the ConfigMap
+                                                namespace.
+                                              type: string
+                                          required:
+                                          - name
+                                          type: object
+                                        imageRegistry:
+                                          description: ImageRegistry defines requests
+                                            to an OCI/Docker V2 registry to fetch
+                                            image details.
+                                          properties:
+                                            jmesPath:
+                                              description: JMESPath is an optional
+                                                JSON Match Expression that can be
+                                                used to transform the ImageData struct
+                                                returned as a result of processing
+                                                the image reference.
+                                              type: string
+                                            reference:
+                                              description: 'Reference is image reference
+                                                to a container image in the registry.
+                                                Example: ghcr.io/kyverno/kyverno:latest'
+                                              type: string
+                                          required:
+                                          - reference
+                                          type: object
+                                        name:
+                                          description: Name is the variable name.
+                                          type: string
+                                        variable:
+                                          description: Variable defines an arbitrary
+                                            JMESPath context variable that can be
+                                            defined inline.
+                                          properties:
+                                            default:
+                                              description: Default is an optional
+                                                arbitrary JSON object that the variable
+                                                may take if the JMESPath expression
+                                                evaluates to nil
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            jmesPath:
+                                              description: JMESPath is an optional
+                                                JMESPath Expression that can be used
+                                                to transform the variable.
+                                              type: string
+                                            value:
+                                              description: Value is any arbitrary
+                                                JSON object representable in YAML
+                                                or JSON form.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                      type: object
+                                    type: array
+                                  list:
+                                    description: List specifies a JMESPath expression
+                                      that results in one or more elements to which
+                                      the validation logic is applied.
+                                    type: string
+                                  patchStrategicMerge:
+                                    description: PatchStrategicMerge is a strategic
+                                      merge patch used to modify resources. See https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/
+                                      and https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  patchesJson6902:
+                                    description: PatchesJSON6902 is a list of RFC
+                                      6902 JSON Patch declarations used to modify
+                                      resources. See https://tools.ietf.org/html/rfc6902
+                                      and https://kubectl.docs.kubernetes.io/references/kustomize/patchesjson6902/.
+                                    type: string
+                                  preconditions:
+                                    description: 'AnyAllConditions are used to determine
+                                      if a policy rule should be applied by evaluating
+                                      a set of conditions. The declaration can contain
+                                      nested `any` or `all` statements. See: https://kyverno.io/docs/writing-policies/preconditions/'
+                                    properties:
+                                      all:
+                                        description: AllConditions enable variable-based
+                                          conditional rule execution. This is useful
+                                          for finer control of when an rule is applied.
+                                          A condition can reference object data using
+                                          JMESPath notation. Here, all of the conditions
+                                          need to pass
+                                        items:
+                                          description: Condition defines variable-based
+                                            conditional criteria for rule execution.
+                                          properties:
+                                            key:
+                                              description: Key is the context entry
+                                                (using JMESPath) for conditional rule
+                                                evaluation.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            operator:
+                                              description: 'Operator is the conditional
+                                                operation to perform. Valid operators
+                                                are: Equals, NotEquals, In, AnyIn,
+                                                AllIn, NotIn, AnyNotIn, AllNotIn,
+                                                GreaterThanOrEquals, GreaterThan,
+                                                LessThanOrEquals, LessThan, DurationGreaterThanOrEquals,
+                                                DurationGreaterThan, DurationLessThanOrEquals,
+                                                DurationLessThan'
+                                              enum:
+                                              - Equals
+                                              - NotEquals
+                                              - In
+                                              - AnyIn
+                                              - AllIn
+                                              - NotIn
+                                              - AnyNotIn
+                                              - AllNotIn
+                                              - GreaterThanOrEquals
+                                              - GreaterThan
+                                              - LessThanOrEquals
+                                              - LessThan
+                                              - DurationGreaterThanOrEquals
+                                              - DurationGreaterThan
+                                              - DurationLessThanOrEquals
+                                              - DurationLessThan
+                                              type: string
+                                            value:
+                                              description: Value is the conditional
+                                                value, or set of values. The values
+                                                can be fixed set or can be variables
+                                                declared using JMESPath.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                        type: array
+                                      any:
+                                        description: AnyConditions enable variable-based
+                                          conditional rule execution. This is useful
+                                          for finer control of when an rule is applied.
+                                          A condition can reference object data using
+                                          JMESPath notation. Here, at least one of
+                                          the conditions need to pass
+                                        items:
+                                          description: Condition defines variable-based
+                                            conditional criteria for rule execution.
+                                          properties:
+                                            key:
+                                              description: Key is the context entry
+                                                (using JMESPath) for conditional rule
+                                                evaluation.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            operator:
+                                              description: 'Operator is the conditional
+                                                operation to perform. Valid operators
+                                                are: Equals, NotEquals, In, AnyIn,
+                                                AllIn, NotIn, AnyNotIn, AllNotIn,
+                                                GreaterThanOrEquals, GreaterThan,
+                                                LessThanOrEquals, LessThan, DurationGreaterThanOrEquals,
+                                                DurationGreaterThan, DurationLessThanOrEquals,
+                                                DurationLessThan'
+                                              enum:
+                                              - Equals
+                                              - NotEquals
+                                              - In
+                                              - AnyIn
+                                              - AllIn
+                                              - NotIn
+                                              - AnyNotIn
+                                              - AllNotIn
+                                              - GreaterThanOrEquals
+                                              - GreaterThan
+                                              - LessThanOrEquals
+                                              - LessThan
+                                              - DurationGreaterThanOrEquals
+                                              - DurationGreaterThan
+                                              - DurationLessThanOrEquals
+                                              - DurationLessThan
+                                              type: string
+                                            value:
+                                              description: Value is the conditional
+                                                value, or set of values. The values
+                                                can be fixed set or can be variables
+                                                declared using JMESPath.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                        type: array
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              type: array
+                            patchStrategicMerge:
+                              description: PatchStrategicMerge is a strategic merge
+                                patch used to modify resources. See https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/
+                                and https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.
+                              x-kubernetes-preserve-unknown-fields: true
+                            patchesJson6902:
+                              description: PatchesJSON6902 is a list of RFC 6902 JSON
+                                Patch declarations used to modify resources. See https://tools.ietf.org/html/rfc6902
+                                and https://kubectl.docs.kubernetes.io/references/kustomize/patchesjson6902/.
+                              type: string
+                            targets:
+                              description: Targets defines the target resources to
+                                be mutated.
+                              items:
+                                properties:
+                                  apiVersion:
+                                    description: APIVersion specifies resource apiVersion.
+                                    type: string
+                                  kind:
+                                    description: Kind specifies resource kind.
+                                    type: string
+                                  name:
+                                    description: Name specifies the resource name.
+                                    type: string
+                                  namespace:
+                                    description: Namespace specifies resource namespace.
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        name:
+                          description: Name is a label to identify the rule, It must
+                            be unique within the policy.
+                          maxLength: 63
+                          type: string
+                        preconditions:
+                          description: 'Preconditions are used to determine if a policy
+                            rule should be applied by evaluating a set of conditions.
+                            The declaration can contain nested `any` or `all` statements.
+                            A direct list of conditions (without `any` or `all` statements
+                            is supported for backwards compatibility but will be deprecated
+                            in the next major release. See: https://kyverno.io/docs/writing-policies/preconditions/'
+                          x-kubernetes-preserve-unknown-fields: true
+                        validate:
+                          description: Validation is used to validate matching resources.
+                          properties:
+                            anyPattern:
+                              description: AnyPattern specifies list of validation
+                                patterns. At least one of the patterns must be satisfied
+                                for the validation rule to succeed.
+                              x-kubernetes-preserve-unknown-fields: true
+                            deny:
+                              description: Deny defines conditions used to pass or
+                                fail a validation rule.
+                              properties:
+                                conditions:
+                                  description: 'Multiple conditions can be declared
+                                    under an `any` or `all` statement. A direct list
+                                    of conditions (without `any` or `all` statements)
+                                    is also supported for backwards compatibility
+                                    but will be deprecated in the next major release.
+                                    See: https://kyverno.io/docs/writing-policies/validate/#deny-rules'
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            foreach:
+                              description: ForEach applies validate rules to a list
+                                of sub-elements by creating a context for each entry
+                                in the list and looping over it to apply the specified
+                                logic.
+                              items:
+                                description: ForEach applies validate rules to a list
+                                  of sub-elements by creating a context for each entry
+                                  in the list and looping over it to apply the specified
+                                  logic.
+                                properties:
+                                  anyPattern:
+                                    description: AnyPattern specifies list of validation
+                                      patterns. At least one of the patterns must
+                                      be satisfied for the validation rule to succeed.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  context:
+                                    description: Context defines variables and data
+                                      sources that can be used during rule execution.
+                                    items:
+                                      description: ContextEntry adds variables and
+                                        data sources to a rule Context. Either a ConfigMap
+                                        reference or a APILookup must be provided.
+                                      properties:
+                                        apiCall:
+                                          description: APICall defines an HTTP request
+                                            to the Kubernetes API server. The JSON
+                                            data retrieved is stored in the context.
+                                          properties:
+                                            jmesPath:
+                                              description: JMESPath is an optional
+                                                JSON Match Expression that can be
+                                                used to transform the JSON response
+                                                returned from the API server. For
+                                                example a JMESPath of "items | length(@)"
+                                                applied to the API server response
+                                                to the URLPath "/apis/apps/v1/deployments"
+                                                will return the total count of deployments
+                                                across all namespaces.
+                                              type: string
+                                            urlPath:
+                                              description: URLPath is the URL path
+                                                to be used in the HTTP GET request
+                                                to the Kubernetes API server (e.g.
+                                                "/api/v1/namespaces" or  "/apis/apps/v1/deployments").
+                                                The format required is the same format
+                                                used by the `kubectl get --raw` command.
+                                              type: string
+                                          required:
+                                          - urlPath
+                                          type: object
+                                        configMap:
+                                          description: ConfigMap is the ConfigMap
+                                            reference.
+                                          properties:
+                                            name:
+                                              description: Name is the ConfigMap name.
+                                              type: string
+                                            namespace:
+                                              description: Namespace is the ConfigMap
+                                                namespace.
+                                              type: string
+                                          required:
+                                          - name
+                                          type: object
+                                        imageRegistry:
+                                          description: ImageRegistry defines requests
+                                            to an OCI/Docker V2 registry to fetch
+                                            image details.
+                                          properties:
+                                            jmesPath:
+                                              description: JMESPath is an optional
+                                                JSON Match Expression that can be
+                                                used to transform the ImageData struct
+                                                returned as a result of processing
+                                                the image reference.
+                                              type: string
+                                            reference:
+                                              description: 'Reference is image reference
+                                                to a container image in the registry.
+                                                Example: ghcr.io/kyverno/kyverno:latest'
+                                              type: string
+                                          required:
+                                          - reference
+                                          type: object
+                                        name:
+                                          description: Name is the variable name.
+                                          type: string
+                                        variable:
+                                          description: Variable defines an arbitrary
+                                            JMESPath context variable that can be
+                                            defined inline.
+                                          properties:
+                                            default:
+                                              description: Default is an optional
+                                                arbitrary JSON object that the variable
+                                                may take if the JMESPath expression
+                                                evaluates to nil
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            jmesPath:
+                                              description: JMESPath is an optional
+                                                JMESPath Expression that can be used
+                                                to transform the variable.
+                                              type: string
+                                            value:
+                                              description: Value is any arbitrary
+                                                JSON object representable in YAML
+                                                or JSON form.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                      type: object
+                                    type: array
+                                  deny:
+                                    description: Deny defines conditions used to pass
+                                      or fail a validation rule.
+                                    properties:
+                                      conditions:
+                                        description: 'Multiple conditions can be declared
+                                          under an `any` or `all` statement. A direct
+                                          list of conditions (without `any` or `all`
+                                          statements) is also supported for backwards
+                                          compatibility but will be deprecated in
+                                          the next major release. See: https://kyverno.io/docs/writing-policies/validate/#deny-rules'
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                  elementScope:
+                                    description: ElementScope specifies whether to
+                                      use the current list element as the scope for
+                                      validation. Defaults to "true" if not specified.
+                                      When set to "false", "request.object" is used
+                                      as the validation scope within the foreach block
+                                      to allow referencing other elements in the subtree.
+                                    type: boolean
+                                  list:
+                                    description: List specifies a JMESPath expression
+                                      that results in one or more elements to which
+                                      the validation logic is applied.
+                                    type: string
+                                  pattern:
+                                    description: Pattern specifies an overlay-style
+                                      pattern used to check resources.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  preconditions:
+                                    description: 'AnyAllConditions are used to determine
+                                      if a policy rule should be applied by evaluating
+                                      a set of conditions. The declaration can contain
+                                      nested `any` or `all` statements. See: https://kyverno.io/docs/writing-policies/preconditions/'
+                                    properties:
+                                      all:
+                                        description: AllConditions enable variable-based
+                                          conditional rule execution. This is useful
+                                          for finer control of when an rule is applied.
+                                          A condition can reference object data using
+                                          JMESPath notation. Here, all of the conditions
+                                          need to pass
+                                        items:
+                                          description: Condition defines variable-based
+                                            conditional criteria for rule execution.
+                                          properties:
+                                            key:
+                                              description: Key is the context entry
+                                                (using JMESPath) for conditional rule
+                                                evaluation.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            operator:
+                                              description: 'Operator is the conditional
+                                                operation to perform. Valid operators
+                                                are: Equals, NotEquals, In, AnyIn,
+                                                AllIn, NotIn, AnyNotIn, AllNotIn,
+                                                GreaterThanOrEquals, GreaterThan,
+                                                LessThanOrEquals, LessThan, DurationGreaterThanOrEquals,
+                                                DurationGreaterThan, DurationLessThanOrEquals,
+                                                DurationLessThan'
+                                              enum:
+                                              - Equals
+                                              - NotEquals
+                                              - In
+                                              - AnyIn
+                                              - AllIn
+                                              - NotIn
+                                              - AnyNotIn
+                                              - AllNotIn
+                                              - GreaterThanOrEquals
+                                              - GreaterThan
+                                              - LessThanOrEquals
+                                              - LessThan
+                                              - DurationGreaterThanOrEquals
+                                              - DurationGreaterThan
+                                              - DurationLessThanOrEquals
+                                              - DurationLessThan
+                                              type: string
+                                            value:
+                                              description: Value is the conditional
+                                                value, or set of values. The values
+                                                can be fixed set or can be variables
+                                                declared using JMESPath.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                        type: array
+                                      any:
+                                        description: AnyConditions enable variable-based
+                                          conditional rule execution. This is useful
+                                          for finer control of when an rule is applied.
+                                          A condition can reference object data using
+                                          JMESPath notation. Here, at least one of
+                                          the conditions need to pass
+                                        items:
+                                          description: Condition defines variable-based
+                                            conditional criteria for rule execution.
+                                          properties:
+                                            key:
+                                              description: Key is the context entry
+                                                (using JMESPath) for conditional rule
+                                                evaluation.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            operator:
+                                              description: 'Operator is the conditional
+                                                operation to perform. Valid operators
+                                                are: Equals, NotEquals, In, AnyIn,
+                                                AllIn, NotIn, AnyNotIn, AllNotIn,
+                                                GreaterThanOrEquals, GreaterThan,
+                                                LessThanOrEquals, LessThan, DurationGreaterThanOrEquals,
+                                                DurationGreaterThan, DurationLessThanOrEquals,
+                                                DurationLessThan'
+                                              enum:
+                                              - Equals
+                                              - NotEquals
+                                              - In
+                                              - AnyIn
+                                              - AllIn
+                                              - NotIn
+                                              - AnyNotIn
+                                              - AllNotIn
+                                              - GreaterThanOrEquals
+                                              - GreaterThan
+                                              - LessThanOrEquals
+                                              - LessThan
+                                              - DurationGreaterThanOrEquals
+                                              - DurationGreaterThan
+                                              - DurationLessThanOrEquals
+                                              - DurationLessThan
+                                              type: string
+                                            value:
+                                              description: Value is the conditional
+                                                value, or set of values. The values
+                                                can be fixed set or can be variables
+                                                declared using JMESPath.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                        type: array
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              type: array
+                            manifests:
+                              description: Manifest specifies conditions for manifest
+                                verification
+                              properties:
+                                annotationDomain:
+                                  description: AnnotationDomain is custom domain of
+                                    annotation for message and signature. Default
+                                    is "cosign.sigstore.dev".
+                                  type: string
+                                attestors:
+                                  description: Attestors specified the required attestors
+                                    (i.e. authorities)
+                                  items:
+                                    properties:
+                                      count:
+                                        description: Count specifies the required
+                                          number of entries that must match. If the
+                                          count is null, all entries must match (a
+                                          logical AND). If the count is 1, at least
+                                          one entry must match (a logical OR). If
+                                          the count contains a value N, then N must
+                                          be less than or equal to the size of entries,
+                                          and at least N entries must match.
+                                        minimum: 1
+                                        type: integer
+                                      entries:
+                                        description: Entries contains the available
+                                          attestors. An attestor can be a static key,
+                                          attributes for keyless verification, or
+                                          a nested attestor declaration.
+                                        items:
+                                          properties:
+                                            annotations:
+                                              additionalProperties:
+                                                type: string
+                                              description: Annotations are used for
+                                                image verification. Every specified
+                                                key-value pair must exist and match
+                                                in the verified payload. The payload
+                                                may contain other key-value pairs.
+                                              type: object
+                                            attestor:
+                                              description: Attestor is a nested AttestorSet
+                                                used to specify a more complex set
+                                                of match authorities
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            certificates:
+                                              description: Certificates specifies
+                                                one or more certificates
+                                              properties:
+                                                cert:
+                                                  description: Certificate is an optional
+                                                    PEM encoded public certificate.
+                                                  type: string
+                                                certChain:
+                                                  description: CertificateChain is
+                                                    an optional PEM encoded set of
+                                                    certificates used to verify
+                                                  type: string
+                                                rekor:
+                                                  description: Rekor provides configuration
+                                                    for the Rekor transparency log
+                                                    service. If the value is nil,
+                                                    Rekor is not checked. If an empty
+                                                    object is provided the public
+                                                    instance of Rekor (https://rekor.sigstore.dev)
+                                                    is used.
+                                                  properties:
+                                                    url:
+                                                      description: URL is the address
+                                                        of the transparency log. Defaults
+                                                        to the public log https://rekor.sigstore.dev.
+                                                      type: string
+                                                  required:
+                                                  - url
+                                                  type: object
+                                              type: object
+                                            keyless:
+                                              description: Keyless is a set of attribute
+                                                used to verify a Sigstore keyless
+                                                attestor. See https://github.com/sigstore/cosign/blob/main/KEYLESS.md.
+                                              properties:
+                                                additionalExtensions:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: AdditionalExtensions
+                                                    are certificate-extensions used
+                                                    for keyless signing.
+                                                  type: object
+                                                issuer:
+                                                  description: Issuer is the certificate
+                                                    issuer used for keyless signing.
+                                                  type: string
+                                                rekor:
+                                                  description: Rekor provides configuration
+                                                    for the Rekor transparency log
+                                                    service. If the value is nil,
+                                                    Rekor is not checked and a root
+                                                    certificate chain is expected
+                                                    instead. If an empty object is
+                                                    provided the public instance of
+                                                    Rekor (https://rekor.sigstore.dev)
+                                                    is used.
+                                                  properties:
+                                                    url:
+                                                      description: URL is the address
+                                                        of the transparency log. Defaults
+                                                        to the public log https://rekor.sigstore.dev.
+                                                      type: string
+                                                  required:
+                                                  - url
+                                                  type: object
+                                                roots:
+                                                  description: Roots is an optional
+                                                    set of PEM encoded trusted root
+                                                    certificates. If not provided,
+                                                    the system roots are used.
+                                                  type: string
+                                                subject:
+                                                  description: Subject is the verified
+                                                    identity used for keyless signing,
+                                                    for example the email address
+                                                  type: string
+                                              type: object
+                                            keys:
+                                              description: Keys specifies one or more
+                                                public keys
+                                              properties:
+                                                publicKeys:
+                                                  description: Keys is a set of X.509
+                                                    public keys used to verify image
+                                                    signatures. The keys can be directly
+                                                    specified or can be a variable
+                                                    reference to a key specified in
+                                                    a ConfigMap (see https://kyverno.io/docs/writing-policies/variables/).
+                                                    When multiple keys are specified
+                                                    each key is processed as a separate
+                                                    staticKey entry (.attestors[*].entries.keys)
+                                                    within the set of attestors and
+                                                    the count is applied across the
+                                                    keys.
+                                                  type: string
+                                                rekor:
+                                                  description: Rekor provides configuration
+                                                    for the Rekor transparency log
+                                                    service. If the value is nil,
+                                                    Rekor is not checked. If an empty
+                                                    object is provided the public
+                                                    instance of Rekor (https://rekor.sigstore.dev)
+                                                    is used.
+                                                  properties:
+                                                    url:
+                                                      description: URL is the address
+                                                        of the transparency log. Defaults
+                                                        to the public log https://rekor.sigstore.dev.
+                                                      type: string
+                                                  required:
+                                                  - url
+                                                  type: object
+                                              type: object
+                                            repository:
+                                              description: Repository is an optional
+                                                alternate OCI repository to use for
+                                                signatures and attestations that match
+                                                this rule. If specified Repository
+                                                will override other OCI image repository
+                                                locations for this Attestor.
+                                              type: string
+                                          type: object
+                                        type: array
+                                    type: object
+                                  type: array
+                                dryRun:
+                                  description: DryRun configuration
+                                  properties:
+                                    enable:
+                                      type: boolean
+                                    namespace:
+                                      type: string
+                                  type: object
+                                ignoreFields:
+                                  description: Fields which will be ignored while
+                                    comparing manifests.
+                                  items:
+                                    properties:
+                                      fields:
+                                        items:
+                                          type: string
+                                        type: array
+                                      objects:
+                                        items:
+                                          properties:
+                                            group:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            name:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            version:
+                                              type: string
+                                          type: object
+                                        type: array
+                                    type: object
+                                  type: array
+                                repository:
+                                  description: Repository is an optional alternate
+                                    OCI repository to use for resource bundle reference.
+                                    The repository can be overridden per Attestor
+                                    or Attestation.
+                                  type: string
+                              type: object
+                            message:
+                              description: Message specifies a custom message to be
+                                displayed on failure.
+                              type: string
+                            pattern:
+                              description: Pattern specifies an overlay-style pattern
+                                used to check resources.
+                              x-kubernetes-preserve-unknown-fields: true
+                            podSecurity:
+                              description: PodSecurity applies exemptions for Kubernetes
+                                Pod Security admission by specifying exclusions for
+                                Pod Security Standards controls.
+                              properties:
+                                exclude:
+                                  description: Exclude specifies the Pod Security
+                                    Standard controls to be excluded.
+                                  items:
+                                    description: PodSecurityStandard specifies the
+                                      Pod Security Standard controls to be excluded.
+                                    properties:
+                                      controlName:
+                                        description: 'ControlName specifies the name
+                                          of the Pod Security Standard control. See:
+                                          https://kubernetes.io/docs/concepts/security/pod-security-standards/'
+                                        enum:
+                                        - HostProcess
+                                        - Host Namespaces
+                                        - Privileged Containers
+                                        - Capabilities
+                                        - HostPath Volumes
+                                        - Host Ports
+                                        - AppArmor
+                                        - SELinux
+                                        - /proc Mount Type
+                                        - Seccomp
+                                        - Sysctls
+                                        - Volume Types
+                                        - Privilege Escalation
+                                        - Running as Non-root
+                                        - Running as Non-root user
+                                        type: string
+                                      images:
+                                        description: 'Images selects matching containers
+                                          and applies the container level PSS. Each
+                                          image is the image name consisting of the
+                                          registry address, repository, image, and
+                                          tag. Empty list matches no containers, PSS
+                                          checks are applied at the pod level only.
+                                          Wildcards (''*'' and ''?'') are allowed.
+                                          See: https://kubernetes.io/docs/concepts/containers/images.'
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - controlName
+                                    type: object
+                                  type: array
+                                level:
+                                  description: Level defines the Pod Security Standard
+                                    level to be applied to workloads. Allowed values
+                                    are privileged, baseline, and restricted.
+                                  enum:
+                                  - privileged
+                                  - baseline
+                                  - restricted
+                                  type: string
+                                version:
+                                  description: Version defines the Pod Security Standard
+                                    versions that Kubernetes supports. Allowed values
+                                    are v1.19, v1.20, v1.21, v1.22, v1.23, v1.24,
+                                    v1.25, latest. Defaults to latest.
+                                  enum:
+                                  - v1.19
+                                  - v1.20
+                                  - v1.21
+                                  - v1.22
+                                  - v1.23
+                                  - v1.24
+                                  - v1.25
+                                  - latest
+                                  type: string
+                              type: object
+                          type: object
+                        verifyImages:
+                          description: VerifyImages is used to verify image signatures
+                            and mutate them to add a digest
+                          items:
+                            description: ImageVerification validates that images that
+                              match the specified pattern are signed with the supplied
+                              public key. Once the image is verified it is mutated
+                              to include the SHA digest retrieved during the registration.
+                            properties:
+                              additionalExtensions:
+                                additionalProperties:
+                                  type: string
+                                description: AdditionalExtensions are certificate-extensions
+                                  used for keyless signing. Deprecated.
+                                type: object
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                description: Annotations are used for image verification.
+                                  Every specified key-value pair must exist and match
+                                  in the verified payload. The payload may contain
+                                  other key-value pairs. Deprecated. Use annotations
+                                  per Attestor instead.
+                                type: object
+                              attestations:
+                                description: Attestations are optional checks for
+                                  signed in-toto Statements used to verify the image.
+                                  See https://github.com/in-toto/attestation. Kyverno
+                                  fetches signed attestations from the OCI registry
+                                  and decodes them into a list of Statement declarations.
+                                items:
+                                  description: Attestation are checks for signed in-toto
+                                    Statements that are used to verify the image.
+                                    See https://github.com/in-toto/attestation. Kyverno
+                                    fetches signed attestations from the OCI registry
+                                    and decodes them into a list of Statements.
+                                  properties:
+                                    conditions:
+                                      description: Conditions are used to verify attributes
+                                        within a Predicate. If no Conditions are specified
+                                        the attestation check is satisfied as long
+                                        there are predicates that match the predicate
+                                        type.
+                                      items:
+                                        description: AnyAllConditions consists of
+                                          conditions wrapped denoting a logical criteria
+                                          to be fulfilled. AnyConditions get fulfilled
+                                          when at least one of its sub-conditions
+                                          passes. AllConditions get fulfilled only
+                                          when all of its sub-conditions pass.
+                                        properties:
+                                          all:
+                                            description: AllConditions enable variable-based
+                                              conditional rule execution. This is
+                                              useful for finer control of when an
+                                              rule is applied. A condition can reference
+                                              object data using JMESPath notation.
+                                              Here, all of the conditions need to
+                                              pass
+                                            items:
+                                              description: Condition defines variable-based
+                                                conditional criteria for rule execution.
+                                              properties:
+                                                key:
+                                                  description: Key is the context
+                                                    entry (using JMESPath) for conditional
+                                                    rule evaluation.
+                                                  x-kubernetes-preserve-unknown-fields: true
+                                                operator:
+                                                  description: 'Operator is the conditional
+                                                    operation to perform. Valid operators
+                                                    are: Equals, NotEquals, In, AnyIn,
+                                                    AllIn, NotIn, AnyNotIn, AllNotIn,
+                                                    GreaterThanOrEquals, GreaterThan,
+                                                    LessThanOrEquals, LessThan, DurationGreaterThanOrEquals,
+                                                    DurationGreaterThan, DurationLessThanOrEquals,
+                                                    DurationLessThan'
+                                                  enum:
+                                                  - Equals
+                                                  - NotEquals
+                                                  - In
+                                                  - AnyIn
+                                                  - AllIn
+                                                  - NotIn
+                                                  - AnyNotIn
+                                                  - AllNotIn
+                                                  - GreaterThanOrEquals
+                                                  - GreaterThan
+                                                  - LessThanOrEquals
+                                                  - LessThan
+                                                  - DurationGreaterThanOrEquals
+                                                  - DurationGreaterThan
+                                                  - DurationLessThanOrEquals
+                                                  - DurationLessThan
+                                                  type: string
+                                                value:
+                                                  description: Value is the conditional
+                                                    value, or set of values. The values
+                                                    can be fixed set or can be variables
+                                                    declared using JMESPath.
+                                                  x-kubernetes-preserve-unknown-fields: true
+                                              type: object
+                                            type: array
+                                          any:
+                                            description: AnyConditions enable variable-based
+                                              conditional rule execution. This is
+                                              useful for finer control of when an
+                                              rule is applied. A condition can reference
+                                              object data using JMESPath notation.
+                                              Here, at least one of the conditions
+                                              need to pass
+                                            items:
+                                              description: Condition defines variable-based
+                                                conditional criteria for rule execution.
+                                              properties:
+                                                key:
+                                                  description: Key is the context
+                                                    entry (using JMESPath) for conditional
+                                                    rule evaluation.
+                                                  x-kubernetes-preserve-unknown-fields: true
+                                                operator:
+                                                  description: 'Operator is the conditional
+                                                    operation to perform. Valid operators
+                                                    are: Equals, NotEquals, In, AnyIn,
+                                                    AllIn, NotIn, AnyNotIn, AllNotIn,
+                                                    GreaterThanOrEquals, GreaterThan,
+                                                    LessThanOrEquals, LessThan, DurationGreaterThanOrEquals,
+                                                    DurationGreaterThan, DurationLessThanOrEquals,
+                                                    DurationLessThan'
+                                                  enum:
+                                                  - Equals
+                                                  - NotEquals
+                                                  - In
+                                                  - AnyIn
+                                                  - AllIn
+                                                  - NotIn
+                                                  - AnyNotIn
+                                                  - AllNotIn
+                                                  - GreaterThanOrEquals
+                                                  - GreaterThan
+                                                  - LessThanOrEquals
+                                                  - LessThan
+                                                  - DurationGreaterThanOrEquals
+                                                  - DurationGreaterThan
+                                                  - DurationLessThanOrEquals
+                                                  - DurationLessThan
+                                                  type: string
+                                                value:
+                                                  description: Value is the conditional
+                                                    value, or set of values. The values
+                                                    can be fixed set or can be variables
+                                                    declared using JMESPath.
+                                                  x-kubernetes-preserve-unknown-fields: true
+                                              type: object
+                                            type: array
+                                        type: object
+                                      type: array
+                                    predicateType:
+                                      description: PredicateType defines the type
+                                        of Predicate contained within the Statement.
+                                      type: string
+                                  type: object
+                                type: array
+                              attestors:
+                                description: Attestors specified the required attestors
+                                  (i.e. authorities)
+                                items:
+                                  properties:
+                                    count:
+                                      description: Count specifies the required number
+                                        of entries that must match. If the count is
+                                        null, all entries must match (a logical AND).
+                                        If the count is 1, at least one entry must
+                                        match (a logical OR). If the count contains
+                                        a value N, then N must be less than or equal
+                                        to the size of entries, and at least N entries
+                                        must match.
+                                      minimum: 1
+                                      type: integer
+                                    entries:
+                                      description: Entries contains the available
+                                        attestors. An attestor can be a static key,
+                                        attributes for keyless verification, or a
+                                        nested attestor declaration.
+                                      items:
+                                        properties:
+                                          annotations:
+                                            additionalProperties:
+                                              type: string
+                                            description: Annotations are used for
+                                              image verification. Every specified
+                                              key-value pair must exist and match
+                                              in the verified payload. The payload
+                                              may contain other key-value pairs.
+                                            type: object
+                                          attestor:
+                                            description: Attestor is a nested AttestorSet
+                                              used to specify a more complex set of
+                                              match authorities
+                                            x-kubernetes-preserve-unknown-fields: true
+                                          certificates:
+                                            description: Certificates specifies one
+                                              or more certificates
+                                            properties:
+                                              cert:
+                                                description: Certificate is an optional
+                                                  PEM encoded public certificate.
+                                                type: string
+                                              certChain:
+                                                description: CertificateChain is an
+                                                  optional PEM encoded set of certificates
+                                                  used to verify
+                                                type: string
+                                              rekor:
+                                                description: Rekor provides configuration
+                                                  for the Rekor transparency log service.
+                                                  If the value is nil, Rekor is not
+                                                  checked. If an empty object is provided
+                                                  the public instance of Rekor (https://rekor.sigstore.dev)
+                                                  is used.
+                                                properties:
+                                                  url:
+                                                    description: URL is the address
+                                                      of the transparency log. Defaults
+                                                      to the public log https://rekor.sigstore.dev.
+                                                    type: string
+                                                required:
+                                                - url
+                                                type: object
+                                            type: object
+                                          keyless:
+                                            description: Keyless is a set of attribute
+                                              used to verify a Sigstore keyless attestor.
+                                              See https://github.com/sigstore/cosign/blob/main/KEYLESS.md.
+                                            properties:
+                                              additionalExtensions:
+                                                additionalProperties:
+                                                  type: string
+                                                description: AdditionalExtensions
+                                                  are certificate-extensions used
+                                                  for keyless signing.
+                                                type: object
+                                              issuer:
+                                                description: Issuer is the certificate
+                                                  issuer used for keyless signing.
+                                                type: string
+                                              rekor:
+                                                description: Rekor provides configuration
+                                                  for the Rekor transparency log service.
+                                                  If the value is nil, Rekor is not
+                                                  checked and a root certificate chain
+                                                  is expected instead. If an empty
+                                                  object is provided the public instance
+                                                  of Rekor (https://rekor.sigstore.dev)
+                                                  is used.
+                                                properties:
+                                                  url:
+                                                    description: URL is the address
+                                                      of the transparency log. Defaults
+                                                      to the public log https://rekor.sigstore.dev.
+                                                    type: string
+                                                required:
+                                                - url
+                                                type: object
+                                              roots:
+                                                description: Roots is an optional
+                                                  set of PEM encoded trusted root
+                                                  certificates. If not provided, the
+                                                  system roots are used.
+                                                type: string
+                                              subject:
+                                                description: Subject is the verified
+                                                  identity used for keyless signing,
+                                                  for example the email address
+                                                type: string
+                                            type: object
+                                          keys:
+                                            description: Keys specifies one or more
+                                              public keys
+                                            properties:
+                                              publicKeys:
+                                                description: Keys is a set of X.509
+                                                  public keys used to verify image
+                                                  signatures. The keys can be directly
+                                                  specified or can be a variable reference
+                                                  to a key specified in a ConfigMap
+                                                  (see https://kyverno.io/docs/writing-policies/variables/).
+                                                  When multiple keys are specified
+                                                  each key is processed as a separate
+                                                  staticKey entry (.attestors[*].entries.keys)
+                                                  within the set of attestors and
+                                                  the count is applied across the
+                                                  keys.
+                                                type: string
+                                              rekor:
+                                                description: Rekor provides configuration
+                                                  for the Rekor transparency log service.
+                                                  If the value is nil, Rekor is not
+                                                  checked. If an empty object is provided
+                                                  the public instance of Rekor (https://rekor.sigstore.dev)
+                                                  is used.
+                                                properties:
+                                                  url:
+                                                    description: URL is the address
+                                                      of the transparency log. Defaults
+                                                      to the public log https://rekor.sigstore.dev.
+                                                    type: string
+                                                required:
+                                                - url
+                                                type: object
+                                            type: object
+                                          repository:
+                                            description: Repository is an optional
+                                              alternate OCI repository to use for
+                                              signatures and attestations that match
+                                              this rule. If specified Repository will
+                                              override other OCI image repository
+                                              locations for this Attestor.
+                                            type: string
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                              image:
+                                description: 'Image is the image name consisting of
+                                  the registry address, repository, image, and tag.
+                                  Wildcards (''*'' and ''?'') are allowed. See: https://kubernetes.io/docs/concepts/containers/images.
+                                  Deprecated. Use ImageReferences instead.'
+                                type: string
+                              imageReferences:
+                                description: 'ImageReferences is a list of matching
+                                  image reference patterns. At least one pattern in
+                                  the list must match the image for the rule to apply.
+                                  Each image reference consists of a registry address
+                                  (defaults to docker.io), repository, image, and
+                                  tag (defaults to latest). Wildcards (''*'' and ''?'')
+                                  are allowed. See: https://kubernetes.io/docs/concepts/containers/images.'
+                                items:
+                                  type: string
+                                type: array
+                              issuer:
+                                description: Issuer is the certificate issuer used
+                                  for keyless signing. Deprecated. Use KeylessAttestor
+                                  instead.
+                                type: string
+                              key:
+                                description: Key is the PEM encoded public key that
+                                  the image or attestation is signed with. Deprecated.
+                                  Use StaticKeyAttestor instead.
+                                type: string
+                              mutateDigest:
+                                default: true
+                                description: MutateDigest enables replacement of image
+                                  tags with digests. Defaults to true.
+                                type: boolean
+                              repository:
+                                description: Repository is an optional alternate OCI
+                                  repository to use for image signatures and attestations
+                                  that match this rule. If specified Repository will
+                                  override the default OCI image repository configured
+                                  for the installation. The repository can also be
+                                  overridden per Attestor or Attestation.
+                                type: string
+                              required:
+                                default: true
+                                description: Required validates that images are verified
+                                  i.e. have matched passed a signature or attestation
+                                  check.
+                                type: boolean
+                              roots:
+                                description: Roots is the PEM encoded Root certificate
+                                  chain used for keyless signing Deprecated. Use KeylessAttestor
+                                  instead.
+                                type: string
+                              subject:
+                                description: Subject is the identity used for keyless
+                                  signing, for example an email address Deprecated.
+                                  Use KeylessAttestor instead.
+                                type: string
+                              verifyDigest:
+                                default: true
+                                description: VerifyDigest validates that images have
+                                  a digest.
+                                type: boolean
+                            type: object
+                          type: array
+                      type: object
+                    type: array
+                type: object
+              conditions:
+                description: Conditions is a list of conditions that apply to the
+                  policy
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              ready:
+                description: Ready indicates if the policy is ready to serve the admission
+                  request. Deprecated in favor of Conditions
+                type: boolean
+            required:
+            - ready
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.background
+      name: Background
+      type: boolean
+    - jsonPath: .spec.validationFailureAction
+      name: Validate Action
+      type: string
+    - jsonPath: .spec.failurePolicy
+      name: Failure Policy
+      priority: 1
+      type: string
+    - jsonPath: .status.ready
+      name: Ready
+      type: boolean
+    name: v2beta1
+    schema:
+      openAPIV3Schema:
+        description: 'Policy declares validation, mutation, and generation behaviors
+          for matching resources. See: https://kyverno.io/docs/writing-policies/ for
+          more information.'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines policy behaviors and contains one or more rules.
+            properties:
+              applyRules:
+                description: ApplyRules controls how rules in a policy are applied.
+                  Rule are processed in the order of declaration. When set to `One`
+                  processing stops after a rule has been applied i.e. the rule matches
+                  and results in a pass, fail, or error. When set to `All` all rules
+                  in the policy are processed. The default is `All`.
+                enum:
+                - All
+                - One
+                type: string
+              background:
+                default: true
+                description: Background controls if rules are applied to existing
+                  resources during a background scan. Optional. Default value is "true".
+                  The value must be set to "false" if the policy rule uses variables
+                  that are only available in the admission review request (e.g. user
+                  name).
+                type: boolean
+              failurePolicy:
+                description: FailurePolicy defines how unexpected policy errors and
+                  webhook response timeout errors are handled. Rules within the same
+                  policy share the same failure behavior. Allowed values are Ignore
+                  or Fail. Defaults to Fail.
+                enum:
+                - Ignore
+                - Fail
+                type: string
+              generateExistingOnPolicyUpdate:
+                description: GenerateExistingOnPolicyUpdate controls whether to trigger
+                  generate rule in existing resources If is set to "true" generate
+                  rule will be triggered and applied to existing matched resources.
+                  Defaults to "false" if not specified.
+                type: boolean
+              mutateExistingOnPolicyUpdate:
+                description: MutateExistingOnPolicyUpdate controls if a mutateExisting
+                  policy is applied on policy events. Default value is "false".
+                type: boolean
+              rules:
+                description: Rules is a list of Rule instances. A Policy contains
+                  multiple rules and each rule can validate, mutate, or generate resources.
+                items:
+                  description: Rule defines a validation, mutation, or generation
+                    control for matching resources. Each rules contains a match declaration
+                    to select resources, and an optional exclude declaration to specify
+                    which resources to exclude.
+                  properties:
+                    context:
+                      description: Context defines variables and data sources that
+                        can be used during rule execution.
+                      items:
+                        description: ContextEntry adds variables and data sources
+                          to a rule Context. Either a ConfigMap reference or a APILookup
+                          must be provided.
+                        properties:
+                          apiCall:
+                            description: APICall defines an HTTP request to the Kubernetes
+                              API server. The JSON data retrieved is stored in the
+                              context.
+                            properties:
+                              jmesPath:
+                                description: JMESPath is an optional JSON Match Expression
+                                  that can be used to transform the JSON response
+                                  returned from the API server. For example a JMESPath
+                                  of "items | length(@)" applied to the API server
+                                  response to the URLPath "/apis/apps/v1/deployments"
+                                  will return the total count of deployments across
+                                  all namespaces.
+                                type: string
+                              urlPath:
+                                description: URLPath is the URL path to be used in
+                                  the HTTP GET request to the Kubernetes API server
+                                  (e.g. "/api/v1/namespaces" or  "/apis/apps/v1/deployments").
+                                  The format required is the same format used by the
+                                  `kubectl get --raw` command.
+                                type: string
+                            required:
+                            - urlPath
+                            type: object
+                          configMap:
+                            description: ConfigMap is the ConfigMap reference.
+                            properties:
+                              name:
+                                description: Name is the ConfigMap name.
+                                type: string
+                              namespace:
+                                description: Namespace is the ConfigMap namespace.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          imageRegistry:
+                            description: ImageRegistry defines requests to an OCI/Docker
+                              V2 registry to fetch image details.
+                            properties:
+                              jmesPath:
+                                description: JMESPath is an optional JSON Match Expression
+                                  that can be used to transform the ImageData struct
+                                  returned as a result of processing the image reference.
+                                type: string
+                              reference:
+                                description: 'Reference is image reference to a container
+                                  image in the registry. Example: ghcr.io/kyverno/kyverno:latest'
+                                type: string
+                            required:
+                            - reference
+                            type: object
+                          name:
+                            description: Name is the variable name.
+                            type: string
+                          variable:
+                            description: Variable defines an arbitrary JMESPath context
+                              variable that can be defined inline.
+                            properties:
+                              default:
+                                description: Default is an optional arbitrary JSON
+                                  object that the variable may take if the JMESPath
+                                  expression evaluates to nil
+                                x-kubernetes-preserve-unknown-fields: true
+                              jmesPath:
+                                description: JMESPath is an optional JMESPath Expression
+                                  that can be used to transform the variable.
+                                type: string
+                              value:
+                                description: Value is any arbitrary JSON object representable
+                                  in YAML or JSON form.
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                        type: object
+                      type: array
+                    exclude:
+                      description: ExcludeResources defines when this policy rule
+                        should not be applied. The exclude criteria can include resource
+                        information (e.g. kind, name, namespace, labels) and admission
+                        review request information like the name or role.
+                      properties:
+                        all:
+                          description: All allows specifying resources which will
+                            be ANDed
+                          items:
+                            description: ResourceFilter allow users to "AND" or "OR"
+                              between resources
+                            properties:
+                              clusterRoles:
+                                description: ClusterRoles is the list of cluster-wide
+                                  role names for the user.
+                                items:
+                                  type: string
+                                type: array
+                              resources:
+                                description: ResourceDescription contains information
+                                  about the resource being created or modified.
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations is a  map of annotations
+                                      (key-value pairs of type string). Annotation
+                                      keys and values support the wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (matches at least one character).
+                                    type: object
+                                  kinds:
+                                    description: Kinds is a list of resource kinds.
+                                    items:
+                                      type: string
+                                    type: array
+                                  name:
+                                    description: 'Name is the name of the resource.
+                                      The name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character). NOTE: "Name" is being deprecated
+                                      in favor of "Names".'
+                                    type: string
+                                  names:
+                                    description: Names are the names of the resources.
+                                      Each name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character).
+                                    items:
+                                      type: string
+                                    type: array
+                                  namespaceSelector:
+                                    description: 'NamespaceSelector is a label selector
+                                      for the resource namespace. Label keys and values
+                                      in `matchLabels` support the wildcard characters
+                                      `*` (matches zero or many characters) and `?`
+                                      (matches one character).Wildcards allows writing
+                                      label selectors like ["storage.k8s.io/*": "*"].
+                                      Note that using ["*" : "*"] matches any key
+                                      and value but does not match an empty label
+                                      set.'
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaces:
+                                    description: Namespaces is a list of namespaces
+                                      names. Each name supports wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (at least one character).
+                                    items:
+                                      type: string
+                                    type: array
+                                  selector:
+                                    description: 'Selector is a label selector. Label
+                                      keys and values in `matchLabels` support the
+                                      wildcard characters `*` (matches zero or many
+                                      characters) and `?` (matches one character).
+                                      Wildcards allows writing label selectors like
+                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                      : "*"] matches any key and value but does not
+                                      match an empty label set.'
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              roles:
+                                description: Roles is the list of namespaced role
+                                  names for the user.
+                                items:
+                                  type: string
+                                type: array
+                              subjects:
+                                description: Subjects is the list of subject names
+                                  like users, user groups, and service accounts.
+                                items:
+                                  description: Subject contains a reference to the
+                                    object or user identities a role binding applies
+                                    to.  This can either hold a direct API object
+                                    reference, or a value for non-objects such as
+                                    user and group names.
+                                  properties:
+                                    apiGroup:
+                                      description: APIGroup holds the API group of
+                                        the referenced subject. Defaults to "" for
+                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
+                                        for User and Group subjects.
+                                      type: string
+                                    kind:
+                                      description: Kind of object being referenced.
+                                        Values defined by this API group are "User",
+                                        "Group", and "ServiceAccount". If the Authorizer
+                                        does not recognized the kind value, the Authorizer
+                                        should report an error.
+                                      type: string
+                                    name:
+                                      description: Name of the object being referenced.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the referenced object.  If
+                                        the object kind is non-namespace, such as
+                                        "User" or "Group", and this value is not empty
+                                        the Authorizer should report an error.
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                type: array
+                            type: object
+                          type: array
+                        any:
+                          description: Any allows specifying resources which will
+                            be ORed
+                          items:
+                            description: ResourceFilter allow users to "AND" or "OR"
+                              between resources
+                            properties:
+                              clusterRoles:
+                                description: ClusterRoles is the list of cluster-wide
+                                  role names for the user.
+                                items:
+                                  type: string
+                                type: array
+                              resources:
+                                description: ResourceDescription contains information
+                                  about the resource being created or modified.
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations is a  map of annotations
+                                      (key-value pairs of type string). Annotation
+                                      keys and values support the wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (matches at least one character).
+                                    type: object
+                                  kinds:
+                                    description: Kinds is a list of resource kinds.
+                                    items:
+                                      type: string
+                                    type: array
+                                  name:
+                                    description: 'Name is the name of the resource.
+                                      The name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character). NOTE: "Name" is being deprecated
+                                      in favor of "Names".'
+                                    type: string
+                                  names:
+                                    description: Names are the names of the resources.
+                                      Each name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character).
+                                    items:
+                                      type: string
+                                    type: array
+                                  namespaceSelector:
+                                    description: 'NamespaceSelector is a label selector
+                                      for the resource namespace. Label keys and values
+                                      in `matchLabels` support the wildcard characters
+                                      `*` (matches zero or many characters) and `?`
+                                      (matches one character).Wildcards allows writing
+                                      label selectors like ["storage.k8s.io/*": "*"].
+                                      Note that using ["*" : "*"] matches any key
+                                      and value but does not match an empty label
+                                      set.'
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaces:
+                                    description: Namespaces is a list of namespaces
+                                      names. Each name supports wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (at least one character).
+                                    items:
+                                      type: string
+                                    type: array
+                                  selector:
+                                    description: 'Selector is a label selector. Label
+                                      keys and values in `matchLabels` support the
+                                      wildcard characters `*` (matches zero or many
+                                      characters) and `?` (matches one character).
+                                      Wildcards allows writing label selectors like
+                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                      : "*"] matches any key and value but does not
+                                      match an empty label set.'
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              roles:
+                                description: Roles is the list of namespaced role
+                                  names for the user.
+                                items:
+                                  type: string
+                                type: array
+                              subjects:
+                                description: Subjects is the list of subject names
+                                  like users, user groups, and service accounts.
+                                items:
+                                  description: Subject contains a reference to the
+                                    object or user identities a role binding applies
+                                    to.  This can either hold a direct API object
+                                    reference, or a value for non-objects such as
+                                    user and group names.
+                                  properties:
+                                    apiGroup:
+                                      description: APIGroup holds the API group of
+                                        the referenced subject. Defaults to "" for
+                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
+                                        for User and Group subjects.
+                                      type: string
+                                    kind:
+                                      description: Kind of object being referenced.
+                                        Values defined by this API group are "User",
+                                        "Group", and "ServiceAccount". If the Authorizer
+                                        does not recognized the kind value, the Authorizer
+                                        should report an error.
+                                      type: string
+                                    name:
+                                      description: Name of the object being referenced.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the referenced object.  If
+                                        the object kind is non-namespace, such as
+                                        "User" or "Group", and this value is not empty
+                                        the Authorizer should report an error.
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                type: array
+                            type: object
+                          type: array
+                      type: object
+                    generate:
+                      description: Generation is used to create new resources.
+                      properties:
+                        apiVersion:
+                          description: APIVersion specifies resource apiVersion.
+                          type: string
+                        clone:
+                          description: Clone specifies the source resource used to
+                            populate each generated resource. At most one of Data
+                            or Clone can be specified. If neither are provided, the
+                            generated resource will be created with default data only.
+                          properties:
+                            name:
+                              description: Name specifies name of the resource.
+                              type: string
+                            namespace:
+                              description: Namespace specifies source resource namespace.
+                              type: string
+                          type: object
+                        cloneList:
+                          description: CloneList specifies the list of source resource
+                            used to populate each generated resource.
+                          properties:
+                            kinds:
+                              description: Kinds is a list of resource kinds.
+                              items:
+                                type: string
+                              type: array
+                            namespace:
+                              description: Namespace specifies source resource namespace.
+                              type: string
+                            selector:
+                              description: Selector is a label selector. Label keys
+                                and values in `matchLabels`. wildcard characters are
+                                not supported.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        data:
+                          description: Data provides the resource declaration used
+                            to populate each generated resource. At most one of Data
+                            or Clone must be specified. If neither are provided, the
+                            generated resource will be created with default data only.
+                          x-kubernetes-preserve-unknown-fields: true
+                        kind:
+                          description: Kind specifies resource kind.
+                          type: string
+                        name:
+                          description: Name specifies the resource name.
+                          type: string
+                        namespace:
+                          description: Namespace specifies resource namespace.
+                          type: string
+                        synchronize:
+                          description: Synchronize controls if generated resources
+                            should be kept in-sync with their source resource. If
+                            Synchronize is set to "true" changes to generated resources
+                            will be overwritten with resource data from Data or the
+                            resource specified in the Clone declaration. Optional.
+                            Defaults to "false" if not specified.
+                          type: boolean
+                      type: object
+                    imageExtractors:
+                      additionalProperties:
+                        items:
+                          properties:
+                            key:
+                              description: Key is an optional name of the field within
+                                'path' that will be used to uniquely identify an image.
+                                Note - this field MUST be unique.
+                              type: string
+                            name:
+                              description: Name is the entry the image will be available
+                                under 'images.<name>' in the context. If this field
+                                is not defined, image entries will appear under 'images.custom'.
+                              type: string
+                            path:
+                              description: Path is the path to the object containing
+                                the image field in a custom resource. It should be
+                                slash-separated. Each slash-separated key must be
+                                a valid YAML key or a wildcard '*'. Wildcard keys
+                                are expanded in case of arrays or objects.
+                              type: string
+                            value:
+                              description: Value is an optional name of the field
+                                within 'path' that points to the image URI. This is
+                                useful when a custom 'key' is also defined.
+                              type: string
+                          required:
+                          - path
+                          type: object
+                        type: array
+                      description: ImageExtractors defines a mapping from kinds to
+                        ImageExtractorConfigs. This config is only valid for verifyImages
+                        rules.
+                      type: object
+                    match:
+                      description: MatchResources defines when this policy rule should
+                        be applied. The match criteria can include resource information
+                        (e.g. kind, name, namespace, labels) and admission review
+                        request information like the user name or role. At least one
+                        kind is required.
+                      properties:
+                        all:
+                          description: All allows specifying resources which will
+                            be ANDed
+                          items:
+                            description: ResourceFilter allow users to "AND" or "OR"
+                              between resources
+                            properties:
+                              clusterRoles:
+                                description: ClusterRoles is the list of cluster-wide
+                                  role names for the user.
+                                items:
+                                  type: string
+                                type: array
+                              resources:
+                                description: ResourceDescription contains information
+                                  about the resource being created or modified.
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations is a  map of annotations
+                                      (key-value pairs of type string). Annotation
+                                      keys and values support the wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (matches at least one character).
+                                    type: object
+                                  kinds:
+                                    description: Kinds is a list of resource kinds.
+                                    items:
+                                      type: string
+                                    type: array
+                                  name:
+                                    description: 'Name is the name of the resource.
+                                      The name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character). NOTE: "Name" is being deprecated
+                                      in favor of "Names".'
+                                    type: string
+                                  names:
+                                    description: Names are the names of the resources.
+                                      Each name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character).
+                                    items:
+                                      type: string
+                                    type: array
+                                  namespaceSelector:
+                                    description: 'NamespaceSelector is a label selector
+                                      for the resource namespace. Label keys and values
+                                      in `matchLabels` support the wildcard characters
+                                      `*` (matches zero or many characters) and `?`
+                                      (matches one character).Wildcards allows writing
+                                      label selectors like ["storage.k8s.io/*": "*"].
+                                      Note that using ["*" : "*"] matches any key
+                                      and value but does not match an empty label
+                                      set.'
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaces:
+                                    description: Namespaces is a list of namespaces
+                                      names. Each name supports wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (at least one character).
+                                    items:
+                                      type: string
+                                    type: array
+                                  selector:
+                                    description: 'Selector is a label selector. Label
+                                      keys and values in `matchLabels` support the
+                                      wildcard characters `*` (matches zero or many
+                                      characters) and `?` (matches one character).
+                                      Wildcards allows writing label selectors like
+                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                      : "*"] matches any key and value but does not
+                                      match an empty label set.'
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              roles:
+                                description: Roles is the list of namespaced role
+                                  names for the user.
+                                items:
+                                  type: string
+                                type: array
+                              subjects:
+                                description: Subjects is the list of subject names
+                                  like users, user groups, and service accounts.
+                                items:
+                                  description: Subject contains a reference to the
+                                    object or user identities a role binding applies
+                                    to.  This can either hold a direct API object
+                                    reference, or a value for non-objects such as
+                                    user and group names.
+                                  properties:
+                                    apiGroup:
+                                      description: APIGroup holds the API group of
+                                        the referenced subject. Defaults to "" for
+                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
+                                        for User and Group subjects.
+                                      type: string
+                                    kind:
+                                      description: Kind of object being referenced.
+                                        Values defined by this API group are "User",
+                                        "Group", and "ServiceAccount". If the Authorizer
+                                        does not recognized the kind value, the Authorizer
+                                        should report an error.
+                                      type: string
+                                    name:
+                                      description: Name of the object being referenced.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the referenced object.  If
+                                        the object kind is non-namespace, such as
+                                        "User" or "Group", and this value is not empty
+                                        the Authorizer should report an error.
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                type: array
+                            type: object
+                          type: array
+                        any:
+                          description: Any allows specifying resources which will
+                            be ORed
+                          items:
+                            description: ResourceFilter allow users to "AND" or "OR"
+                              between resources
+                            properties:
+                              clusterRoles:
+                                description: ClusterRoles is the list of cluster-wide
+                                  role names for the user.
+                                items:
+                                  type: string
+                                type: array
+                              resources:
+                                description: ResourceDescription contains information
+                                  about the resource being created or modified.
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations is a  map of annotations
+                                      (key-value pairs of type string). Annotation
+                                      keys and values support the wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (matches at least one character).
+                                    type: object
+                                  kinds:
+                                    description: Kinds is a list of resource kinds.
+                                    items:
+                                      type: string
+                                    type: array
+                                  name:
+                                    description: 'Name is the name of the resource.
+                                      The name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character). NOTE: "Name" is being deprecated
+                                      in favor of "Names".'
+                                    type: string
+                                  names:
+                                    description: Names are the names of the resources.
+                                      Each name supports wildcard characters "*" (matches
+                                      zero or many characters) and "?" (at least one
+                                      character).
+                                    items:
+                                      type: string
+                                    type: array
+                                  namespaceSelector:
+                                    description: 'NamespaceSelector is a label selector
+                                      for the resource namespace. Label keys and values
+                                      in `matchLabels` support the wildcard characters
+                                      `*` (matches zero or many characters) and `?`
+                                      (matches one character).Wildcards allows writing
+                                      label selectors like ["storage.k8s.io/*": "*"].
+                                      Note that using ["*" : "*"] matches any key
+                                      and value but does not match an empty label
+                                      set.'
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaces:
+                                    description: Namespaces is a list of namespaces
+                                      names. Each name supports wildcard characters
+                                      "*" (matches zero or many characters) and "?"
+                                      (at least one character).
+                                    items:
+                                      type: string
+                                    type: array
+                                  selector:
+                                    description: 'Selector is a label selector. Label
+                                      keys and values in `matchLabels` support the
+                                      wildcard characters `*` (matches zero or many
+                                      characters) and `?` (matches one character).
+                                      Wildcards allows writing label selectors like
+                                      ["storage.k8s.io/*": "*"]. Note that using ["*"
+                                      : "*"] matches any key and value but does not
+                                      match an empty label set.'
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              roles:
+                                description: Roles is the list of namespaced role
+                                  names for the user.
+                                items:
+                                  type: string
+                                type: array
+                              subjects:
+                                description: Subjects is the list of subject names
+                                  like users, user groups, and service accounts.
+                                items:
+                                  description: Subject contains a reference to the
+                                    object or user identities a role binding applies
+                                    to.  This can either hold a direct API object
+                                    reference, or a value for non-objects such as
+                                    user and group names.
+                                  properties:
+                                    apiGroup:
+                                      description: APIGroup holds the API group of
+                                        the referenced subject. Defaults to "" for
+                                        ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
+                                        for User and Group subjects.
+                                      type: string
+                                    kind:
+                                      description: Kind of object being referenced.
+                                        Values defined by this API group are "User",
+                                        "Group", and "ServiceAccount". If the Authorizer
+                                        does not recognized the kind value, the Authorizer
+                                        should report an error.
+                                      type: string
+                                    name:
+                                      description: Name of the object being referenced.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the referenced object.  If
+                                        the object kind is non-namespace, such as
+                                        "User" or "Group", and this value is not empty
+                                        the Authorizer should report an error.
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                type: array
+                            type: object
+                          type: array
+                      type: object
+                    mutate:
+                      description: Mutation is used to modify matching resources.
+                      properties:
+                        foreach:
+                          description: ForEach applies mutation rules to a list of
+                            sub-elements by creating a context for each entry in the
+                            list and looping over it to apply the specified logic.
+                          items:
+                            description: ForEach applies mutation rules to a list
+                              of sub-elements by creating a context for each entry
+                              in the list and looping over it to apply the specified
+                              logic.
+                            properties:
+                              context:
+                                description: Context defines variables and data sources
+                                  that can be used during rule execution.
+                                items:
+                                  description: ContextEntry adds variables and data
+                                    sources to a rule Context. Either a ConfigMap
+                                    reference or a APILookup must be provided.
+                                  properties:
+                                    apiCall:
+                                      description: APICall defines an HTTP request
+                                        to the Kubernetes API server. The JSON data
+                                        retrieved is stored in the context.
+                                      properties:
+                                        jmesPath:
+                                          description: JMESPath is an optional JSON
+                                            Match Expression that can be used to transform
+                                            the JSON response returned from the API
+                                            server. For example a JMESPath of "items
+                                            | length(@)" applied to the API server
+                                            response to the URLPath "/apis/apps/v1/deployments"
+                                            will return the total count of deployments
+                                            across all namespaces.
+                                          type: string
+                                        urlPath:
+                                          description: URLPath is the URL path to
+                                            be used in the HTTP GET request to the
+                                            Kubernetes API server (e.g. "/api/v1/namespaces"
+                                            or  "/apis/apps/v1/deployments"). The
+                                            format required is the same format used
+                                            by the `kubectl get --raw` command.
+                                          type: string
+                                      required:
+                                      - urlPath
+                                      type: object
+                                    configMap:
+                                      description: ConfigMap is the ConfigMap reference.
+                                      properties:
+                                        name:
+                                          description: Name is the ConfigMap name.
+                                          type: string
+                                        namespace:
+                                          description: Namespace is the ConfigMap
+                                            namespace.
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    imageRegistry:
+                                      description: ImageRegistry defines requests
+                                        to an OCI/Docker V2 registry to fetch image
+                                        details.
+                                      properties:
+                                        jmesPath:
+                                          description: JMESPath is an optional JSON
+                                            Match Expression that can be used to transform
+                                            the ImageData struct returned as a result
+                                            of processing the image reference.
+                                          type: string
+                                        reference:
+                                          description: 'Reference is image reference
+                                            to a container image in the registry.
+                                            Example: ghcr.io/kyverno/kyverno:latest'
+                                          type: string
+                                      required:
+                                      - reference
+                                      type: object
+                                    name:
+                                      description: Name is the variable name.
+                                      type: string
+                                    variable:
+                                      description: Variable defines an arbitrary JMESPath
+                                        context variable that can be defined inline.
+                                      properties:
+                                        default:
+                                          description: Default is an optional arbitrary
+                                            JSON object that the variable may take
+                                            if the JMESPath expression evaluates to
+                                            nil
+                                          x-kubernetes-preserve-unknown-fields: true
+                                        jmesPath:
+                                          description: JMESPath is an optional JMESPath
+                                            Expression that can be used to transform
+                                            the variable.
+                                          type: string
+                                        value:
+                                          description: Value is any arbitrary JSON
+                                            object representable in YAML or JSON form.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                  type: object
+                                type: array
+                              list:
+                                description: List specifies a JMESPath expression
+                                  that results in one or more elements to which the
+                                  validation logic is applied.
+                                type: string
+                              patchStrategicMerge:
+                                description: PatchStrategicMerge is a strategic merge
+                                  patch used to modify resources. See https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/
+                                  and https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.
+                                x-kubernetes-preserve-unknown-fields: true
+                              patchesJson6902:
+                                description: PatchesJSON6902 is a list of RFC 6902
+                                  JSON Patch declarations used to modify resources.
+                                  See https://tools.ietf.org/html/rfc6902 and https://kubectl.docs.kubernetes.io/references/kustomize/patchesjson6902/.
+                                type: string
+                              preconditions:
+                                description: 'AnyAllConditions are used to determine
+                                  if a policy rule should be applied by evaluating
+                                  a set of conditions. The declaration can contain
+                                  nested `any` or `all` statements. See: https://kyverno.io/docs/writing-policies/preconditions/'
+                                properties:
+                                  all:
+                                    description: AllConditions enable variable-based
+                                      conditional rule execution. This is useful for
+                                      finer control of when an rule is applied. A
+                                      condition can reference object data using JMESPath
+                                      notation. Here, all of the conditions need to
+                                      pass
+                                    items:
+                                      description: Condition defines variable-based
+                                        conditional criteria for rule execution.
+                                      properties:
+                                        key:
+                                          description: Key is the context entry (using
+                                            JMESPath) for conditional rule evaluation.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                        operator:
+                                          description: 'Operator is the conditional
+                                            operation to perform. Valid operators
+                                            are: Equals, NotEquals, In, AnyIn, AllIn,
+                                            NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,
+                                            GreaterThan, LessThanOrEquals, LessThan,
+                                            DurationGreaterThanOrEquals, DurationGreaterThan,
+                                            DurationLessThanOrEquals, DurationLessThan'
+                                          enum:
+                                          - Equals
+                                          - NotEquals
+                                          - In
+                                          - AnyIn
+                                          - AllIn
+                                          - NotIn
+                                          - AnyNotIn
+                                          - AllNotIn
+                                          - GreaterThanOrEquals
+                                          - GreaterThan
+                                          - LessThanOrEquals
+                                          - LessThan
+                                          - DurationGreaterThanOrEquals
+                                          - DurationGreaterThan
+                                          - DurationLessThanOrEquals
+                                          - DurationLessThan
+                                          type: string
+                                        value:
+                                          description: Value is the conditional value,
+                                            or set of values. The values can be fixed
+                                            set or can be variables declared using
+                                            JMESPath.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                    type: array
+                                  any:
+                                    description: AnyConditions enable variable-based
+                                      conditional rule execution. This is useful for
+                                      finer control of when an rule is applied. A
+                                      condition can reference object data using JMESPath
+                                      notation. Here, at least one of the conditions
+                                      need to pass
+                                    items:
+                                      description: Condition defines variable-based
+                                        conditional criteria for rule execution.
+                                      properties:
+                                        key:
+                                          description: Key is the context entry (using
+                                            JMESPath) for conditional rule evaluation.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                        operator:
+                                          description: 'Operator is the conditional
+                                            operation to perform. Valid operators
+                                            are: Equals, NotEquals, In, AnyIn, AllIn,
+                                            NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,
+                                            GreaterThan, LessThanOrEquals, LessThan,
+                                            DurationGreaterThanOrEquals, DurationGreaterThan,
+                                            DurationLessThanOrEquals, DurationLessThan'
+                                          enum:
+                                          - Equals
+                                          - NotEquals
+                                          - In
+                                          - AnyIn
+                                          - AllIn
+                                          - NotIn
+                                          - AnyNotIn
+                                          - AllNotIn
+                                          - GreaterThanOrEquals
+                                          - GreaterThan
+                                          - LessThanOrEquals
+                                          - LessThan
+                                          - DurationGreaterThanOrEquals
+                                          - DurationGreaterThan
+                                          - DurationLessThanOrEquals
+                                          - DurationLessThan
+                                          type: string
+                                        value:
+                                          description: Value is the conditional value,
+                                            or set of values. The values can be fixed
+                                            set or can be variables declared using
+                                            JMESPath.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                    type: array
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          type: array
+                        patchStrategicMerge:
+                          description: PatchStrategicMerge is a strategic merge patch
+                            used to modify resources. See https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/
+                            and https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.
+                          x-kubernetes-preserve-unknown-fields: true
+                        patchesJson6902:
+                          description: PatchesJSON6902 is a list of RFC 6902 JSON
+                            Patch declarations used to modify resources. See https://tools.ietf.org/html/rfc6902
+                            and https://kubectl.docs.kubernetes.io/references/kustomize/patchesjson6902/.
+                          type: string
+                        targets:
+                          description: Targets defines the target resources to be
+                            mutated.
+                          items:
+                            properties:
+                              apiVersion:
+                                description: APIVersion specifies resource apiVersion.
+                                type: string
+                              kind:
+                                description: Kind specifies resource kind.
+                                type: string
+                              name:
+                                description: Name specifies the resource name.
+                                type: string
+                              namespace:
+                                description: Namespace specifies resource namespace.
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    name:
+                      description: Name is a label to identify the rule, It must be
+                        unique within the policy.
+                      maxLength: 63
+                      type: string
+                    preconditions:
+                      description: 'Preconditions are used to determine if a policy
+                        rule should be applied by evaluating a set of conditions.
+                        The declaration can contain nested `any` or `all` statements.
+                        A direct list of conditions (without `any` or `all` statements
+                        is supported for backwards compatibility but See: https://kyverno.io/docs/writing-policies/preconditions/'
+                      properties:
+                        all:
+                          description: AllConditions enable variable-based conditional
+                            rule execution. This is useful for finer control of when
+                            an rule is applied. A condition can reference object data
+                            using JMESPath notation. Here, all of the conditions need
+                            to pass
+                          items:
+                            properties:
+                              key:
+                                description: Key is the context entry (using JMESPath)
+                                  for conditional rule evaluation.
+                                x-kubernetes-preserve-unknown-fields: true
+                              operator:
+                                description: 'Operator is the conditional operation
+                                  to perform. Valid operators are: Equals, NotEquals,
+                                  In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,
+                                  GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals,
+                                  DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan'
+                                enum:
+                                - Equals
+                                - NotEquals
+                                - AnyIn
+                                - AllIn
+                                - AnyNotIn
+                                - AllNotIn
+                                - GreaterThanOrEquals
+                                - GreaterThan
+                                - LessThanOrEquals
+                                - LessThan
+                                - DurationGreaterThanOrEquals
+                                - DurationGreaterThan
+                                - DurationLessThanOrEquals
+                                - DurationLessThan
+                                type: string
+                              value:
+                                description: Value is the conditional value, or set
+                                  of values. The values can be fixed set or can be
+                                  variables declared using JMESPath.
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          type: array
+                        any:
+                          description: AnyConditions enable variable-based conditional
+                            rule execution. This is useful for finer control of when
+                            an rule is applied. A condition can reference object data
+                            using JMESPath notation. Here, at least one of the conditions
+                            need to pass
+                          items:
+                            properties:
+                              key:
+                                description: Key is the context entry (using JMESPath)
+                                  for conditional rule evaluation.
+                                x-kubernetes-preserve-unknown-fields: true
+                              operator:
+                                description: 'Operator is the conditional operation
+                                  to perform. Valid operators are: Equals, NotEquals,
+                                  In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,
+                                  GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals,
+                                  DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan'
+                                enum:
+                                - Equals
+                                - NotEquals
+                                - AnyIn
+                                - AllIn
+                                - AnyNotIn
+                                - AllNotIn
+                                - GreaterThanOrEquals
+                                - GreaterThan
+                                - LessThanOrEquals
+                                - LessThan
+                                - DurationGreaterThanOrEquals
+                                - DurationGreaterThan
+                                - DurationLessThanOrEquals
+                                - DurationLessThan
+                                type: string
+                              value:
+                                description: Value is the conditional value, or set
+                                  of values. The values can be fixed set or can be
+                                  variables declared using JMESPath.
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          type: array
+                      type: object
+                    validate:
+                      description: Validation is used to validate matching resources.
+                      properties:
+                        anyPattern:
+                          description: AnyPattern specifies list of validation patterns.
+                            At least one of the patterns must be satisfied for the
+                            validation rule to succeed.
+                          x-kubernetes-preserve-unknown-fields: true
+                        deny:
+                          description: Deny defines conditions used to pass or fail
+                            a validation rule.
+                          properties:
+                            conditions:
+                              description: 'Multiple conditions can be declared under
+                                an `any` or `all` statement. A direct list of conditions
+                                (without `any` or `all` statements) is also supported
+                                for backwards compatibility See: https://kyverno.io/docs/writing-policies/validate/#deny-rules'
+                              properties:
+                                all:
+                                  description: AllConditions enable variable-based
+                                    conditional rule execution. This is useful for
+                                    finer control of when an rule is applied. A condition
+                                    can reference object data using JMESPath notation.
+                                    Here, all of the conditions need to pass
+                                  items:
+                                    properties:
+                                      key:
+                                        description: Key is the context entry (using
+                                          JMESPath) for conditional rule evaluation.
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      operator:
+                                        description: 'Operator is the conditional
+                                          operation to perform. Valid operators are:
+                                          Equals, NotEquals, In, AnyIn, AllIn, NotIn,
+                                          AnyNotIn, AllNotIn, GreaterThanOrEquals,
+                                          GreaterThan, LessThanOrEquals, LessThan,
+                                          DurationGreaterThanOrEquals, DurationGreaterThan,
+                                          DurationLessThanOrEquals, DurationLessThan'
+                                        enum:
+                                        - Equals
+                                        - NotEquals
+                                        - AnyIn
+                                        - AllIn
+                                        - AnyNotIn
+                                        - AllNotIn
+                                        - GreaterThanOrEquals
+                                        - GreaterThan
+                                        - LessThanOrEquals
+                                        - LessThan
+                                        - DurationGreaterThanOrEquals
+                                        - DurationGreaterThan
+                                        - DurationLessThanOrEquals
+                                        - DurationLessThan
+                                        type: string
+                                      value:
+                                        description: Value is the conditional value,
+                                          or set of values. The values can be fixed
+                                          set or can be variables declared using JMESPath.
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                  type: array
+                                any:
+                                  description: AnyConditions enable variable-based
+                                    conditional rule execution. This is useful for
+                                    finer control of when an rule is applied. A condition
+                                    can reference object data using JMESPath notation.
+                                    Here, at least one of the conditions need to pass
+                                  items:
+                                    properties:
+                                      key:
+                                        description: Key is the context entry (using
+                                          JMESPath) for conditional rule evaluation.
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      operator:
+                                        description: 'Operator is the conditional
+                                          operation to perform. Valid operators are:
+                                          Equals, NotEquals, In, AnyIn, AllIn, NotIn,
+                                          AnyNotIn, AllNotIn, GreaterThanOrEquals,
+                                          GreaterThan, LessThanOrEquals, LessThan,
+                                          DurationGreaterThanOrEquals, DurationGreaterThan,
+                                          DurationLessThanOrEquals, DurationLessThan'
+                                        enum:
+                                        - Equals
+                                        - NotEquals
+                                        - AnyIn
+                                        - AllIn
+                                        - AnyNotIn
+                                        - AllNotIn
+                                        - GreaterThanOrEquals
+                                        - GreaterThan
+                                        - LessThanOrEquals
+                                        - LessThan
+                                        - DurationGreaterThanOrEquals
+                                        - DurationGreaterThan
+                                        - DurationLessThanOrEquals
+                                        - DurationLessThan
+                                        type: string
+                                      value:
+                                        description: Value is the conditional value,
+                                          or set of values. The values can be fixed
+                                          set or can be variables declared using JMESPath.
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                  type: array
+                              type: object
+                          type: object
+                        foreach:
+                          description: ForEach applies validate rules to a list of
+                            sub-elements by creating a context for each entry in the
+                            list and looping over it to apply the specified logic.
+                          items:
+                            description: ForEach applies validate rules to a list
+                              of sub-elements by creating a context for each entry
+                              in the list and looping over it to apply the specified
+                              logic.
+                            properties:
+                              anyPattern:
+                                description: AnyPattern specifies list of validation
+                                  patterns. At least one of the patterns must be satisfied
+                                  for the validation rule to succeed.
+                                x-kubernetes-preserve-unknown-fields: true
+                              context:
+                                description: Context defines variables and data sources
+                                  that can be used during rule execution.
+                                items:
+                                  description: ContextEntry adds variables and data
+                                    sources to a rule Context. Either a ConfigMap
+                                    reference or a APILookup must be provided.
+                                  properties:
+                                    apiCall:
+                                      description: APICall defines an HTTP request
+                                        to the Kubernetes API server. The JSON data
+                                        retrieved is stored in the context.
+                                      properties:
+                                        jmesPath:
+                                          description: JMESPath is an optional JSON
+                                            Match Expression that can be used to transform
+                                            the JSON response returned from the API
+                                            server. For example a JMESPath of "items
+                                            | length(@)" applied to the API server
+                                            response to the URLPath "/apis/apps/v1/deployments"
+                                            will return the total count of deployments
+                                            across all namespaces.
+                                          type: string
+                                        urlPath:
+                                          description: URLPath is the URL path to
+                                            be used in the HTTP GET request to the
+                                            Kubernetes API server (e.g. "/api/v1/namespaces"
+                                            or  "/apis/apps/v1/deployments"). The
+                                            format required is the same format used
+                                            by the `kubectl get --raw` command.
+                                          type: string
+                                      required:
+                                      - urlPath
+                                      type: object
+                                    configMap:
+                                      description: ConfigMap is the ConfigMap reference.
+                                      properties:
+                                        name:
+                                          description: Name is the ConfigMap name.
+                                          type: string
+                                        namespace:
+                                          description: Namespace is the ConfigMap
+                                            namespace.
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    imageRegistry:
+                                      description: ImageRegistry defines requests
+                                        to an OCI/Docker V2 registry to fetch image
+                                        details.
+                                      properties:
+                                        jmesPath:
+                                          description: JMESPath is an optional JSON
+                                            Match Expression that can be used to transform
+                                            the ImageData struct returned as a result
+                                            of processing the image reference.
+                                          type: string
+                                        reference:
+                                          description: 'Reference is image reference
+                                            to a container image in the registry.
+                                            Example: ghcr.io/kyverno/kyverno:latest'
+                                          type: string
+                                      required:
+                                      - reference
+                                      type: object
+                                    name:
+                                      description: Name is the variable name.
+                                      type: string
+                                    variable:
+                                      description: Variable defines an arbitrary JMESPath
+                                        context variable that can be defined inline.
+                                      properties:
+                                        default:
+                                          description: Default is an optional arbitrary
+                                            JSON object that the variable may take
+                                            if the JMESPath expression evaluates to
+                                            nil
+                                          x-kubernetes-preserve-unknown-fields: true
+                                        jmesPath:
+                                          description: JMESPath is an optional JMESPath
+                                            Expression that can be used to transform
+                                            the variable.
+                                          type: string
+                                        value:
+                                          description: Value is any arbitrary JSON
+                                            object representable in YAML or JSON form.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                  type: object
+                                type: array
+                              deny:
+                                description: Deny defines conditions used to pass
+                                  or fail a validation rule.
+                                properties:
+                                  conditions:
+                                    description: 'Multiple conditions can be declared
+                                      under an `any` or `all` statement. A direct
+                                      list of conditions (without `any` or `all` statements)
+                                      is also supported for backwards compatibility
+                                      but will be deprecated in the next major release.
+                                      See: https://kyverno.io/docs/writing-policies/validate/#deny-rules'
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              elementScope:
+                                description: ElementScope specifies whether to use
+                                  the current list element as the scope for validation.
+                                  Defaults to "true" if not specified. When set to
+                                  "false", "request.object" is used as the validation
+                                  scope within the foreach block to allow referencing
+                                  other elements in the subtree.
+                                type: boolean
+                              list:
+                                description: List specifies a JMESPath expression
+                                  that results in one or more elements to which the
+                                  validation logic is applied.
+                                type: string
+                              pattern:
+                                description: Pattern specifies an overlay-style pattern
+                                  used to check resources.
+                                x-kubernetes-preserve-unknown-fields: true
+                              preconditions:
+                                description: 'AnyAllConditions are used to determine
+                                  if a policy rule should be applied by evaluating
+                                  a set of conditions. The declaration can contain
+                                  nested `any` or `all` statements. See: https://kyverno.io/docs/writing-policies/preconditions/'
+                                properties:
+                                  all:
+                                    description: AllConditions enable variable-based
+                                      conditional rule execution. This is useful for
+                                      finer control of when an rule is applied. A
+                                      condition can reference object data using JMESPath
+                                      notation. Here, all of the conditions need to
+                                      pass
+                                    items:
+                                      description: Condition defines variable-based
+                                        conditional criteria for rule execution.
+                                      properties:
+                                        key:
+                                          description: Key is the context entry (using
+                                            JMESPath) for conditional rule evaluation.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                        operator:
+                                          description: 'Operator is the conditional
+                                            operation to perform. Valid operators
+                                            are: Equals, NotEquals, In, AnyIn, AllIn,
+                                            NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,
+                                            GreaterThan, LessThanOrEquals, LessThan,
+                                            DurationGreaterThanOrEquals, DurationGreaterThan,
+                                            DurationLessThanOrEquals, DurationLessThan'
+                                          enum:
+                                          - Equals
+                                          - NotEquals
+                                          - In
+                                          - AnyIn
+                                          - AllIn
+                                          - NotIn
+                                          - AnyNotIn
+                                          - AllNotIn
+                                          - GreaterThanOrEquals
+                                          - GreaterThan
+                                          - LessThanOrEquals
+                                          - LessThan
+                                          - DurationGreaterThanOrEquals
+                                          - DurationGreaterThan
+                                          - DurationLessThanOrEquals
+                                          - DurationLessThan
+                                          type: string
+                                        value:
+                                          description: Value is the conditional value,
+                                            or set of values. The values can be fixed
+                                            set or can be variables declared using
+                                            JMESPath.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                    type: array
+                                  any:
+                                    description: AnyConditions enable variable-based
+                                      conditional rule execution. This is useful for
+                                      finer control of when an rule is applied. A
+                                      condition can reference object data using JMESPath
+                                      notation. Here, at least one of the conditions
+                                      need to pass
+                                    items:
+                                      description: Condition defines variable-based
+                                        conditional criteria for rule execution.
+                                      properties:
+                                        key:
+                                          description: Key is the context entry (using
+                                            JMESPath) for conditional rule evaluation.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                        operator:
+                                          description: 'Operator is the conditional
+                                            operation to perform. Valid operators
+                                            are: Equals, NotEquals, In, AnyIn, AllIn,
+                                            NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,
+                                            GreaterThan, LessThanOrEquals, LessThan,
+                                            DurationGreaterThanOrEquals, DurationGreaterThan,
+                                            DurationLessThanOrEquals, DurationLessThan'
+                                          enum:
+                                          - Equals
+                                          - NotEquals
+                                          - In
+                                          - AnyIn
+                                          - AllIn
+                                          - NotIn
+                                          - AnyNotIn
+                                          - AllNotIn
+                                          - GreaterThanOrEquals
+                                          - GreaterThan
+                                          - LessThanOrEquals
+                                          - LessThan
+                                          - DurationGreaterThanOrEquals
+                                          - DurationGreaterThan
+                                          - DurationLessThanOrEquals
+                                          - DurationLessThan
+                                          type: string
+                                        value:
+                                          description: Value is the conditional value,
+                                            or set of values. The values can be fixed
+                                            set or can be variables declared using
+                                            JMESPath.
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                    type: array
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          type: array
+                        manifests:
+                          description: Manifest specifies conditions for manifest
+                            verification
+                          properties:
+                            annotationDomain:
+                              description: AnnotationDomain is custom domain of annotation
+                                for message and signature. Default is "cosign.sigstore.dev".
+                              type: string
+                            attestors:
+                              description: Attestors specified the required attestors
+                                (i.e. authorities)
+                              items:
+                                properties:
+                                  count:
+                                    description: Count specifies the required number
+                                      of entries that must match. If the count is
+                                      null, all entries must match (a logical AND).
+                                      If the count is 1, at least one entry must match
+                                      (a logical OR). If the count contains a value
+                                      N, then N must be less than or equal to the
+                                      size of entries, and at least N entries must
+                                      match.
+                                    minimum: 1
+                                    type: integer
+                                  entries:
+                                    description: Entries contains the available attestors.
+                                      An attestor can be a static key, attributes
+                                      for keyless verification, or a nested attestor
+                                      declaration.
+                                    items:
+                                      properties:
+                                        annotations:
+                                          additionalProperties:
+                                            type: string
+                                          description: Annotations are used for image
+                                            verification. Every specified key-value
+                                            pair must exist and match in the verified
+                                            payload. The payload may contain other
+                                            key-value pairs.
+                                          type: object
+                                        attestor:
+                                          description: Attestor is a nested AttestorSet
+                                            used to specify a more complex set of
+                                            match authorities
+                                          x-kubernetes-preserve-unknown-fields: true
+                                        certificates:
+                                          description: Certificates specifies one
+                                            or more certificates
+                                          properties:
+                                            cert:
+                                              description: Certificate is an optional
+                                                PEM encoded public certificate.
+                                              type: string
+                                            certChain:
+                                              description: CertificateChain is an
+                                                optional PEM encoded set of certificates
+                                                used to verify
+                                              type: string
+                                            rekor:
+                                              description: Rekor provides configuration
+                                                for the Rekor transparency log service.
+                                                If the value is nil, Rekor is not
+                                                checked. If an empty object is provided
+                                                the public instance of Rekor (https://rekor.sigstore.dev)
+                                                is used.
+                                              properties:
+                                                url:
+                                                  description: URL is the address
+                                                    of the transparency log. Defaults
+                                                    to the public log https://rekor.sigstore.dev.
+                                                  type: string
+                                              required:
+                                              - url
+                                              type: object
+                                          type: object
+                                        keyless:
+                                          description: Keyless is a set of attribute
+                                            used to verify a Sigstore keyless attestor.
+                                            See https://github.com/sigstore/cosign/blob/main/KEYLESS.md.
+                                          properties:
+                                            additionalExtensions:
+                                              additionalProperties:
+                                                type: string
+                                              description: AdditionalExtensions are
+                                                certificate-extensions used for keyless
+                                                signing.
+                                              type: object
+                                            issuer:
+                                              description: Issuer is the certificate
+                                                issuer used for keyless signing.
+                                              type: string
+                                            rekor:
+                                              description: Rekor provides configuration
+                                                for the Rekor transparency log service.
+                                                If the value is nil, Rekor is not
+                                                checked and a root certificate chain
+                                                is expected instead. If an empty object
+                                                is provided the public instance of
+                                                Rekor (https://rekor.sigstore.dev)
+                                                is used.
+                                              properties:
+                                                url:
+                                                  description: URL is the address
+                                                    of the transparency log. Defaults
+                                                    to the public log https://rekor.sigstore.dev.
+                                                  type: string
+                                              required:
+                                              - url
+                                              type: object
+                                            roots:
+                                              description: Roots is an optional set
+                                                of PEM encoded trusted root certificates.
+                                                If not provided, the system roots
+                                                are used.
+                                              type: string
+                                            subject:
+                                              description: Subject is the verified
+                                                identity used for keyless signing,
+                                                for example the email address
+                                              type: string
+                                          type: object
+                                        keys:
+                                          description: Keys specifies one or more
+                                            public keys
+                                          properties:
+                                            publicKeys:
+                                              description: Keys is a set of X.509
+                                                public keys used to verify image signatures.
+                                                The keys can be directly specified
+                                                or can be a variable reference to
+                                                a key specified in a ConfigMap (see
+                                                https://kyverno.io/docs/writing-policies/variables/).
+                                                When multiple keys are specified each
+                                                key is processed as a separate staticKey
+                                                entry (.attestors[*].entries.keys)
+                                                within the set of attestors and the
+                                                count is applied across the keys.
+                                              type: string
+                                            rekor:
+                                              description: Rekor provides configuration
+                                                for the Rekor transparency log service.
+                                                If the value is nil, Rekor is not
+                                                checked. If an empty object is provided
+                                                the public instance of Rekor (https://rekor.sigstore.dev)
+                                                is used.
+                                              properties:
+                                                url:
+                                                  description: URL is the address
+                                                    of the transparency log. Defaults
+                                                    to the public log https://rekor.sigstore.dev.
+                                                  type: string
+                                              required:
+                                              - url
+                                              type: object
+                                          type: object
+                                        repository:
+                                          description: Repository is an optional alternate
+                                            OCI repository to use for signatures and
+                                            attestations that match this rule. If
+                                            specified Repository will override other
+                                            OCI image repository locations for this
+                                            Attestor.
+                                          type: string
+                                      type: object
+                                    type: array
+                                type: object
+                              type: array
+                            dryRun:
+                              description: DryRun configuration
+                              properties:
+                                enable:
+                                  type: boolean
+                                namespace:
+                                  type: string
+                              type: object
+                            ignoreFields:
+                              description: Fields which will be ignored while comparing
+                                manifests.
+                              items:
+                                properties:
+                                  fields:
+                                    items:
+                                      type: string
+                                    type: array
+                                  objects:
+                                    items:
+                                      properties:
+                                        group:
+                                          type: string
+                                        kind:
+                                          type: string
+                                        name:
+                                          type: string
+                                        namespace:
+                                          type: string
+                                        version:
+                                          type: string
+                                      type: object
+                                    type: array
+                                type: object
+                              type: array
+                            repository:
+                              description: Repository is an optional alternate OCI
+                                repository to use for resource bundle reference. The
+                                repository can be overridden per Attestor or Attestation.
+                              type: string
+                          type: object
+                        message:
+                          description: Message specifies a custom message to be displayed
+                            on failure.
+                          type: string
+                        pattern:
+                          description: Pattern specifies an overlay-style pattern
+                            used to check resources.
+                          x-kubernetes-preserve-unknown-fields: true
+                        podSecurity:
+                          description: PodSecurity applies exemptions for Kubernetes
+                            Pod Security admission by specifying exclusions for Pod
+                            Security Standards controls.
+                          properties:
+                            exclude:
+                              description: Exclude specifies the Pod Security Standard
+                                controls to be excluded.
+                              items:
+                                description: PodSecurityStandard specifies the Pod
+                                  Security Standard controls to be excluded.
+                                properties:
+                                  controlName:
+                                    description: 'ControlName specifies the name of
+                                      the Pod Security Standard control. See: https://kubernetes.io/docs/concepts/security/pod-security-standards/'
+                                    enum:
+                                    - HostProcess
+                                    - Host Namespaces
+                                    - Privileged Containers
+                                    - Capabilities
+                                    - HostPath Volumes
+                                    - Host Ports
+                                    - AppArmor
+                                    - SELinux
+                                    - /proc Mount Type
+                                    - Seccomp
+                                    - Sysctls
+                                    - Volume Types
+                                    - Privilege Escalation
+                                    - Running as Non-root
+                                    - Running as Non-root user
+                                    type: string
+                                  images:
+                                    description: 'Images selects matching containers
+                                      and applies the container level PSS. Each image
+                                      is the image name consisting of the registry
+                                      address, repository, image, and tag. Empty list
+                                      matches no containers, PSS checks are applied
+                                      at the pod level only. Wildcards (''*'' and
+                                      ''?'') are allowed. See: https://kubernetes.io/docs/concepts/containers/images.'
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - controlName
+                                type: object
+                              type: array
+                            level:
+                              description: Level defines the Pod Security Standard
+                                level to be applied to workloads. Allowed values are
+                                privileged, baseline, and restricted.
+                              enum:
+                              - privileged
+                              - baseline
+                              - restricted
+                              type: string
+                            version:
+                              description: Version defines the Pod Security Standard
+                                versions that Kubernetes supports. Allowed values
+                                are v1.19, v1.20, v1.21, v1.22, v1.23, v1.24, v1.25,
+                                latest. Defaults to latest.
+                              enum:
+                              - v1.19
+                              - v1.20
+                              - v1.21
+                              - v1.22
+                              - v1.23
+                              - v1.24
+                              - v1.25
+                              - latest
+                              type: string
+                          type: object
+                      type: object
+                    verifyImages:
+                      description: VerifyImages is used to verify image signatures
+                        and mutate them to add a digest
+                      items:
+                        description: ImageVerification validates that images that
+                          match the specified pattern are signed with the supplied
+                          public key. Once the image is verified it is mutated to
+                          include the SHA digest retrieved during the registration.
+                        properties:
+                          attestations:
+                            description: Attestations are optional checks for signed
+                              in-toto Statements used to verify the image. See https://github.com/in-toto/attestation.
+                              Kyverno fetches signed attestations from the OCI registry
+                              and decodes them into a list of Statement declarations.
+                            items:
+                              description: Attestation are checks for signed in-toto
+                                Statements that are used to verify the image. See
+                                https://github.com/in-toto/attestation. Kyverno fetches
+                                signed attestations from the OCI registry and decodes
+                                them into a list of Statements.
+                              properties:
+                                conditions:
+                                  description: Conditions are used to verify attributes
+                                    within a Predicate. If no Conditions are specified
+                                    the attestation check is satisfied as long there
+                                    are predicates that match the predicate type.
+                                  items:
+                                    description: AnyAllConditions consists of conditions
+                                      wrapped denoting a logical criteria to be fulfilled.
+                                      AnyConditions get fulfilled when at least one
+                                      of its sub-conditions passes. AllConditions
+                                      get fulfilled only when all of its sub-conditions
+                                      pass.
+                                    properties:
+                                      all:
+                                        description: AllConditions enable variable-based
+                                          conditional rule execution. This is useful
+                                          for finer control of when an rule is applied.
+                                          A condition can reference object data using
+                                          JMESPath notation. Here, all of the conditions
+                                          need to pass
+                                        items:
+                                          description: Condition defines variable-based
+                                            conditional criteria for rule execution.
+                                          properties:
+                                            key:
+                                              description: Key is the context entry
+                                                (using JMESPath) for conditional rule
+                                                evaluation.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            operator:
+                                              description: 'Operator is the conditional
+                                                operation to perform. Valid operators
+                                                are: Equals, NotEquals, In, AnyIn,
+                                                AllIn, NotIn, AnyNotIn, AllNotIn,
+                                                GreaterThanOrEquals, GreaterThan,
+                                                LessThanOrEquals, LessThan, DurationGreaterThanOrEquals,
+                                                DurationGreaterThan, DurationLessThanOrEquals,
+                                                DurationLessThan'
+                                              enum:
+                                              - Equals
+                                              - NotEquals
+                                              - In
+                                              - AnyIn
+                                              - AllIn
+                                              - NotIn
+                                              - AnyNotIn
+                                              - AllNotIn
+                                              - GreaterThanOrEquals
+                                              - GreaterThan
+                                              - LessThanOrEquals
+                                              - LessThan
+                                              - DurationGreaterThanOrEquals
+                                              - DurationGreaterThan
+                                              - DurationLessThanOrEquals
+                                              - DurationLessThan
+                                              type: string
+                                            value:
+                                              description: Value is the conditional
+                                                value, or set of values. The values
+                                                can be fixed set or can be variables
+                                                declared using JMESPath.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                        type: array
+                                      any:
+                                        description: AnyConditions enable variable-based
+                                          conditional rule execution. This is useful
+                                          for finer control of when an rule is applied.
+                                          A condition can reference object data using
+                                          JMESPath notation. Here, at least one of
+                                          the conditions need to pass
+                                        items:
+                                          description: Condition defines variable-based
+                                            conditional criteria for rule execution.
+                                          properties:
+                                            key:
+                                              description: Key is the context entry
+                                                (using JMESPath) for conditional rule
+                                                evaluation.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            operator:
+                                              description: 'Operator is the conditional
+                                                operation to perform. Valid operators
+                                                are: Equals, NotEquals, In, AnyIn,
+                                                AllIn, NotIn, AnyNotIn, AllNotIn,
+                                                GreaterThanOrEquals, GreaterThan,
+                                                LessThanOrEquals, LessThan, DurationGreaterThanOrEquals,
+                                                DurationGreaterThan, DurationLessThanOrEquals,
+                                                DurationLessThan'
+                                              enum:
+                                              - Equals
+                                              - NotEquals
+                                              - In
+                                              - AnyIn
+                                              - AllIn
+                                              - NotIn
+                                              - AnyNotIn
+                                              - AllNotIn
+                                              - GreaterThanOrEquals
+                                              - GreaterThan
+                                              - LessThanOrEquals
+                                              - LessThan
+                                              - DurationGreaterThanOrEquals
+                                              - DurationGreaterThan
+                                              - DurationLessThanOrEquals
+                                              - DurationLessThan
+                                              type: string
+                                            value:
+                                              description: Value is the conditional
+                                                value, or set of values. The values
+                                                can be fixed set or can be variables
+                                                declared using JMESPath.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                        type: array
+                                    type: object
+                                  type: array
+                                predicateType:
+                                  description: PredicateType defines the type of Predicate
+                                    contained within the Statement.
+                                  type: string
+                              type: object
+                            type: array
+                          attestors:
+                            description: Attestors specified the required attestors
+                              (i.e. authorities)
+                            items:
+                              properties:
+                                count:
+                                  description: Count specifies the required number
+                                    of entries that must match. If the count is null,
+                                    all entries must match (a logical AND). If the
+                                    count is 1, at least one entry must match (a logical
+                                    OR). If the count contains a value N, then N must
+                                    be less than or equal to the size of entries,
+                                    and at least N entries must match.
+                                  minimum: 1
+                                  type: integer
+                                entries:
+                                  description: Entries contains the available attestors.
+                                    An attestor can be a static key, attributes for
+                                    keyless verification, or a nested attestor declaration.
+                                  items:
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations are used for image
+                                          verification. Every specified key-value
+                                          pair must exist and match in the verified
+                                          payload. The payload may contain other key-value
+                                          pairs.
+                                        type: object
+                                      attestor:
+                                        description: Attestor is a nested AttestorSet
+                                          used to specify a more complex set of match
+                                          authorities
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      certificates:
+                                        description: Certificates specifies one or
+                                          more certificates
+                                        properties:
+                                          cert:
+                                            description: Certificate is an optional
+                                              PEM encoded public certificate.
+                                            type: string
+                                          certChain:
+                                            description: CertificateChain is an optional
+                                              PEM encoded set of certificates used
+                                              to verify
+                                            type: string
+                                          rekor:
+                                            description: Rekor provides configuration
+                                              for the Rekor transparency log service.
+                                              If the value is nil, Rekor is not checked.
+                                              If an empty object is provided the public
+                                              instance of Rekor (https://rekor.sigstore.dev)
+                                              is used.
+                                            properties:
+                                              url:
+                                                description: URL is the address of
+                                                  the transparency log. Defaults to
+                                                  the public log https://rekor.sigstore.dev.
+                                                type: string
+                                            required:
+                                            - url
+                                            type: object
+                                        type: object
+                                      keyless:
+                                        description: Keyless is a set of attribute
+                                          used to verify a Sigstore keyless attestor.
+                                          See https://github.com/sigstore/cosign/blob/main/KEYLESS.md.
+                                        properties:
+                                          additionalExtensions:
+                                            additionalProperties:
+                                              type: string
+                                            description: AdditionalExtensions are
+                                              certificate-extensions used for keyless
+                                              signing.
+                                            type: object
+                                          issuer:
+                                            description: Issuer is the certificate
+                                              issuer used for keyless signing.
+                                            type: string
+                                          rekor:
+                                            description: Rekor provides configuration
+                                              for the Rekor transparency log service.
+                                              If the value is nil, Rekor is not checked
+                                              and a root certificate chain is expected
+                                              instead. If an empty object is provided
+                                              the public instance of Rekor (https://rekor.sigstore.dev)
+                                              is used.
+                                            properties:
+                                              url:
+                                                description: URL is the address of
+                                                  the transparency log. Defaults to
+                                                  the public log https://rekor.sigstore.dev.
+                                                type: string
+                                            required:
+                                            - url
+                                            type: object
+                                          roots:
+                                            description: Roots is an optional set
+                                              of PEM encoded trusted root certificates.
+                                              If not provided, the system roots are
+                                              used.
+                                            type: string
+                                          subject:
+                                            description: Subject is the verified identity
+                                              used for keyless signing, for example
+                                              the email address
+                                            type: string
+                                        type: object
+                                      keys:
+                                        description: Keys specifies one or more public
+                                          keys
+                                        properties:
+                                          publicKeys:
+                                            description: Keys is a set of X.509 public
+                                              keys used to verify image signatures.
+                                              The keys can be directly specified or
+                                              can be a variable reference to a key
+                                              specified in a ConfigMap (see https://kyverno.io/docs/writing-policies/variables/).
+                                              When multiple keys are specified each
+                                              key is processed as a separate staticKey
+                                              entry (.attestors[*].entries.keys) within
+                                              the set of attestors and the count is
+                                              applied across the keys.
+                                            type: string
+                                          rekor:
+                                            description: Rekor provides configuration
+                                              for the Rekor transparency log service.
+                                              If the value is nil, Rekor is not checked.
+                                              If an empty object is provided the public
+                                              instance of Rekor (https://rekor.sigstore.dev)
+                                              is used.
+                                            properties:
+                                              url:
+                                                description: URL is the address of
+                                                  the transparency log. Defaults to
+                                                  the public log https://rekor.sigstore.dev.
+                                                type: string
+                                            required:
+                                            - url
+                                            type: object
+                                        type: object
+                                      repository:
+                                        description: Repository is an optional alternate
+                                          OCI repository to use for signatures and
+                                          attestations that match this rule. If specified
+                                          Repository will override other OCI image
+                                          repository locations for this Attestor.
+                                        type: string
+                                    type: object
+                                  type: array
+                              type: object
+                            type: array
+                          imageReferences:
+                            description: 'ImageReferences is a list of matching image
+                              reference patterns. At least one pattern in the list
+                              must match the image for the rule to apply. Each image
+                              reference consists of a registry address (defaults to
+                              docker.io), repository, image, and tag (defaults to
+                              latest). Wildcards (''*'' and ''?'') are allowed. See:
+                              https://kubernetes.io/docs/concepts/containers/images.'
+                            items:
+                              type: string
+                            type: array
+                          mutateDigest:
+                            default: true
+                            description: MutateDigest enables replacement of image
+                              tags with digests. Defaults to true.
+                            type: boolean
+                          repository:
+                            description: Repository is an optional alternate OCI repository
+                              to use for image signatures and attestations that match
+                              this rule. If specified Repository will override the
+                              default OCI image repository configured for the installation.
+                              The repository can also be overridden per Attestor or
+                              Attestation.
+                            type: string
+                          required:
+                            default: true
+                            description: Required validates that images are verified
+                              i.e. have matched passed a signature or attestation
+                              check.
+                            type: boolean
+                          verifyDigest:
+                            default: true
+                            description: VerifyDigest validates that images have a
+                              digest.
+                            type: boolean
+                        type: object
+                      type: array
+                  type: object
+                type: array
+              schemaValidation:
+                description: SchemaValidation skips policy validation checks. Optional.
+                  The default value is set to "true", it must be set to "false" to
+                  disable the validation checks.
+                type: boolean
+              validationFailureAction:
+                default: audit
+                description: ValidationFailureAction defines if a validation policy
+                  rule violation should block the admission review request (enforce),
+                  or allow (audit) the admission review request and report an error
+                  in a policy report. Optional. Allowed values are audit or enforce.
+                  The default value is "audit".
+                enum:
+                - audit
+                - enforce
+                type: string
+              validationFailureActionOverrides:
+                description: ValidationFailureActionOverrides is a Cluster Policy
+                  attribute that specifies ValidationFailureAction namespace-wise.
+                  It overrides ValidationFailureAction for the specified namespaces.
+                items:
+                  properties:
+                    action:
+                      description: ValidationFailureAction defines the policy validation
+                        failure action
+                      enum:
+                      - audit
+                      - enforce
+                      type: string
+                    namespaces:
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                type: array
+              webhookTimeoutSeconds:
+                description: WebhookTimeoutSeconds specifies the maximum time in seconds
+                  allowed to apply this policy. After the configured time expires,
+                  the admission request may fail, or may simply ignore the policy
+                  results, based on the failure policy. The default timeout is 10s,
+                  the value must be between 1 and 30 seconds.
+                format: int32
+                type: integer
+            type: object
+          status:
+            description: Status contains policy runtime data.
+            properties:
+              autogen:
+                description: Autogen contains autogen status information
+                properties:
+                  rules:
+                    description: Rules is a list of Rule instances. It contains auto
+                      generated rules added for pod controllers
+                    items:
+                      description: Rule defines a validation, mutation, or generation
+                        control for matching resources. Each rules contains a match
+                        declaration to select resources, and an optional exclude declaration
+                        to specify which resources to exclude.
+                      properties:
+                        context:
+                          description: Context defines variables and data sources
+                            that can be used during rule execution.
+                          items:
+                            description: ContextEntry adds variables and data sources
+                              to a rule Context. Either a ConfigMap reference or a
+                              APILookup must be provided.
+                            properties:
+                              apiCall:
+                                description: APICall defines an HTTP request to the
+                                  Kubernetes API server. The JSON data retrieved is
+                                  stored in the context.
+                                properties:
+                                  jmesPath:
+                                    description: JMESPath is an optional JSON Match
+                                      Expression that can be used to transform the
+                                      JSON response returned from the API server.
+                                      For example a JMESPath of "items | length(@)"
+                                      applied to the API server response to the URLPath
+                                      "/apis/apps/v1/deployments" will return the
+                                      total count of deployments across all namespaces.
+                                    type: string
+                                  urlPath:
+                                    description: URLPath is the URL path to be used
+                                      in the HTTP GET request to the Kubernetes API
+                                      server (e.g. "/api/v1/namespaces" or  "/apis/apps/v1/deployments").
+                                      The format required is the same format used
+                                      by the `kubectl get --raw` command.
+                                    type: string
+                                required:
+                                - urlPath
+                                type: object
+                              configMap:
+                                description: ConfigMap is the ConfigMap reference.
+                                properties:
+                                  name:
+                                    description: Name is the ConfigMap name.
+                                    type: string
+                                  namespace:
+                                    description: Namespace is the ConfigMap namespace.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              imageRegistry:
+                                description: ImageRegistry defines requests to an
+                                  OCI/Docker V2 registry to fetch image details.
+                                properties:
+                                  jmesPath:
+                                    description: JMESPath is an optional JSON Match
+                                      Expression that can be used to transform the
+                                      ImageData struct returned as a result of processing
+                                      the image reference.
+                                    type: string
+                                  reference:
+                                    description: 'Reference is image reference to
+                                      a container image in the registry. Example:
+                                      ghcr.io/kyverno/kyverno:latest'
+                                    type: string
+                                required:
+                                - reference
+                                type: object
+                              name:
+                                description: Name is the variable name.
+                                type: string
+                              variable:
+                                description: Variable defines an arbitrary JMESPath
+                                  context variable that can be defined inline.
+                                properties:
+                                  default:
+                                    description: Default is an optional arbitrary
+                                      JSON object that the variable may take if the
+                                      JMESPath expression evaluates to nil
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  jmesPath:
+                                    description: JMESPath is an optional JMESPath
+                                      Expression that can be used to transform the
+                                      variable.
+                                    type: string
+                                  value:
+                                    description: Value is any arbitrary JSON object
+                                      representable in YAML or JSON form.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                            type: object
+                          type: array
+                        exclude:
+                          description: ExcludeResources defines when this policy rule
+                            should not be applied. The exclude criteria can include
+                            resource information (e.g. kind, name, namespace, labels)
+                            and admission review request information like the name
+                            or role.
+                          properties:
+                            all:
+                              description: All allows specifying resources which will
+                                be ANDed
+                              items:
+                                description: ResourceFilter allow users to "AND" or
+                                  "OR" between resources
+                                properties:
+                                  clusterRoles:
+                                    description: ClusterRoles is the list of cluster-wide
+                                      role names for the user.
+                                    items:
+                                      type: string
+                                    type: array
+                                  resources:
+                                    description: ResourceDescription contains information
+                                      about the resource being created or modified.
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations is a  map of annotations
+                                          (key-value pairs of type string). Annotation
+                                          keys and values support the wildcard characters
+                                          "*" (matches zero or many characters) and
+                                          "?" (matches at least one character).
+                                        type: object
+                                      kinds:
+                                        description: Kinds is a list of resource kinds.
+                                        items:
+                                          type: string
+                                        type: array
+                                      name:
+                                        description: 'Name is the name of the resource.
+                                          The name supports wildcard characters "*"
+                                          (matches zero or many characters) and "?"
+                                          (at least one character). NOTE: "Name" is
+                                          being deprecated in favor of "Names".'
+                                        type: string
+                                      names:
+                                        description: Names are the names of the resources.
+                                          Each name supports wildcard characters "*"
+                                          (matches zero or many characters) and "?"
+                                          (at least one character).
+                                        items:
+                                          type: string
+                                        type: array
+                                      namespaceSelector:
+                                        description: 'NamespaceSelector is a label
+                                          selector for the resource namespace. Label
+                                          keys and values in `matchLabels` support
+                                          the wildcard characters `*` (matches zero
+                                          or many characters) and `?` (matches one
+                                          character).Wildcards allows writing label
+                                          selectors like ["storage.k8s.io/*": "*"].
+                                          Note that using ["*" : "*"] matches any
+                                          key and value but does not match an empty
+                                          label set.'
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      namespaces:
+                                        description: Namespaces is a list of namespaces
+                                          names. Each name supports wildcard characters
+                                          "*" (matches zero or many characters) and
+                                          "?" (at least one character).
+                                        items:
+                                          type: string
+                                        type: array
+                                      selector:
+                                        description: 'Selector is a label selector.
+                                          Label keys and values in `matchLabels` support
+                                          the wildcard characters `*` (matches zero
+                                          or many characters) and `?` (matches one
+                                          character). Wildcards allows writing label
+                                          selectors like ["storage.k8s.io/*": "*"].
+                                          Note that using ["*" : "*"] matches any
+                                          key and value but does not match an empty
+                                          label set.'
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  roles:
+                                    description: Roles is the list of namespaced role
+                                      names for the user.
+                                    items:
+                                      type: string
+                                    type: array
+                                  subjects:
+                                    description: Subjects is the list of subject names
+                                      like users, user groups, and service accounts.
+                                    items:
+                                      description: Subject contains a reference to
+                                        the object or user identities a role binding
+                                        applies to.  This can either hold a direct
+                                        API object reference, or a value for non-objects
+                                        such as user and group names.
+                                      properties:
+                                        apiGroup:
+                                          description: APIGroup holds the API group
+                                            of the referenced subject. Defaults to
+                                            "" for ServiceAccount subjects. Defaults
+                                            to "rbac.authorization.k8s.io" for User
+                                            and Group subjects.
+                                          type: string
+                                        kind:
+                                          description: Kind of object being referenced.
+                                            Values defined by this API group are "User",
+                                            "Group", and "ServiceAccount". If the
+                                            Authorizer does not recognized the kind
+                                            value, the Authorizer should report an
+                                            error.
+                                          type: string
+                                        name:
+                                          description: Name of the object being referenced.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the referenced
+                                            object.  If the object kind is non-namespace,
+                                            such as "User" or "Group", and this value
+                                            is not empty the Authorizer should report
+                                            an error.
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    type: array
+                                type: object
+                              type: array
+                            any:
+                              description: Any allows specifying resources which will
+                                be ORed
+                              items:
+                                description: ResourceFilter allow users to "AND" or
+                                  "OR" between resources
+                                properties:
+                                  clusterRoles:
+                                    description: ClusterRoles is the list of cluster-wide
+                                      role names for the user.
+                                    items:
+                                      type: string
+                                    type: array
+                                  resources:
+                                    description: ResourceDescription contains information
+                                      about the resource being created or modified.
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations is a  map of annotations
+                                          (key-value pairs of type string). Annotation
+                                          keys and values support the wildcard characters
+                                          "*" (matches zero or many characters) and
+                                          "?" (matches at least one character).
+                                        type: object
+                                      kinds:
+                                        description: Kinds is a list of resource kinds.
+                                        items:
+                                          type: string
+                                        type: array
+                                      name:
+                                        description: 'Name is the name of the resource.
+                                          The name supports wildcard characters "*"
+                                          (matches zero or many characters) and "?"
+                                          (at least one character). NOTE: "Name" is
+                                          being deprecated in favor of "Names".'
+                                        type: string
+                                      names:
+                                        description: Names are the names of the resources.
+                                          Each name supports wildcard characters "*"
+                                          (matches zero or many characters) and "?"
+                                          (at least one character).
+                                        items:
+                                          type: string
+                                        type: array
+                                      namespaceSelector:
+                                        description: 'NamespaceSelector is a label
+                                          selector for the resource namespace. Label
+                                          keys and values in `matchLabels` support
+                                          the wildcard characters `*` (matches zero
+                                          or many characters) and `?` (matches one
+                                          character).Wildcards allows writing label
+                                          selectors like ["storage.k8s.io/*": "*"].
+                                          Note that using ["*" : "*"] matches any
+                                          key and value but does not match an empty
+                                          label set.'
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      namespaces:
+                                        description: Namespaces is a list of namespaces
+                                          names. Each name supports wildcard characters
+                                          "*" (matches zero or many characters) and
+                                          "?" (at least one character).
+                                        items:
+                                          type: string
+                                        type: array
+                                      selector:
+                                        description: 'Selector is a label selector.
+                                          Label keys and values in `matchLabels` support
+                                          the wildcard characters `*` (matches zero
+                                          or many characters) and `?` (matches one
+                                          character). Wildcards allows writing label
+                                          selectors like ["storage.k8s.io/*": "*"].
+                                          Note that using ["*" : "*"] matches any
+                                          key and value but does not match an empty
+                                          label set.'
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  roles:
+                                    description: Roles is the list of namespaced role
+                                      names for the user.
+                                    items:
+                                      type: string
+                                    type: array
+                                  subjects:
+                                    description: Subjects is the list of subject names
+                                      like users, user groups, and service accounts.
+                                    items:
+                                      description: Subject contains a reference to
+                                        the object or user identities a role binding
+                                        applies to.  This can either hold a direct
+                                        API object reference, or a value for non-objects
+                                        such as user and group names.
+                                      properties:
+                                        apiGroup:
+                                          description: APIGroup holds the API group
+                                            of the referenced subject. Defaults to
+                                            "" for ServiceAccount subjects. Defaults
+                                            to "rbac.authorization.k8s.io" for User
+                                            and Group subjects.
+                                          type: string
+                                        kind:
+                                          description: Kind of object being referenced.
+                                            Values defined by this API group are "User",
+                                            "Group", and "ServiceAccount". If the
+                                            Authorizer does not recognized the kind
+                                            value, the Authorizer should report an
+                                            error.
+                                          type: string
+                                        name:
+                                          description: Name of the object being referenced.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the referenced
+                                            object.  If the object kind is non-namespace,
+                                            such as "User" or "Group", and this value
+                                            is not empty the Authorizer should report
+                                            an error.
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    type: array
+                                type: object
+                              type: array
+                            clusterRoles:
+                              description: ClusterRoles is the list of cluster-wide
+                                role names for the user.
+                              items:
+                                type: string
+                              type: array
+                            resources:
+                              description: ResourceDescription contains information
+                                about the resource being created or modified. Requires
+                                at least one tag to be specified when under MatchResources.
+                                Specifying ResourceDescription directly under match
+                                is being deprecated. Please specify under "any" or
+                                "all" instead.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  description: Annotations is a  map of annotations
+                                    (key-value pairs of type string). Annotation keys
+                                    and values support the wildcard characters "*"
+                                    (matches zero or many characters) and "?" (matches
+                                    at least one character).
+                                  type: object
+                                kinds:
+                                  description: Kinds is a list of resource kinds.
+                                  items:
+                                    type: string
+                                  type: array
+                                name:
+                                  description: 'Name is the name of the resource.
+                                    The name supports wildcard characters "*" (matches
+                                    zero or many characters) and "?" (at least one
+                                    character). NOTE: "Name" is being deprecated in
+                                    favor of "Names".'
+                                  type: string
+                                names:
+                                  description: Names are the names of the resources.
+                                    Each name supports wildcard characters "*" (matches
+                                    zero or many characters) and "?" (at least one
+                                    character).
+                                  items:
+                                    type: string
+                                  type: array
+                                namespaceSelector:
+                                  description: 'NamespaceSelector is a label selector
+                                    for the resource namespace. Label keys and values
+                                    in `matchLabels` support the wildcard characters
+                                    `*` (matches zero or many characters) and `?`
+                                    (matches one character).Wildcards allows writing
+                                    label selectors like ["storage.k8s.io/*": "*"].
+                                    Note that using ["*" : "*"] matches any key and
+                                    value but does not match an empty label set.'
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: Namespaces is a list of namespaces
+                                    names. Each name supports wildcard characters
+                                    "*" (matches zero or many characters) and "?"
+                                    (at least one character).
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: 'Selector is a label selector. Label
+                                    keys and values in `matchLabels` support the wildcard
+                                    characters `*` (matches zero or many characters)
+                                    and `?` (matches one character). Wildcards allows
+                                    writing label selectors like ["storage.k8s.io/*":
+                                    "*"]. Note that using ["*" : "*"] matches any
+                                    key and value but does not match an empty label
+                                    set.'
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            roles:
+                              description: Roles is the list of namespaced role names
+                                for the user.
+                              items:
+                                type: string
+                              type: array
+                            subjects:
+                              description: Subjects is the list of subject names like
+                                users, user groups, and service accounts.
+                              items:
+                                description: Subject contains a reference to the object
+                                  or user identities a role binding applies to.  This
+                                  can either hold a direct API object reference, or
+                                  a value for non-objects such as user and group names.
+                                properties:
+                                  apiGroup:
+                                    description: APIGroup holds the API group of the
+                                      referenced subject. Defaults to "" for ServiceAccount
+                                      subjects. Defaults to "rbac.authorization.k8s.io"
+                                      for User and Group subjects.
+                                    type: string
+                                  kind:
+                                    description: Kind of object being referenced.
+                                      Values defined by this API group are "User",
+                                      "Group", and "ServiceAccount". If the Authorizer
+                                      does not recognized the kind value, the Authorizer
+                                      should report an error.
+                                    type: string
+                                  name:
+                                    description: Name of the object being referenced.
+                                    type: string
+                                  namespace:
+                                    description: Namespace of the referenced object.  If
+                                      the object kind is non-namespace, such as "User"
+                                      or "Group", and this value is not empty the
+                                      Authorizer should report an error.
+                                    type: string
+                                required:
+                                - kind
+                                - name
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              type: array
+                          type: object
+                        generate:
+                          description: Generation is used to create new resources.
+                          properties:
+                            apiVersion:
+                              description: APIVersion specifies resource apiVersion.
+                              type: string
+                            clone:
+                              description: Clone specifies the source resource used
+                                to populate each generated resource. At most one of
+                                Data or Clone can be specified. If neither are provided,
+                                the generated resource will be created with default
+                                data only.
+                              properties:
+                                name:
+                                  description: Name specifies name of the resource.
+                                  type: string
+                                namespace:
+                                  description: Namespace specifies source resource
+                                    namespace.
+                                  type: string
+                              type: object
+                            cloneList:
+                              description: CloneList specifies the list of source
+                                resource used to populate each generated resource.
+                              properties:
+                                kinds:
+                                  description: Kinds is a list of resource kinds.
+                                  items:
+                                    type: string
+                                  type: array
+                                namespace:
+                                  description: Namespace specifies source resource
+                                    namespace.
+                                  type: string
+                                selector:
+                                  description: Selector is a label selector. Label
+                                    keys and values in `matchLabels`. wildcard characters
+                                    are not supported.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            data:
+                              description: Data provides the resource declaration
+                                used to populate each generated resource. At most
+                                one of Data or Clone must be specified. If neither
+                                are provided, the generated resource will be created
+                                with default data only.
+                              x-kubernetes-preserve-unknown-fields: true
+                            kind:
+                              description: Kind specifies resource kind.
+                              type: string
+                            name:
+                              description: Name specifies the resource name.
+                              type: string
+                            namespace:
+                              description: Namespace specifies resource namespace.
+                              type: string
+                            synchronize:
+                              description: Synchronize controls if generated resources
+                                should be kept in-sync with their source resource.
+                                If Synchronize is set to "true" changes to generated
+                                resources will be overwritten with resource data from
+                                Data or the resource specified in the Clone declaration.
+                                Optional. Defaults to "false" if not specified.
+                              type: boolean
+                          type: object
+                        imageExtractors:
+                          additionalProperties:
+                            items:
+                              properties:
+                                key:
+                                  description: Key is an optional name of the field
+                                    within 'path' that will be used to uniquely identify
+                                    an image. Note - this field MUST be unique.
+                                  type: string
+                                name:
+                                  description: Name is the entry the image will be
+                                    available under 'images.<name>' in the context.
+                                    If this field is not defined, image entries will
+                                    appear under 'images.custom'.
+                                  type: string
+                                path:
+                                  description: Path is the path to the object containing
+                                    the image field in a custom resource. It should
+                                    be slash-separated. Each slash-separated key must
+                                    be a valid YAML key or a wildcard '*'. Wildcard
+                                    keys are expanded in case of arrays or objects.
+                                  type: string
+                                value:
+                                  description: Value is an optional name of the field
+                                    within 'path' that points to the image URI. This
+                                    is useful when a custom 'key' is also defined.
+                                  type: string
+                              required:
+                              - path
+                              type: object
+                            type: array
+                          description: ImageExtractors defines a mapping from kinds
+                            to ImageExtractorConfigs. This config is only valid for
+                            verifyImages rules.
+                          type: object
+                        match:
+                          description: MatchResources defines when this policy rule
+                            should be applied. The match criteria can include resource
+                            information (e.g. kind, name, namespace, labels) and admission
+                            review request information like the user name or role.
+                            At least one kind is required.
+                          properties:
+                            all:
+                              description: All allows specifying resources which will
+                                be ANDed
+                              items:
+                                description: ResourceFilter allow users to "AND" or
+                                  "OR" between resources
+                                properties:
+                                  clusterRoles:
+                                    description: ClusterRoles is the list of cluster-wide
+                                      role names for the user.
+                                    items:
+                                      type: string
+                                    type: array
+                                  resources:
+                                    description: ResourceDescription contains information
+                                      about the resource being created or modified.
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations is a  map of annotations
+                                          (key-value pairs of type string). Annotation
+                                          keys and values support the wildcard characters
+                                          "*" (matches zero or many characters) and
+                                          "?" (matches at least one character).
+                                        type: object
+                                      kinds:
+                                        description: Kinds is a list of resource kinds.
+                                        items:
+                                          type: string
+                                        type: array
+                                      name:
+                                        description: 'Name is the name of the resource.
+                                          The name supports wildcard characters "*"
+                                          (matches zero or many characters) and "?"
+                                          (at least one character). NOTE: "Name" is
+                                          being deprecated in favor of "Names".'
+                                        type: string
+                                      names:
+                                        description: Names are the names of the resources.
+                                          Each name supports wildcard characters "*"
+                                          (matches zero or many characters) and "?"
+                                          (at least one character).
+                                        items:
+                                          type: string
+                                        type: array
+                                      namespaceSelector:
+                                        description: 'NamespaceSelector is a label
+                                          selector for the resource namespace. Label
+                                          keys and values in `matchLabels` support
+                                          the wildcard characters `*` (matches zero
+                                          or many characters) and `?` (matches one
+                                          character).Wildcards allows writing label
+                                          selectors like ["storage.k8s.io/*": "*"].
+                                          Note that using ["*" : "*"] matches any
+                                          key and value but does not match an empty
+                                          label set.'
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      namespaces:
+                                        description: Namespaces is a list of namespaces
+                                          names. Each name supports wildcard characters
+                                          "*" (matches zero or many characters) and
+                                          "?" (at least one character).
+                                        items:
+                                          type: string
+                                        type: array
+                                      selector:
+                                        description: 'Selector is a label selector.
+                                          Label keys and values in `matchLabels` support
+                                          the wildcard characters `*` (matches zero
+                                          or many characters) and `?` (matches one
+                                          character). Wildcards allows writing label
+                                          selectors like ["storage.k8s.io/*": "*"].
+                                          Note that using ["*" : "*"] matches any
+                                          key and value but does not match an empty
+                                          label set.'
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  roles:
+                                    description: Roles is the list of namespaced role
+                                      names for the user.
+                                    items:
+                                      type: string
+                                    type: array
+                                  subjects:
+                                    description: Subjects is the list of subject names
+                                      like users, user groups, and service accounts.
+                                    items:
+                                      description: Subject contains a reference to
+                                        the object or user identities a role binding
+                                        applies to.  This can either hold a direct
+                                        API object reference, or a value for non-objects
+                                        such as user and group names.
+                                      properties:
+                                        apiGroup:
+                                          description: APIGroup holds the API group
+                                            of the referenced subject. Defaults to
+                                            "" for ServiceAccount subjects. Defaults
+                                            to "rbac.authorization.k8s.io" for User
+                                            and Group subjects.
+                                          type: string
+                                        kind:
+                                          description: Kind of object being referenced.
+                                            Values defined by this API group are "User",
+                                            "Group", and "ServiceAccount". If the
+                                            Authorizer does not recognized the kind
+                                            value, the Authorizer should report an
+                                            error.
+                                          type: string
+                                        name:
+                                          description: Name of the object being referenced.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the referenced
+                                            object.  If the object kind is non-namespace,
+                                            such as "User" or "Group", and this value
+                                            is not empty the Authorizer should report
+                                            an error.
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    type: array
+                                type: object
+                              type: array
+                            any:
+                              description: Any allows specifying resources which will
+                                be ORed
+                              items:
+                                description: ResourceFilter allow users to "AND" or
+                                  "OR" between resources
+                                properties:
+                                  clusterRoles:
+                                    description: ClusterRoles is the list of cluster-wide
+                                      role names for the user.
+                                    items:
+                                      type: string
+                                    type: array
+                                  resources:
+                                    description: ResourceDescription contains information
+                                      about the resource being created or modified.
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations is a  map of annotations
+                                          (key-value pairs of type string). Annotation
+                                          keys and values support the wildcard characters
+                                          "*" (matches zero or many characters) and
+                                          "?" (matches at least one character).
+                                        type: object
+                                      kinds:
+                                        description: Kinds is a list of resource kinds.
+                                        items:
+                                          type: string
+                                        type: array
+                                      name:
+                                        description: 'Name is the name of the resource.
+                                          The name supports wildcard characters "*"
+                                          (matches zero or many characters) and "?"
+                                          (at least one character). NOTE: "Name" is
+                                          being deprecated in favor of "Names".'
+                                        type: string
+                                      names:
+                                        description: Names are the names of the resources.
+                                          Each name supports wildcard characters "*"
+                                          (matches zero or many characters) and "?"
+                                          (at least one character).
+                                        items:
+                                          type: string
+                                        type: array
+                                      namespaceSelector:
+                                        description: 'NamespaceSelector is a label
+                                          selector for the resource namespace. Label
+                                          keys and values in `matchLabels` support
+                                          the wildcard characters `*` (matches zero
+                                          or many characters) and `?` (matches one
+                                          character).Wildcards allows writing label
+                                          selectors like ["storage.k8s.io/*": "*"].
+                                          Note that using ["*" : "*"] matches any
+                                          key and value but does not match an empty
+                                          label set.'
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      namespaces:
+                                        description: Namespaces is a list of namespaces
+                                          names. Each name supports wildcard characters
+                                          "*" (matches zero or many characters) and
+                                          "?" (at least one character).
+                                        items:
+                                          type: string
+                                        type: array
+                                      selector:
+                                        description: 'Selector is a label selector.
+                                          Label keys and values in `matchLabels` support
+                                          the wildcard characters `*` (matches zero
+                                          or many characters) and `?` (matches one
+                                          character). Wildcards allows writing label
+                                          selectors like ["storage.k8s.io/*": "*"].
+                                          Note that using ["*" : "*"] matches any
+                                          key and value but does not match an empty
+                                          label set.'
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  roles:
+                                    description: Roles is the list of namespaced role
+                                      names for the user.
+                                    items:
+                                      type: string
+                                    type: array
+                                  subjects:
+                                    description: Subjects is the list of subject names
+                                      like users, user groups, and service accounts.
+                                    items:
+                                      description: Subject contains a reference to
+                                        the object or user identities a role binding
+                                        applies to.  This can either hold a direct
+                                        API object reference, or a value for non-objects
+                                        such as user and group names.
+                                      properties:
+                                        apiGroup:
+                                          description: APIGroup holds the API group
+                                            of the referenced subject. Defaults to
+                                            "" for ServiceAccount subjects. Defaults
+                                            to "rbac.authorization.k8s.io" for User
+                                            and Group subjects.
+                                          type: string
+                                        kind:
+                                          description: Kind of object being referenced.
+                                            Values defined by this API group are "User",
+                                            "Group", and "ServiceAccount". If the
+                                            Authorizer does not recognized the kind
+                                            value, the Authorizer should report an
+                                            error.
+                                          type: string
+                                        name:
+                                          description: Name of the object being referenced.
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the referenced
+                                            object.  If the object kind is non-namespace,
+                                            such as "User" or "Group", and this value
+                                            is not empty the Authorizer should report
+                                            an error.
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    type: array
+                                type: object
+                              type: array
+                            clusterRoles:
+                              description: ClusterRoles is the list of cluster-wide
+                                role names for the user.
+                              items:
+                                type: string
+                              type: array
+                            resources:
+                              description: ResourceDescription contains information
+                                about the resource being created or modified. Requires
+                                at least one tag to be specified when under MatchResources.
+                                Specifying ResourceDescription directly under match
+                                is being deprecated. Please specify under "any" or
+                                "all" instead.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  description: Annotations is a  map of annotations
+                                    (key-value pairs of type string). Annotation keys
+                                    and values support the wildcard characters "*"
+                                    (matches zero or many characters) and "?" (matches
+                                    at least one character).
+                                  type: object
+                                kinds:
+                                  description: Kinds is a list of resource kinds.
+                                  items:
+                                    type: string
+                                  type: array
+                                name:
+                                  description: 'Name is the name of the resource.
+                                    The name supports wildcard characters "*" (matches
+                                    zero or many characters) and "?" (at least one
+                                    character). NOTE: "Name" is being deprecated in
+                                    favor of "Names".'
+                                  type: string
+                                names:
+                                  description: Names are the names of the resources.
+                                    Each name supports wildcard characters "*" (matches
+                                    zero or many characters) and "?" (at least one
+                                    character).
+                                  items:
+                                    type: string
+                                  type: array
+                                namespaceSelector:
+                                  description: 'NamespaceSelector is a label selector
+                                    for the resource namespace. Label keys and values
+                                    in `matchLabels` support the wildcard characters
+                                    `*` (matches zero or many characters) and `?`
+                                    (matches one character).Wildcards allows writing
+                                    label selectors like ["storage.k8s.io/*": "*"].
+                                    Note that using ["*" : "*"] matches any key and
+                                    value but does not match an empty label set.'
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: Namespaces is a list of namespaces
+                                    names. Each name supports wildcard characters
+                                    "*" (matches zero or many characters) and "?"
+                                    (at least one character).
+                                  items:
+                                    type: string
+                                  type: array
+                                selector:
+                                  description: 'Selector is a label selector. Label
+                                    keys and values in `matchLabels` support the wildcard
+                                    characters `*` (matches zero or many characters)
+                                    and `?` (matches one character). Wildcards allows
+                                    writing label selectors like ["storage.k8s.io/*":
+                                    "*"]. Note that using ["*" : "*"] matches any
+                                    key and value but does not match an empty label
+                                    set.'
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            roles:
+                              description: Roles is the list of namespaced role names
+                                for the user.
+                              items:
+                                type: string
+                              type: array
+                            subjects:
+                              description: Subjects is the list of subject names like
+                                users, user groups, and service accounts.
+                              items:
+                                description: Subject contains a reference to the object
+                                  or user identities a role binding applies to.  This
+                                  can either hold a direct API object reference, or
+                                  a value for non-objects such as user and group names.
+                                properties:
+                                  apiGroup:
+                                    description: APIGroup holds the API group of the
+                                      referenced subject. Defaults to "" for ServiceAccount
+                                      subjects. Defaults to "rbac.authorization.k8s.io"
+                                      for User and Group subjects.
+                                    type: string
+                                  kind:
+                                    description: Kind of object being referenced.
+                                      Values defined by this API group are "User",
+                                      "Group", and "ServiceAccount". If the Authorizer
+                                      does not recognized the kind value, the Authorizer
+                                      should report an error.
+                                    type: string
+                                  name:
+                                    description: Name of the object being referenced.
+                                    type: string
+                                  namespace:
+                                    description: Namespace of the referenced object.  If
+                                      the object kind is non-namespace, such as "User"
+                                      or "Group", and this value is not empty the
+                                      Authorizer should report an error.
+                                    type: string
+                                required:
+                                - kind
+                                - name
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              type: array
+                          type: object
+                        mutate:
+                          description: Mutation is used to modify matching resources.
+                          properties:
+                            foreach:
+                              description: ForEach applies mutation rules to a list
+                                of sub-elements by creating a context for each entry
+                                in the list and looping over it to apply the specified
+                                logic.
+                              items:
+                                description: ForEach applies mutation rules to a list
+                                  of sub-elements by creating a context for each entry
+                                  in the list and looping over it to apply the specified
+                                  logic.
+                                properties:
+                                  context:
+                                    description: Context defines variables and data
+                                      sources that can be used during rule execution.
+                                    items:
+                                      description: ContextEntry adds variables and
+                                        data sources to a rule Context. Either a ConfigMap
+                                        reference or a APILookup must be provided.
+                                      properties:
+                                        apiCall:
+                                          description: APICall defines an HTTP request
+                                            to the Kubernetes API server. The JSON
+                                            data retrieved is stored in the context.
+                                          properties:
+                                            jmesPath:
+                                              description: JMESPath is an optional
+                                                JSON Match Expression that can be
+                                                used to transform the JSON response
+                                                returned from the API server. For
+                                                example a JMESPath of "items | length(@)"
+                                                applied to the API server response
+                                                to the URLPath "/apis/apps/v1/deployments"
+                                                will return the total count of deployments
+                                                across all namespaces.
+                                              type: string
+                                            urlPath:
+                                              description: URLPath is the URL path
+                                                to be used in the HTTP GET request
+                                                to the Kubernetes API server (e.g.
+                                                "/api/v1/namespaces" or  "/apis/apps/v1/deployments").
+                                                The format required is the same format
+                                                used by the `kubectl get --raw` command.
+                                              type: string
+                                          required:
+                                          - urlPath
+                                          type: object
+                                        configMap:
+                                          description: ConfigMap is the ConfigMap
+                                            reference.
+                                          properties:
+                                            name:
+                                              description: Name is the ConfigMap name.
+                                              type: string
+                                            namespace:
+                                              description: Namespace is the ConfigMap
+                                                namespace.
+                                              type: string
+                                          required:
+                                          - name
+                                          type: object
+                                        imageRegistry:
+                                          description: ImageRegistry defines requests
+                                            to an OCI/Docker V2 registry to fetch
+                                            image details.
+                                          properties:
+                                            jmesPath:
+                                              description: JMESPath is an optional
+                                                JSON Match Expression that can be
+                                                used to transform the ImageData struct
+                                                returned as a result of processing
+                                                the image reference.
+                                              type: string
+                                            reference:
+                                              description: 'Reference is image reference
+                                                to a container image in the registry.
+                                                Example: ghcr.io/kyverno/kyverno:latest'
+                                              type: string
+                                          required:
+                                          - reference
+                                          type: object
+                                        name:
+                                          description: Name is the variable name.
+                                          type: string
+                                        variable:
+                                          description: Variable defines an arbitrary
+                                            JMESPath context variable that can be
+                                            defined inline.
+                                          properties:
+                                            default:
+                                              description: Default is an optional
+                                                arbitrary JSON object that the variable
+                                                may take if the JMESPath expression
+                                                evaluates to nil
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            jmesPath:
+                                              description: JMESPath is an optional
+                                                JMESPath Expression that can be used
+                                                to transform the variable.
+                                              type: string
+                                            value:
+                                              description: Value is any arbitrary
+                                                JSON object representable in YAML
+                                                or JSON form.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                      type: object
+                                    type: array
+                                  list:
+                                    description: List specifies a JMESPath expression
+                                      that results in one or more elements to which
+                                      the validation logic is applied.
+                                    type: string
+                                  patchStrategicMerge:
+                                    description: PatchStrategicMerge is a strategic
+                                      merge patch used to modify resources. See https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/
+                                      and https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  patchesJson6902:
+                                    description: PatchesJSON6902 is a list of RFC
+                                      6902 JSON Patch declarations used to modify
+                                      resources. See https://tools.ietf.org/html/rfc6902
+                                      and https://kubectl.docs.kubernetes.io/references/kustomize/patchesjson6902/.
+                                    type: string
+                                  preconditions:
+                                    description: 'AnyAllConditions are used to determine
+                                      if a policy rule should be applied by evaluating
+                                      a set of conditions. The declaration can contain
+                                      nested `any` or `all` statements. See: https://kyverno.io/docs/writing-policies/preconditions/'
+                                    properties:
+                                      all:
+                                        description: AllConditions enable variable-based
+                                          conditional rule execution. This is useful
+                                          for finer control of when an rule is applied.
+                                          A condition can reference object data using
+                                          JMESPath notation. Here, all of the conditions
+                                          need to pass
+                                        items:
+                                          description: Condition defines variable-based
+                                            conditional criteria for rule execution.
+                                          properties:
+                                            key:
+                                              description: Key is the context entry
+                                                (using JMESPath) for conditional rule
+                                                evaluation.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            operator:
+                                              description: 'Operator is the conditional
+                                                operation to perform. Valid operators
+                                                are: Equals, NotEquals, In, AnyIn,
+                                                AllIn, NotIn, AnyNotIn, AllNotIn,
+                                                GreaterThanOrEquals, GreaterThan,
+                                                LessThanOrEquals, LessThan, DurationGreaterThanOrEquals,
+                                                DurationGreaterThan, DurationLessThanOrEquals,
+                                                DurationLessThan'
+                                              enum:
+                                              - Equals
+                                              - NotEquals
+                                              - In
+                                              - AnyIn
+                                              - AllIn
+                                              - NotIn
+                                              - AnyNotIn
+                                              - AllNotIn
+                                              - GreaterThanOrEquals
+                                              - GreaterThan
+                                              - LessThanOrEquals
+                                              - LessThan
+                                              - DurationGreaterThanOrEquals
+                                              - DurationGreaterThan
+                                              - DurationLessThanOrEquals
+                                              - DurationLessThan
+                                              type: string
+                                            value:
+                                              description: Value is the conditional
+                                                value, or set of values. The values
+                                                can be fixed set or can be variables
+                                                declared using JMESPath.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                        type: array
+                                      any:
+                                        description: AnyConditions enable variable-based
+                                          conditional rule execution. This is useful
+                                          for finer control of when an rule is applied.
+                                          A condition can reference object data using
+                                          JMESPath notation. Here, at least one of
+                                          the conditions need to pass
+                                        items:
+                                          description: Condition defines variable-based
+                                            conditional criteria for rule execution.
+                                          properties:
+                                            key:
+                                              description: Key is the context entry
+                                                (using JMESPath) for conditional rule
+                                                evaluation.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            operator:
+                                              description: 'Operator is the conditional
+                                                operation to perform. Valid operators
+                                                are: Equals, NotEquals, In, AnyIn,
+                                                AllIn, NotIn, AnyNotIn, AllNotIn,
+                                                GreaterThanOrEquals, GreaterThan,
+                                                LessThanOrEquals, LessThan, DurationGreaterThanOrEquals,
+                                                DurationGreaterThan, DurationLessThanOrEquals,
+                                                DurationLessThan'
+                                              enum:
+                                              - Equals
+                                              - NotEquals
+                                              - In
+                                              - AnyIn
+                                              - AllIn
+                                              - NotIn
+                                              - AnyNotIn
+                                              - AllNotIn
+                                              - GreaterThanOrEquals
+                                              - GreaterThan
+                                              - LessThanOrEquals
+                                              - LessThan
+                                              - DurationGreaterThanOrEquals
+                                              - DurationGreaterThan
+                                              - DurationLessThanOrEquals
+                                              - DurationLessThan
+                                              type: string
+                                            value:
+                                              description: Value is the conditional
+                                                value, or set of values. The values
+                                                can be fixed set or can be variables
+                                                declared using JMESPath.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                        type: array
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              type: array
+                            patchStrategicMerge:
+                              description: PatchStrategicMerge is a strategic merge
+                                patch used to modify resources. See https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/
+                                and https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.
+                              x-kubernetes-preserve-unknown-fields: true
+                            patchesJson6902:
+                              description: PatchesJSON6902 is a list of RFC 6902 JSON
+                                Patch declarations used to modify resources. See https://tools.ietf.org/html/rfc6902
+                                and https://kubectl.docs.kubernetes.io/references/kustomize/patchesjson6902/.
+                              type: string
+                            targets:
+                              description: Targets defines the target resources to
+                                be mutated.
+                              items:
+                                properties:
+                                  apiVersion:
+                                    description: APIVersion specifies resource apiVersion.
+                                    type: string
+                                  kind:
+                                    description: Kind specifies resource kind.
+                                    type: string
+                                  name:
+                                    description: Name specifies the resource name.
+                                    type: string
+                                  namespace:
+                                    description: Namespace specifies resource namespace.
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        name:
+                          description: Name is a label to identify the rule, It must
+                            be unique within the policy.
+                          maxLength: 63
+                          type: string
+                        preconditions:
+                          description: 'Preconditions are used to determine if a policy
+                            rule should be applied by evaluating a set of conditions.
+                            The declaration can contain nested `any` or `all` statements.
+                            A direct list of conditions (without `any` or `all` statements
+                            is supported for backwards compatibility but will be deprecated
+                            in the next major release. See: https://kyverno.io/docs/writing-policies/preconditions/'
+                          x-kubernetes-preserve-unknown-fields: true
+                        validate:
+                          description: Validation is used to validate matching resources.
+                          properties:
+                            anyPattern:
+                              description: AnyPattern specifies list of validation
+                                patterns. At least one of the patterns must be satisfied
+                                for the validation rule to succeed.
+                              x-kubernetes-preserve-unknown-fields: true
+                            deny:
+                              description: Deny defines conditions used to pass or
+                                fail a validation rule.
+                              properties:
+                                conditions:
+                                  description: 'Multiple conditions can be declared
+                                    under an `any` or `all` statement. A direct list
+                                    of conditions (without `any` or `all` statements)
+                                    is also supported for backwards compatibility
+                                    but will be deprecated in the next major release.
+                                    See: https://kyverno.io/docs/writing-policies/validate/#deny-rules'
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            foreach:
+                              description: ForEach applies validate rules to a list
+                                of sub-elements by creating a context for each entry
+                                in the list and looping over it to apply the specified
+                                logic.
+                              items:
+                                description: ForEach applies validate rules to a list
+                                  of sub-elements by creating a context for each entry
+                                  in the list and looping over it to apply the specified
+                                  logic.
+                                properties:
+                                  anyPattern:
+                                    description: AnyPattern specifies list of validation
+                                      patterns. At least one of the patterns must
+                                      be satisfied for the validation rule to succeed.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  context:
+                                    description: Context defines variables and data
+                                      sources that can be used during rule execution.
+                                    items:
+                                      description: ContextEntry adds variables and
+                                        data sources to a rule Context. Either a ConfigMap
+                                        reference or a APILookup must be provided.
+                                      properties:
+                                        apiCall:
+                                          description: APICall defines an HTTP request
+                                            to the Kubernetes API server. The JSON
+                                            data retrieved is stored in the context.
+                                          properties:
+                                            jmesPath:
+                                              description: JMESPath is an optional
+                                                JSON Match Expression that can be
+                                                used to transform the JSON response
+                                                returned from the API server. For
+                                                example a JMESPath of "items | length(@)"
+                                                applied to the API server response
+                                                to the URLPath "/apis/apps/v1/deployments"
+                                                will return the total count of deployments
+                                                across all namespaces.
+                                              type: string
+                                            urlPath:
+                                              description: URLPath is the URL path
+                                                to be used in the HTTP GET request
+                                                to the Kubernetes API server (e.g.
+                                                "/api/v1/namespaces" or  "/apis/apps/v1/deployments").
+                                                The format required is the same format
+                                                used by the `kubectl get --raw` command.
+                                              type: string
+                                          required:
+                                          - urlPath
+                                          type: object
+                                        configMap:
+                                          description: ConfigMap is the ConfigMap
+                                            reference.
+                                          properties:
+                                            name:
+                                              description: Name is the ConfigMap name.
+                                              type: string
+                                            namespace:
+                                              description: Namespace is the ConfigMap
+                                                namespace.
+                                              type: string
+                                          required:
+                                          - name
+                                          type: object
+                                        imageRegistry:
+                                          description: ImageRegistry defines requests
+                                            to an OCI/Docker V2 registry to fetch
+                                            image details.
+                                          properties:
+                                            jmesPath:
+                                              description: JMESPath is an optional
+                                                JSON Match Expression that can be
+                                                used to transform the ImageData struct
+                                                returned as a result of processing
+                                                the image reference.
+                                              type: string
+                                            reference:
+                                              description: 'Reference is image reference
+                                                to a container image in the registry.
+                                                Example: ghcr.io/kyverno/kyverno:latest'
+                                              type: string
+                                          required:
+                                          - reference
+                                          type: object
+                                        name:
+                                          description: Name is the variable name.
+                                          type: string
+                                        variable:
+                                          description: Variable defines an arbitrary
+                                            JMESPath context variable that can be
+                                            defined inline.
+                                          properties:
+                                            default:
+                                              description: Default is an optional
+                                                arbitrary JSON object that the variable
+                                                may take if the JMESPath expression
+                                                evaluates to nil
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            jmesPath:
+                                              description: JMESPath is an optional
+                                                JMESPath Expression that can be used
+                                                to transform the variable.
+                                              type: string
+                                            value:
+                                              description: Value is any arbitrary
+                                                JSON object representable in YAML
+                                                or JSON form.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                      type: object
+                                    type: array
+                                  deny:
+                                    description: Deny defines conditions used to pass
+                                      or fail a validation rule.
+                                    properties:
+                                      conditions:
+                                        description: 'Multiple conditions can be declared
+                                          under an `any` or `all` statement. A direct
+                                          list of conditions (without `any` or `all`
+                                          statements) is also supported for backwards
+                                          compatibility but will be deprecated in
+                                          the next major release. See: https://kyverno.io/docs/writing-policies/validate/#deny-rules'
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                  elementScope:
+                                    description: ElementScope specifies whether to
+                                      use the current list element as the scope for
+                                      validation. Defaults to "true" if not specified.
+                                      When set to "false", "request.object" is used
+                                      as the validation scope within the foreach block
+                                      to allow referencing other elements in the subtree.
+                                    type: boolean
+                                  list:
+                                    description: List specifies a JMESPath expression
+                                      that results in one or more elements to which
+                                      the validation logic is applied.
+                                    type: string
+                                  pattern:
+                                    description: Pattern specifies an overlay-style
+                                      pattern used to check resources.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  preconditions:
+                                    description: 'AnyAllConditions are used to determine
+                                      if a policy rule should be applied by evaluating
+                                      a set of conditions. The declaration can contain
+                                      nested `any` or `all` statements. See: https://kyverno.io/docs/writing-policies/preconditions/'
+                                    properties:
+                                      all:
+                                        description: AllConditions enable variable-based
+                                          conditional rule execution. This is useful
+                                          for finer control of when an rule is applied.
+                                          A condition can reference object data using
+                                          JMESPath notation. Here, all of the conditions
+                                          need to pass
+                                        items:
+                                          description: Condition defines variable-based
+                                            conditional criteria for rule execution.
+                                          properties:
+                                            key:
+                                              description: Key is the context entry
+                                                (using JMESPath) for conditional rule
+                                                evaluation.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            operator:
+                                              description: 'Operator is the conditional
+                                                operation to perform. Valid operators
+                                                are: Equals, NotEquals, In, AnyIn,
+                                                AllIn, NotIn, AnyNotIn, AllNotIn,
+                                                GreaterThanOrEquals, GreaterThan,
+                                                LessThanOrEquals, LessThan, DurationGreaterThanOrEquals,
+                                                DurationGreaterThan, DurationLessThanOrEquals,
+                                                DurationLessThan'
+                                              enum:
+                                              - Equals
+                                              - NotEquals
+                                              - In
+                                              - AnyIn
+                                              - AllIn
+                                              - NotIn
+                                              - AnyNotIn
+                                              - AllNotIn
+                                              - GreaterThanOrEquals
+                                              - GreaterThan
+                                              - LessThanOrEquals
+                                              - LessThan
+                                              - DurationGreaterThanOrEquals
+                                              - DurationGreaterThan
+                                              - DurationLessThanOrEquals
+                                              - DurationLessThan
+                                              type: string
+                                            value:
+                                              description: Value is the conditional
+                                                value, or set of values. The values
+                                                can be fixed set or can be variables
+                                                declared using JMESPath.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                        type: array
+                                      any:
+                                        description: AnyConditions enable variable-based
+                                          conditional rule execution. This is useful
+                                          for finer control of when an rule is applied.
+                                          A condition can reference object data using
+                                          JMESPath notation. Here, at least one of
+                                          the conditions need to pass
+                                        items:
+                                          description: Condition defines variable-based
+                                            conditional criteria for rule execution.
+                                          properties:
+                                            key:
+                                              description: Key is the context entry
+                                                (using JMESPath) for conditional rule
+                                                evaluation.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            operator:
+                                              description: 'Operator is the conditional
+                                                operation to perform. Valid operators
+                                                are: Equals, NotEquals, In, AnyIn,
+                                                AllIn, NotIn, AnyNotIn, AllNotIn,
+                                                GreaterThanOrEquals, GreaterThan,
+                                                LessThanOrEquals, LessThan, DurationGreaterThanOrEquals,
+                                                DurationGreaterThan, DurationLessThanOrEquals,
+                                                DurationLessThan'
+                                              enum:
+                                              - Equals
+                                              - NotEquals
+                                              - In
+                                              - AnyIn
+                                              - AllIn
+                                              - NotIn
+                                              - AnyNotIn
+                                              - AllNotIn
+                                              - GreaterThanOrEquals
+                                              - GreaterThan
+                                              - LessThanOrEquals
+                                              - LessThan
+                                              - DurationGreaterThanOrEquals
+                                              - DurationGreaterThan
+                                              - DurationLessThanOrEquals
+                                              - DurationLessThan
+                                              type: string
+                                            value:
+                                              description: Value is the conditional
+                                                value, or set of values. The values
+                                                can be fixed set or can be variables
+                                                declared using JMESPath.
+                                              x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                        type: array
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              type: array
+                            manifests:
+                              description: Manifest specifies conditions for manifest
+                                verification
+                              properties:
+                                annotationDomain:
+                                  description: AnnotationDomain is custom domain of
+                                    annotation for message and signature. Default
+                                    is "cosign.sigstore.dev".
+                                  type: string
+                                attestors:
+                                  description: Attestors specified the required attestors
+                                    (i.e. authorities)
+                                  items:
+                                    properties:
+                                      count:
+                                        description: Count specifies the required
+                                          number of entries that must match. If the
+                                          count is null, all entries must match (a
+                                          logical AND). If the count is 1, at least
+                                          one entry must match (a logical OR). If
+                                          the count contains a value N, then N must
+                                          be less than or equal to the size of entries,
+                                          and at least N entries must match.
+                                        minimum: 1
+                                        type: integer
+                                      entries:
+                                        description: Entries contains the available
+                                          attestors. An attestor can be a static key,
+                                          attributes for keyless verification, or
+                                          a nested attestor declaration.
+                                        items:
+                                          properties:
+                                            annotations:
+                                              additionalProperties:
+                                                type: string
+                                              description: Annotations are used for
+                                                image verification. Every specified
+                                                key-value pair must exist and match
+                                                in the verified payload. The payload
+                                                may contain other key-value pairs.
+                                              type: object
+                                            attestor:
+                                              description: Attestor is a nested AttestorSet
+                                                used to specify a more complex set
+                                                of match authorities
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            certificates:
+                                              description: Certificates specifies
+                                                one or more certificates
+                                              properties:
+                                                cert:
+                                                  description: Certificate is an optional
+                                                    PEM encoded public certificate.
+                                                  type: string
+                                                certChain:
+                                                  description: CertificateChain is
+                                                    an optional PEM encoded set of
+                                                    certificates used to verify
+                                                  type: string
+                                                rekor:
+                                                  description: Rekor provides configuration
+                                                    for the Rekor transparency log
+                                                    service. If the value is nil,
+                                                    Rekor is not checked. If an empty
+                                                    object is provided the public
+                                                    instance of Rekor (https://rekor.sigstore.dev)
+                                                    is used.
+                                                  properties:
+                                                    url:
+                                                      description: URL is the address
+                                                        of the transparency log. Defaults
+                                                        to the public log https://rekor.sigstore.dev.
+                                                      type: string
+                                                  required:
+                                                  - url
+                                                  type: object
+                                              type: object
+                                            keyless:
+                                              description: Keyless is a set of attribute
+                                                used to verify a Sigstore keyless
+                                                attestor. See https://github.com/sigstore/cosign/blob/main/KEYLESS.md.
+                                              properties:
+                                                additionalExtensions:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: AdditionalExtensions
+                                                    are certificate-extensions used
+                                                    for keyless signing.
+                                                  type: object
+                                                issuer:
+                                                  description: Issuer is the certificate
+                                                    issuer used for keyless signing.
+                                                  type: string
+                                                rekor:
+                                                  description: Rekor provides configuration
+                                                    for the Rekor transparency log
+                                                    service. If the value is nil,
+                                                    Rekor is not checked and a root
+                                                    certificate chain is expected
+                                                    instead. If an empty object is
+                                                    provided the public instance of
+                                                    Rekor (https://rekor.sigstore.dev)
+                                                    is used.
+                                                  properties:
+                                                    url:
+                                                      description: URL is the address
+                                                        of the transparency log. Defaults
+                                                        to the public log https://rekor.sigstore.dev.
+                                                      type: string
+                                                  required:
+                                                  - url
+                                                  type: object
+                                                roots:
+                                                  description: Roots is an optional
+                                                    set of PEM encoded trusted root
+                                                    certificates. If not provided,
+                                                    the system roots are used.
+                                                  type: string
+                                                subject:
+                                                  description: Subject is the verified
+                                                    identity used for keyless signing,
+                                                    for example the email address
+                                                  type: string
+                                              type: object
+                                            keys:
+                                              description: Keys specifies one or more
+                                                public keys
+                                              properties:
+                                                publicKeys:
+                                                  description: Keys is a set of X.509
+                                                    public keys used to verify image
+                                                    signatures. The keys can be directly
+                                                    specified or can be a variable
+                                                    reference to a key specified in
+                                                    a ConfigMap (see https://kyverno.io/docs/writing-policies/variables/).
+                                                    When multiple keys are specified
+                                                    each key is processed as a separate
+                                                    staticKey entry (.attestors[*].entries.keys)
+                                                    within the set of attestors and
+                                                    the count is applied across the
+                                                    keys.
+                                                  type: string
+                                                rekor:
+                                                  description: Rekor provides configuration
+                                                    for the Rekor transparency log
+                                                    service. If the value is nil,
+                                                    Rekor is not checked. If an empty
+                                                    object is provided the public
+                                                    instance of Rekor (https://rekor.sigstore.dev)
+                                                    is used.
+                                                  properties:
+                                                    url:
+                                                      description: URL is the address
+                                                        of the transparency log. Defaults
+                                                        to the public log https://rekor.sigstore.dev.
+                                                      type: string
+                                                  required:
+                                                  - url
+                                                  type: object
+                                              type: object
+                                            repository:
+                                              description: Repository is an optional
+                                                alternate OCI repository to use for
+                                                signatures and attestations that match
+                                                this rule. If specified Repository
+                                                will override other OCI image repository
+                                                locations for this Attestor.
+                                              type: string
+                                          type: object
+                                        type: array
+                                    type: object
+                                  type: array
+                                dryRun:
+                                  description: DryRun configuration
+                                  properties:
+                                    enable:
+                                      type: boolean
+                                    namespace:
+                                      type: string
+                                  type: object
+                                ignoreFields:
+                                  description: Fields which will be ignored while
+                                    comparing manifests.
+                                  items:
+                                    properties:
+                                      fields:
+                                        items:
+                                          type: string
+                                        type: array
+                                      objects:
+                                        items:
+                                          properties:
+                                            group:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            name:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            version:
+                                              type: string
+                                          type: object
+                                        type: array
+                                    type: object
+                                  type: array
+                                repository:
+                                  description: Repository is an optional alternate
+                                    OCI repository to use for resource bundle reference.
+                                    The repository can be overridden per Attestor
+                                    or Attestation.
+                                  type: string
+                              type: object
+                            message:
+                              description: Message specifies a custom message to be
+                                displayed on failure.
+                              type: string
+                            pattern:
+                              description: Pattern specifies an overlay-style pattern
+                                used to check resources.
+                              x-kubernetes-preserve-unknown-fields: true
+                            podSecurity:
+                              description: PodSecurity applies exemptions for Kubernetes
+                                Pod Security admission by specifying exclusions for
+                                Pod Security Standards controls.
+                              properties:
+                                exclude:
+                                  description: Exclude specifies the Pod Security
+                                    Standard controls to be excluded.
+                                  items:
+                                    description: PodSecurityStandard specifies the
+                                      Pod Security Standard controls to be excluded.
+                                    properties:
+                                      controlName:
+                                        description: 'ControlName specifies the name
+                                          of the Pod Security Standard control. See:
+                                          https://kubernetes.io/docs/concepts/security/pod-security-standards/'
+                                        enum:
+                                        - HostProcess
+                                        - Host Namespaces
+                                        - Privileged Containers
+                                        - Capabilities
+                                        - HostPath Volumes
+                                        - Host Ports
+                                        - AppArmor
+                                        - SELinux
+                                        - /proc Mount Type
+                                        - Seccomp
+                                        - Sysctls
+                                        - Volume Types
+                                        - Privilege Escalation
+                                        - Running as Non-root
+                                        - Running as Non-root user
+                                        type: string
+                                      images:
+                                        description: 'Images selects matching containers
+                                          and applies the container level PSS. Each
+                                          image is the image name consisting of the
+                                          registry address, repository, image, and
+                                          tag. Empty list matches no containers, PSS
+                                          checks are applied at the pod level only.
+                                          Wildcards (''*'' and ''?'') are allowed.
+                                          See: https://kubernetes.io/docs/concepts/containers/images.'
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - controlName
+                                    type: object
+                                  type: array
+                                level:
+                                  description: Level defines the Pod Security Standard
+                                    level to be applied to workloads. Allowed values
+                                    are privileged, baseline, and restricted.
+                                  enum:
+                                  - privileged
+                                  - baseline
+                                  - restricted
+                                  type: string
+                                version:
+                                  description: Version defines the Pod Security Standard
+                                    versions that Kubernetes supports. Allowed values
+                                    are v1.19, v1.20, v1.21, v1.22, v1.23, v1.24,
+                                    v1.25, latest. Defaults to latest.
+                                  enum:
+                                  - v1.19
+                                  - v1.20
+                                  - v1.21
+                                  - v1.22
+                                  - v1.23
+                                  - v1.24
+                                  - v1.25
+                                  - latest
+                                  type: string
+                              type: object
+                          type: object
+                        verifyImages:
+                          description: VerifyImages is used to verify image signatures
+                            and mutate them to add a digest
+                          items:
+                            description: ImageVerification validates that images that
+                              match the specified pattern are signed with the supplied
+                              public key. Once the image is verified it is mutated
+                              to include the SHA digest retrieved during the registration.
+                            properties:
+                              additionalExtensions:
+                                additionalProperties:
+                                  type: string
+                                description: AdditionalExtensions are certificate-extensions
+                                  used for keyless signing. Deprecated.
+                                type: object
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                description: Annotations are used for image verification.
+                                  Every specified key-value pair must exist and match
+                                  in the verified payload. The payload may contain
+                                  other key-value pairs. Deprecated. Use annotations
+                                  per Attestor instead.
+                                type: object
+                              attestations:
+                                description: Attestations are optional checks for
+                                  signed in-toto Statements used to verify the image.
+                                  See https://github.com/in-toto/attestation. Kyverno
+                                  fetches signed attestations from the OCI registry
+                                  and decodes them into a list of Statement declarations.
+                                items:
+                                  description: Attestation are checks for signed in-toto
+                                    Statements that are used to verify the image.
+                                    See https://github.com/in-toto/attestation. Kyverno
+                                    fetches signed attestations from the OCI registry
+                                    and decodes them into a list of Statements.
+                                  properties:
+                                    conditions:
+                                      description: Conditions are used to verify attributes
+                                        within a Predicate. If no Conditions are specified
+                                        the attestation check is satisfied as long
+                                        there are predicates that match the predicate
+                                        type.
+                                      items:
+                                        description: AnyAllConditions consists of
+                                          conditions wrapped denoting a logical criteria
+                                          to be fulfilled. AnyConditions get fulfilled
+                                          when at least one of its sub-conditions
+                                          passes. AllConditions get fulfilled only
+                                          when all of its sub-conditions pass.
+                                        properties:
+                                          all:
+                                            description: AllConditions enable variable-based
+                                              conditional rule execution. This is
+                                              useful for finer control of when an
+                                              rule is applied. A condition can reference
+                                              object data using JMESPath notation.
+                                              Here, all of the conditions need to
+                                              pass
+                                            items:
+                                              description: Condition defines variable-based
+                                                conditional criteria for rule execution.
+                                              properties:
+                                                key:
+                                                  description: Key is the context
+                                                    entry (using JMESPath) for conditional
+                                                    rule evaluation.
+                                                  x-kubernetes-preserve-unknown-fields: true
+                                                operator:
+                                                  description: 'Operator is the conditional
+                                                    operation to perform. Valid operators
+                                                    are: Equals, NotEquals, In, AnyIn,
+                                                    AllIn, NotIn, AnyNotIn, AllNotIn,
+                                                    GreaterThanOrEquals, GreaterThan,
+                                                    LessThanOrEquals, LessThan, DurationGreaterThanOrEquals,
+                                                    DurationGreaterThan, DurationLessThanOrEquals,
+                                                    DurationLessThan'
+                                                  enum:
+                                                  - Equals
+                                                  - NotEquals
+                                                  - In
+                                                  - AnyIn
+                                                  - AllIn
+                                                  - NotIn
+                                                  - AnyNotIn
+                                                  - AllNotIn
+                                                  - GreaterThanOrEquals
+                                                  - GreaterThan
+                                                  - LessThanOrEquals
+                                                  - LessThan
+                                                  - DurationGreaterThanOrEquals
+                                                  - DurationGreaterThan
+                                                  - DurationLessThanOrEquals
+                                                  - DurationLessThan
+                                                  type: string
+                                                value:
+                                                  description: Value is the conditional
+                                                    value, or set of values. The values
+                                                    can be fixed set or can be variables
+                                                    declared using JMESPath.
+                                                  x-kubernetes-preserve-unknown-fields: true
+                                              type: object
+                                            type: array
+                                          any:
+                                            description: AnyConditions enable variable-based
+                                              conditional rule execution. This is
+                                              useful for finer control of when an
+                                              rule is applied. A condition can reference
+                                              object data using JMESPath notation.
+                                              Here, at least one of the conditions
+                                              need to pass
+                                            items:
+                                              description: Condition defines variable-based
+                                                conditional criteria for rule execution.
+                                              properties:
+                                                key:
+                                                  description: Key is the context
+                                                    entry (using JMESPath) for conditional
+                                                    rule evaluation.
+                                                  x-kubernetes-preserve-unknown-fields: true
+                                                operator:
+                                                  description: 'Operator is the conditional
+                                                    operation to perform. Valid operators
+                                                    are: Equals, NotEquals, In, AnyIn,
+                                                    AllIn, NotIn, AnyNotIn, AllNotIn,
+                                                    GreaterThanOrEquals, GreaterThan,
+                                                    LessThanOrEquals, LessThan, DurationGreaterThanOrEquals,
+                                                    DurationGreaterThan, DurationLessThanOrEquals,
+                                                    DurationLessThan'
+                                                  enum:
+                                                  - Equals
+                                                  - NotEquals
+                                                  - In
+                                                  - AnyIn
+                                                  - AllIn
+                                                  - NotIn
+                                                  - AnyNotIn
+                                                  - AllNotIn
+                                                  - GreaterThanOrEquals
+                                                  - GreaterThan
+                                                  - LessThanOrEquals
+                                                  - LessThan
+                                                  - DurationGreaterThanOrEquals
+                                                  - DurationGreaterThan
+                                                  - DurationLessThanOrEquals
+                                                  - DurationLessThan
+                                                  type: string
+                                                value:
+                                                  description: Value is the conditional
+                                                    value, or set of values. The values
+                                                    can be fixed set or can be variables
+                                                    declared using JMESPath.
+                                                  x-kubernetes-preserve-unknown-fields: true
+                                              type: object
+                                            type: array
+                                        type: object
+                                      type: array
+                                    predicateType:
+                                      description: PredicateType defines the type
+                                        of Predicate contained within the Statement.
+                                      type: string
+                                  type: object
+                                type: array
+                              attestors:
+                                description: Attestors specified the required attestors
+                                  (i.e. authorities)
+                                items:
+                                  properties:
+                                    count:
+                                      description: Count specifies the required number
+                                        of entries that must match. If the count is
+                                        null, all entries must match (a logical AND).
+                                        If the count is 1, at least one entry must
+                                        match (a logical OR). If the count contains
+                                        a value N, then N must be less than or equal
+                                        to the size of entries, and at least N entries
+                                        must match.
+                                      minimum: 1
+                                      type: integer
+                                    entries:
+                                      description: Entries contains the available
+                                        attestors. An attestor can be a static key,
+                                        attributes for keyless verification, or a
+                                        nested attestor declaration.
+                                      items:
+                                        properties:
+                                          annotations:
+                                            additionalProperties:
+                                              type: string
+                                            description: Annotations are used for
+                                              image verification. Every specified
+                                              key-value pair must exist and match
+                                              in the verified payload. The payload
+                                              may contain other key-value pairs.
+                                            type: object
+                                          attestor:
+                                            description: Attestor is a nested AttestorSet
+                                              used to specify a more complex set of
+                                              match authorities
+                                            x-kubernetes-preserve-unknown-fields: true
+                                          certificates:
+                                            description: Certificates specifies one
+                                              or more certificates
+                                            properties:
+                                              cert:
+                                                description: Certificate is an optional
+                                                  PEM encoded public certificate.
+                                                type: string
+                                              certChain:
+                                                description: CertificateChain is an
+                                                  optional PEM encoded set of certificates
+                                                  used to verify
+                                                type: string
+                                              rekor:
+                                                description: Rekor provides configuration
+                                                  for the Rekor transparency log service.
+                                                  If the value is nil, Rekor is not
+                                                  checked. If an empty object is provided
+                                                  the public instance of Rekor (https://rekor.sigstore.dev)
+                                                  is used.
+                                                properties:
+                                                  url:
+                                                    description: URL is the address
+                                                      of the transparency log. Defaults
+                                                      to the public log https://rekor.sigstore.dev.
+                                                    type: string
+                                                required:
+                                                - url
+                                                type: object
+                                            type: object
+                                          keyless:
+                                            description: Keyless is a set of attribute
+                                              used to verify a Sigstore keyless attestor.
+                                              See https://github.com/sigstore/cosign/blob/main/KEYLESS.md.
+                                            properties:
+                                              additionalExtensions:
+                                                additionalProperties:
+                                                  type: string
+                                                description: AdditionalExtensions
+                                                  are certificate-extensions used
+                                                  for keyless signing.
+                                                type: object
+                                              issuer:
+                                                description: Issuer is the certificate
+                                                  issuer used for keyless signing.
+                                                type: string
+                                              rekor:
+                                                description: Rekor provides configuration
+                                                  for the Rekor transparency log service.
+                                                  If the value is nil, Rekor is not
+                                                  checked and a root certificate chain
+                                                  is expected instead. If an empty
+                                                  object is provided the public instance
+                                                  of Rekor (https://rekor.sigstore.dev)
+                                                  is used.
+                                                properties:
+                                                  url:
+                                                    description: URL is the address
+                                                      of the transparency log. Defaults
+                                                      to the public log https://rekor.sigstore.dev.
+                                                    type: string
+                                                required:
+                                                - url
+                                                type: object
+                                              roots:
+                                                description: Roots is an optional
+                                                  set of PEM encoded trusted root
+                                                  certificates. If not provided, the
+                                                  system roots are used.
+                                                type: string
+                                              subject:
+                                                description: Subject is the verified
+                                                  identity used for keyless signing,
+                                                  for example the email address
+                                                type: string
+                                            type: object
+                                          keys:
+                                            description: Keys specifies one or more
+                                              public keys
+                                            properties:
+                                              publicKeys:
+                                                description: Keys is a set of X.509
+                                                  public keys used to verify image
+                                                  signatures. The keys can be directly
+                                                  specified or can be a variable reference
+                                                  to a key specified in a ConfigMap
+                                                  (see https://kyverno.io/docs/writing-policies/variables/).
+                                                  When multiple keys are specified
+                                                  each key is processed as a separate
+                                                  staticKey entry (.attestors[*].entries.keys)
+                                                  within the set of attestors and
+                                                  the count is applied across the
+                                                  keys.
+                                                type: string
+                                              rekor:
+                                                description: Rekor provides configuration
+                                                  for the Rekor transparency log service.
+                                                  If the value is nil, Rekor is not
+                                                  checked. If an empty object is provided
+                                                  the public instance of Rekor (https://rekor.sigstore.dev)
+                                                  is used.
+                                                properties:
+                                                  url:
+                                                    description: URL is the address
+                                                      of the transparency log. Defaults
+                                                      to the public log https://rekor.sigstore.dev.
+                                                    type: string
+                                                required:
+                                                - url
+                                                type: object
+                                            type: object
+                                          repository:
+                                            description: Repository is an optional
+                                              alternate OCI repository to use for
+                                              signatures and attestations that match
+                                              this rule. If specified Repository will
+                                              override other OCI image repository
+                                              locations for this Attestor.
+                                            type: string
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                              image:
+                                description: 'Image is the image name consisting of
+                                  the registry address, repository, image, and tag.
+                                  Wildcards (''*'' and ''?'') are allowed. See: https://kubernetes.io/docs/concepts/containers/images.
+                                  Deprecated. Use ImageReferences instead.'
+                                type: string
+                              imageReferences:
+                                description: 'ImageReferences is a list of matching
+                                  image reference patterns. At least one pattern in
+                                  the list must match the image for the rule to apply.
+                                  Each image reference consists of a registry address
+                                  (defaults to docker.io), repository, image, and
+                                  tag (defaults to latest). Wildcards (''*'' and ''?'')
+                                  are allowed. See: https://kubernetes.io/docs/concepts/containers/images.'
+                                items:
+                                  type: string
+                                type: array
+                              issuer:
+                                description: Issuer is the certificate issuer used
+                                  for keyless signing. Deprecated. Use KeylessAttestor
+                                  instead.
+                                type: string
+                              key:
+                                description: Key is the PEM encoded public key that
+                                  the image or attestation is signed with. Deprecated.
+                                  Use StaticKeyAttestor instead.
+                                type: string
+                              mutateDigest:
+                                default: true
+                                description: MutateDigest enables replacement of image
+                                  tags with digests. Defaults to true.
+                                type: boolean
+                              repository:
+                                description: Repository is an optional alternate OCI
+                                  repository to use for image signatures and attestations
+                                  that match this rule. If specified Repository will
+                                  override the default OCI image repository configured
+                                  for the installation. The repository can also be
+                                  overridden per Attestor or Attestation.
+                                type: string
+                              required:
+                                default: true
+                                description: Required validates that images are verified
+                                  i.e. have matched passed a signature or attestation
+                                  check.
+                                type: boolean
+                              roots:
+                                description: Roots is the PEM encoded Root certificate
+                                  chain used for keyless signing Deprecated. Use KeylessAttestor
+                                  instead.
+                                type: string
+                              subject:
+                                description: Subject is the identity used for keyless
+                                  signing, for example an email address Deprecated.
+                                  Use KeylessAttestor instead.
+                                type: string
+                              verifyDigest:
+                                default: true
+                                description: VerifyDigest validates that images have
+                                  a digest.
+                                type: boolean
+                            type: object
+                          type: array
+                      type: object
+                    type: array
+                type: object
+              conditions:
+                description: Conditions is a list of conditions that apply to the
+                  policy
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              ready:
+                description: Ready indicates if the policy is ready to serve the admission
+                  request. Deprecated in favor of Conditions
+                type: boolean
+            required:
+            - ready
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_policyreports.wgpolicyk8s.io.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_policyreports.wgpolicyk8s.io.yaml
@@ -1,0 +1,368 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Replace=true
+    controller-gen.kubebuilder.io/version: v0.10.0
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: kyverno
+    app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/version: v1.8.1
+  name: policyreports.wgpolicyk8s.io
+spec:
+  group: wgpolicyk8s.io
+  names:
+    kind: PolicyReport
+    listKind: PolicyReportList
+    plural: policyreports
+    shortNames:
+    - polr
+    singular: policyreport
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .scope.kind
+      name: Kind
+      priority: 1
+      type: string
+    - jsonPath: .scope.name
+      name: Name
+      priority: 1
+      type: string
+    - jsonPath: .summary.pass
+      name: Pass
+      type: integer
+    - jsonPath: .summary.fail
+      name: Fail
+      type: integer
+    - jsonPath: .summary.warn
+      name: Warn
+      type: integer
+    - jsonPath: .summary.error
+      name: Error
+      type: integer
+    - jsonPath: .summary.skip
+      name: Skip
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: PolicyReport is the Schema for the policyreports API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          results:
+            description: PolicyReportResult provides result details
+            items:
+              description: PolicyReportResult provides the result for an individual
+                policy
+              properties:
+                category:
+                  description: Category indicates policy category
+                  type: string
+                message:
+                  description: Description is a short user friendly message for the
+                    policy rule
+                  type: string
+                policy:
+                  description: Policy is the name or identifier of the policy
+                  type: string
+                properties:
+                  additionalProperties:
+                    type: string
+                  description: Properties provides additional information for the
+                    policy rule
+                  type: object
+                resourceSelector:
+                  description: SubjectSelector is an optional label selector for checked
+                    Kubernetes resources. For example, a policy result may apply to
+                    all pods that match a label. Either a Subject or a SubjectSelector
+                    can be specified. If neither are provided, the result is assumed
+                    to be for the policy report scope.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                  x-kubernetes-map-type: atomic
+                resources:
+                  description: Subjects is an optional reference to the checked Kubernetes
+                    resources
+                  items:
+                    description: "ObjectReference contains enough information to let
+                      you inspect or modify the referred object. --- New uses of this
+                      type are discouraged because of difficulty describing its usage
+                      when embedded in APIs. 1. Ignored fields.  It includes many
+                      fields which are not generally honored.  For instance, ResourceVersion
+                      and FieldPath are both very rarely valid in actual usage. 2.
+                      Invalid usage help.  It is impossible to add specific help for
+                      individual usage.  In most embedded usages, there are particular
+                      restrictions like, \"must refer only to types A and B\" or \"UID
+                      not honored\" or \"name must be restricted\". Those cannot be
+                      well described when embedded. 3. Inconsistent validation.  Because
+                      the usages are different, the validation rules are different
+                      by usage, which makes it hard for users to predict what will
+                      happen. 4. The fields are both imprecise and overly precise.
+                      \ Kind is not a precise mapping to a URL. This can produce ambiguity
+                      during interpretation and require a REST mapping.  In most cases,
+                      the dependency is on the group,resource tuple and the version
+                      of the actual struct is irrelevant. 5. We cannot easily change
+                      it.  Because this type is embedded in many locations, updates
+                      to this type will affect numerous schemas.  Don't make new APIs
+                      embed an underspecified API type they do not control. \n Instead
+                      of using this type, create a locally provided and used type
+                      that is well-focused on your reference. For example, ServiceReferences
+                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                      ."
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object. TODO: this design is not final and this field
+                          is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  type: array
+                result:
+                  description: Result indicates the outcome of the policy rule execution
+                  enum:
+                  - pass
+                  - fail
+                  - warn
+                  - error
+                  - skip
+                  type: string
+                rule:
+                  description: Rule is the name or identifier of the rule within the
+                    policy
+                  type: string
+                scored:
+                  description: Scored indicates if this result is scored
+                  type: boolean
+                severity:
+                  description: Severity indicates policy check result criticality
+                  enum:
+                  - critical
+                  - high
+                  - low
+                  - medium
+                  - info
+                  type: string
+                source:
+                  description: Source is an identifier for the policy engine that
+                    manages this report
+                  type: string
+                timestamp:
+                  description: Timestamp indicates the time the result was found
+                  properties:
+                    nanos:
+                      description: Non-negative fractions of a second at nanosecond
+                        resolution. Negative second values with fractions must still
+                        have non-negative nanos values that count forward in time.
+                        Must be from 0 to 999,999,999 inclusive. This field may be
+                        limited in precision depending on context.
+                      format: int32
+                      type: integer
+                    seconds:
+                      description: Represents seconds of UTC time since Unix epoch
+                        1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
+                        9999-12-31T23:59:59Z inclusive.
+                      format: int64
+                      type: integer
+                  required:
+                  - nanos
+                  - seconds
+                  type: object
+              required:
+              - policy
+              type: object
+            type: array
+          scope:
+            description: Scope is an optional reference to the report scope (e.g.
+              a Deployment, Namespace, or Node)
+            properties:
+              apiVersion:
+                description: API version of the referent.
+                type: string
+              fieldPath:
+                description: 'If referring to a piece of an object instead of an entire
+                  object, this string should contain a valid JSON/Go field access
+                  statement, such as desiredState.manifest.containers[2]. For example,
+                  if the object reference is to a container within a pod, this would
+                  take on a value like: "spec.containers{name}" (where "name" refers
+                  to the name of the container that triggered the event) or if no
+                  container name is specified "spec.containers[2]" (container with
+                  index 2 in this pod). This syntax is chosen only to have some well-defined
+                  way of referencing a part of an object. TODO: this design is not
+                  final and this field is subject to change in the future.'
+                type: string
+              kind:
+                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              name:
+                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                type: string
+              namespace:
+                description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                type: string
+              resourceVersion:
+                description: 'Specific resourceVersion to which this reference is
+                  made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                type: string
+              uid:
+                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                type: string
+            type: object
+            x-kubernetes-map-type: atomic
+          scopeSelector:
+            description: ScopeSelector is an optional selector for multiple scopes
+              (e.g. Pods). Either one of, or none of, but not both of, Scope or ScopeSelector
+              should be specified.
+            properties:
+              matchExpressions:
+                description: matchExpressions is a list of label selector requirements.
+                  The requirements are ANDed.
+                items:
+                  description: A label selector requirement is a selector that contains
+                    values, a key, and an operator that relates the key and values.
+                  properties:
+                    key:
+                      description: key is the label key that the selector applies
+                        to.
+                      type: string
+                    operator:
+                      description: operator represents a key's relationship to a set
+                        of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                      type: string
+                    values:
+                      description: values is an array of string values. If the operator
+                        is In or NotIn, the values array must be non-empty. If the
+                        operator is Exists or DoesNotExist, the values array must
+                        be empty. This array is replaced during a strategic merge
+                        patch.
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - key
+                  - operator
+                  type: object
+                type: array
+              matchLabels:
+                additionalProperties:
+                  type: string
+                description: matchLabels is a map of {key,value} pairs. A single {key,value}
+                  in the matchLabels map is equivalent to an element of matchExpressions,
+                  whose key field is "key", the operator is "In", and the values array
+                  contains only "value". The requirements are ANDed.
+                type: object
+            type: object
+            x-kubernetes-map-type: atomic
+          summary:
+            description: PolicyReportSummary provides a summary of results
+            properties:
+              error:
+                description: Error provides the count of policies that could not be
+                  evaluated
+                type: integer
+              fail:
+                description: Fail provides the count of policies whose requirements
+                  were not met
+                type: integer
+              pass:
+                description: Pass provides the count of policies whose requirements
+                  were met
+                type: integer
+              skip:
+                description: Skip indicates the count of policies that were not selected
+                  for evaluation
+                type: integer
+              warn:
+                description: Warn provides the count of non-scored policies whose
+                  requirements were not met
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_updaterequests.kyverno.io.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_updaterequests.kyverno.io.yaml
@@ -1,0 +1,391 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Replace=true
+    controller-gen.kubebuilder.io/version: v0.10.0
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: kyverno
+    app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/version: v1.8.1
+  name: updaterequests.kyverno.io
+spec:
+  group: kyverno.io
+  names:
+    kind: UpdateRequest
+    listKind: UpdateRequestList
+    plural: updaterequests
+    shortNames:
+    - ur
+    singular: updaterequest
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.policy
+      name: Policy
+      type: string
+    - jsonPath: .spec.requestType
+      name: RuleType
+      type: string
+    - jsonPath: .spec.resource.kind
+      name: ResourceKind
+      type: string
+    - jsonPath: .spec.resource.name
+      name: ResourceName
+      type: string
+    - jsonPath: .spec.resource.namespace
+      name: ResourceNamespace
+      type: string
+    - jsonPath: .status.state
+      name: status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: UpdateRequest is a request to process mutate and generate rules
+          in background.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec is the information to identify the update request.
+            properties:
+              context:
+                description: Context ...
+                properties:
+                  admissionRequestInfo:
+                    description: AdmissionRequestInfoObject stores the admission request
+                      and operation details
+                    properties:
+                      admissionRequest:
+                        description: AdmissionRequest describes the admission.Attributes
+                          for the admission request.
+                        properties:
+                          dryRun:
+                            description: DryRun indicates that modifications will
+                              definitely not be persisted for this request. Defaults
+                              to false.
+                            type: boolean
+                          kind:
+                            description: Kind is the fully-qualified type of object
+                              being submitted (for example, v1.Pod or autoscaling.v1.Scale)
+                            properties:
+                              group:
+                                type: string
+                              kind:
+                                type: string
+                              version:
+                                type: string
+                            required:
+                            - group
+                            - kind
+                            - version
+                            type: object
+                          name:
+                            description: Name is the name of the object as presented
+                              in the request.  On a CREATE operation, the client may
+                              omit name and rely on the server to generate the name.  If
+                              that is the case, this field will contain an empty string.
+                            type: string
+                          namespace:
+                            description: Namespace is the namespace associated with
+                              the request (if any).
+                            type: string
+                          object:
+                            description: Object is the object from the incoming request.
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          oldObject:
+                            description: OldObject is the existing object. Only populated
+                              for DELETE and UPDATE requests.
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          operation:
+                            description: Operation is the operation being performed.
+                              This may be different than the operation requested.
+                              e.g. a patch can result in either a CREATE or UPDATE
+                              Operation.
+                            type: string
+                          options:
+                            description: Options is the operation option structure
+                              of the operation being performed. e.g. `meta.k8s.io/v1.DeleteOptions`
+                              or `meta.k8s.io/v1.CreateOptions`. This may be different
+                              than the options the caller provided. e.g. for a patch
+                              request the performed Operation might be a CREATE, in
+                              which case the Options will a `meta.k8s.io/v1.CreateOptions`
+                              even though the caller provided `meta.k8s.io/v1.PatchOptions`.
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          requestKind:
+                            description: "RequestKind is the fully-qualified type
+                              of the original API request (for example, v1.Pod or
+                              autoscaling.v1.Scale). If this is specified and differs
+                              from the value in \"kind\", an equivalent match and
+                              conversion was performed. \n For example, if deployments
+                              can be modified via apps/v1 and apps/v1beta1, and a
+                              webhook registered a rule of `apiGroups:[\"apps\"],
+                              apiVersions:[\"v1\"], resources: [\"deployments\"]`
+                              and `matchPolicy: Equivalent`, an API request to apps/v1beta1
+                              deployments would be converted and sent to the webhook
+                              with `kind: {group:\"apps\", version:\"v1\", kind:\"Deployment\"}`
+                              (matching the rule the webhook registered for), and
+                              `requestKind: {group:\"apps\", version:\"v1beta1\",
+                              kind:\"Deployment\"}` (indicating the kind of the original
+                              API request). \n See documentation for the \"matchPolicy\"
+                              field in the webhook configuration type for more details."
+                            properties:
+                              group:
+                                type: string
+                              kind:
+                                type: string
+                              version:
+                                type: string
+                            required:
+                            - group
+                            - kind
+                            - version
+                            type: object
+                          requestResource:
+                            description: "RequestResource is the fully-qualified resource
+                              of the original API request (for example, v1.pods).
+                              If this is specified and differs from the value in \"resource\",
+                              an equivalent match and conversion was performed. \n
+                              For example, if deployments can be modified via apps/v1
+                              and apps/v1beta1, and a webhook registered a rule of
+                              `apiGroups:[\"apps\"], apiVersions:[\"v1\"], resources:
+                              [\"deployments\"]` and `matchPolicy: Equivalent`, an
+                              API request to apps/v1beta1 deployments would be converted
+                              and sent to the webhook with `resource: {group:\"apps\",
+                              version:\"v1\", resource:\"deployments\"}` (matching
+                              the resource the webhook registered for), and `requestResource:
+                              {group:\"apps\", version:\"v1beta1\", resource:\"deployments\"}`
+                              (indicating the resource of the original API request).
+                              \n See documentation for the \"matchPolicy\" field in
+                              the webhook configuration type."
+                            properties:
+                              group:
+                                type: string
+                              resource:
+                                type: string
+                              version:
+                                type: string
+                            required:
+                            - group
+                            - resource
+                            - version
+                            type: object
+                          requestSubResource:
+                            description: RequestSubResource is the name of the subresource
+                              of the original API request, if any (for example, "status"
+                              or "scale") If this is specified and differs from the
+                              value in "subResource", an equivalent match and conversion
+                              was performed. See documentation for the "matchPolicy"
+                              field in the webhook configuration type.
+                            type: string
+                          resource:
+                            description: Resource is the fully-qualified resource
+                              being requested (for example, v1.pods)
+                            properties:
+                              group:
+                                type: string
+                              resource:
+                                type: string
+                              version:
+                                type: string
+                            required:
+                            - group
+                            - resource
+                            - version
+                            type: object
+                          subResource:
+                            description: SubResource is the subresource being requested,
+                              if any (for example, "status" or "scale")
+                            type: string
+                          uid:
+                            description: UID is an identifier for the individual request/response.
+                              It allows us to distinguish instances of requests which
+                              are otherwise identical (parallel requests, requests
+                              when earlier requests did not modify etc) The UID is
+                              meant to track the round trip (request/response) between
+                              the KAS and the WebHook, not the user request. It is
+                              suitable for correlating log entries between the webhook
+                              and apiserver, for either auditing or debugging.
+                            type: string
+                          userInfo:
+                            description: UserInfo is information about the requesting
+                              user
+                            properties:
+                              extra:
+                                additionalProperties:
+                                  description: ExtraValue masks the value so protobuf
+                                    can generate
+                                  items:
+                                    type: string
+                                  type: array
+                                description: Any additional information provided by
+                                  the authenticator.
+                                type: object
+                              groups:
+                                description: The names of groups this user is a part
+                                  of.
+                                items:
+                                  type: string
+                                type: array
+                              uid:
+                                description: A unique value that identifies this user
+                                  across time. If this user is deleted and another
+                                  user by the same name is added, they will have different
+                                  UIDs.
+                                type: string
+                              username:
+                                description: The name that uniquely identifies this
+                                  user among all active users.
+                                type: string
+                            type: object
+                        required:
+                        - kind
+                        - operation
+                        - resource
+                        - uid
+                        - userInfo
+                        type: object
+                      operation:
+                        description: Operation is the type of resource operation being
+                          checked for admission control
+                        type: string
+                    type: object
+                  userInfo:
+                    description: RequestInfo contains permission info carried in an
+                      admission request.
+                    properties:
+                      clusterRoles:
+                        description: ClusterRoles is a list of possible clusterRoles
+                          send the request.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      roles:
+                        description: Roles is a list of possible role send the request.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      userInfo:
+                        description: UserInfo is the userInfo carried in the admission
+                          request.
+                        properties:
+                          extra:
+                            additionalProperties:
+                              description: ExtraValue masks the value so protobuf
+                                can generate
+                              items:
+                                type: string
+                              type: array
+                            description: Any additional information provided by the
+                              authenticator.
+                            type: object
+                          groups:
+                            description: The names of groups this user is a part of.
+                            items:
+                              type: string
+                            type: array
+                          uid:
+                            description: A unique value that identifies this user
+                              across time. If this user is deleted and another user
+                              by the same name is added, they will have different
+                              UIDs.
+                            type: string
+                          username:
+                            description: The name that uniquely identifies this user
+                              among all active users.
+                            type: string
+                        type: object
+                    type: object
+                type: object
+              policy:
+                description: Specifies the name of the policy.
+                type: string
+              requestType:
+                description: Type represents request type for background processing
+                enum:
+                - mutate
+                - generate
+                type: string
+              resource:
+                description: ResourceSpec is the information to identify the update
+                  request.
+                properties:
+                  apiVersion:
+                    description: APIVersion specifies resource apiVersion.
+                    type: string
+                  kind:
+                    description: Kind specifies resource kind.
+                    type: string
+                  name:
+                    description: Name specifies the resource name.
+                    type: string
+                  namespace:
+                    description: Namespace specifies resource namespace.
+                    type: string
+                type: object
+            required:
+            - context
+            - policy
+            - resource
+            type: object
+          status:
+            description: Status contains statistics related to update request.
+            properties:
+              generatedResources:
+                description: This will track the resources that are updated by the
+                  generate Policy. Will be used during clean up resources.
+                items:
+                  properties:
+                    apiVersion:
+                      description: APIVersion specifies resource apiVersion.
+                      type: string
+                    kind:
+                      description: Kind specifies resource kind.
+                      type: string
+                    name:
+                      description: Name specifies the resource name.
+                      type: string
+                    namespace:
+                      description: Namespace specifies resource namespace.
+                      type: string
+                  type: object
+                type: array
+              handler:
+                description: Handler represents the instance ID that handles the UR
+                type: string
+              message:
+                description: Specifies request status message.
+                type: string
+              state:
+                description: State represents state of the update request.
+                type: string
+            required:
+            - state
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/apps_v1_deployment_kyverno.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/apps_v1_deployment_kyverno.yaml
@@ -1,0 +1,145 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: kyverno
+    app.kubernetes.io/component: kyverno
+    app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/version: v1.8.1
+    name: kyverno
+  name: kyverno
+  namespace: syn-kyverno
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: kyverno
+      app.kubernetes.io/name: kyverno
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 40%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: kyverno
+        app.kubernetes.io/component: kyverno
+        app.kubernetes.io/instance: kyverno
+        app.kubernetes.io/name: kyverno
+        app.kubernetes.io/part-of: kyverno
+        app.kubernetes.io/version: v1.8.1
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution: []
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - kyverno
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args: []
+        env:
+        - name: INIT_CONFIG
+          value: kyverno
+        - name: METRICS_CONFIG
+          value: kyverno-metrics
+        - name: KYVERNO_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KYVERNO_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: KYVERNO_SVC
+          value: kyverno-svc
+        - name: TUF_ROOT
+          value: /.sigstore
+        image: ghcr.io/kyverno/kyverno:v1.8.1
+        imagePullPolicy: Always
+        livenessProbe:
+          failureThreshold: 2
+          httpGet:
+            path: /health/liveness
+            port: 9443
+            scheme: HTTPS
+          initialDelaySeconds: 15
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 5
+        name: kyverno
+        ports:
+        - containerPort: 9443
+          name: https
+          protocol: TCP
+        - containerPort: 8000
+          name: metrics-port
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 4
+          httpGet:
+            path: /health/readiness
+            port: 9443
+            scheme: HTTPS
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        resources:
+          limits:
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 50Mi
+        startupProbe:
+          failureThreshold: 12
+          httpGet:
+            path: /health/liveness
+            port: 9443
+            scheme: HTTPS
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        volumeMounts:
+        - mountPath: /.sigstore
+          name: sigstore
+      initContainers:
+      - env:
+        - name: METRICS_CONFIG
+          value: kyverno-metrics
+        - name: KYVERNO_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: KYVERNO_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: ghcr.io/kyverno/kyvernopre:v1.8.1
+        imagePullPolicy: Always
+        name: kyverno-pre
+        resources:
+          limits:
+            cpu: 100m
+            memory: 256Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: kyverno-service-account
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      volumes:
+      - emptyDir: {}
+        name: sigstore

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno.yaml
@@ -1,0 +1,15 @@
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      app: kyverno
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: kyverno
+    app.kubernetes.io/component: kyverno
+    app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/version: v1.8.1
+  name: kyverno

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_admin-generaterequest.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_admin-generaterequest.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: kyverno
+    app.kubernetes.io/component: kyverno
+    app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/version: v1.8.1
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+  name: kyverno:admin-generaterequest
+rules:
+- apiGroups:
+  - kyverno.io
+  resources:
+  - generaterequests
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_admin-policies.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_admin-policies.yaml
@@ -1,0 +1,26 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: kyverno
+    app.kubernetes.io/component: kyverno
+    app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/version: v1.8.1
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+  name: kyverno:admin-policies
+rules:
+- apiGroups:
+  - kyverno.io
+  resources:
+  - policies
+  - clusterpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_admin-policyreport.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_admin-policyreport.yaml
@@ -1,0 +1,26 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: kyverno
+    app.kubernetes.io/component: kyverno
+    app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/version: v1.8.1
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+  name: kyverno:admin-policyreport
+rules:
+- apiGroups:
+  - wgpolicyk8s.io
+  resources:
+  - policyreports
+  - clusterpolicyreports
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_admin-reports.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_admin-reports.yaml
@@ -1,0 +1,28 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: kyverno
+    app.kubernetes.io/component: kyverno
+    app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/version: v1.8.1
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+  name: kyverno:admin-reports
+rules:
+- apiGroups:
+  - kyverno.io
+  resources:
+  - admissionreports
+  - clusteradmissionreports
+  - backgroundscanreports
+  - clusterbackgroundscanreports
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_admin-updaterequest.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_admin-updaterequest.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: kyverno
+    app.kubernetes.io/component: kyverno
+    app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/version: v1.8.1
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+  name: kyverno:admin-updaterequest
+rules:
+- apiGroups:
+  - kyverno.io
+  resources:
+  - updaterequests
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_events.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_events.yaml
@@ -1,0 +1,22 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: kyverno
+    app.kubernetes.io/component: kyverno
+    app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/version: v1.8.1
+  name: kyverno:events
+rules:
+- apiGroups:
+  - ""
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - update
+  - patch
+  - delete

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_generate.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_generate.yaml
@@ -1,0 +1,46 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: kyverno
+    app.kubernetes.io/component: kyverno
+    app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/version: v1.8.1
+  name: kyverno:generate
+rules:
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  - ingressclasses
+  - networkpolicies
+  verbs:
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - configmaps
+  - secrets
+  - resourcequotas
+  - limitranges
+  verbs:
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - update
+  - patch
+  - delete

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_policies.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_policies.yaml
@@ -1,0 +1,52 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: kyverno
+    app.kubernetes.io/component: kyverno
+    app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/version: v1.8.1
+  name: kyverno:policies
+rules:
+- apiGroups:
+  - kyverno.io
+  resources:
+  - policies
+  - policies/status
+  - clusterpolicies
+  - clusterpolicies/status
+  - generaterequests
+  - generaterequests/status
+  - updaterequests
+  - updaterequests/status
+  - admissionreports
+  - clusteradmissionreports
+  - backgroundscanreports
+  - clusterbackgroundscanreports
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+  - deletecollection
+- apiGroups:
+  - wgpolicyk8s.io
+  resources:
+  - policyreports
+  - policyreports/status
+  - clusterpolicyreports
+  - clusterpolicyreports/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+  - deletecollection

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_userinfo.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_userinfo.yaml
@@ -1,0 +1,22 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: kyverno
+    app.kubernetes.io/component: kyverno
+    app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/version: v1.8.1
+  name: kyverno:userinfo
+rules:
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - clusterroles
+  - rolebindings
+  - clusterrolebindings
+  verbs:
+  - watch
+  - list

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_view.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_view.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: kyverno
+    app.kubernetes.io/component: kyverno
+    app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/version: v1.8.1
+  name: kyverno:view
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_webhook.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_webhook.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: kyverno
+    app.kubernetes.io/component: kyverno
+    app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/version: v1.8.1
+  name: kyverno:webhook
+rules:
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrolebinding_kyverno.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrolebinding_kyverno.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: kyverno
+    app.kubernetes.io/component: kyverno
+    app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/version: v1.8.1
+  name: kyverno
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kyverno
+subjects:
+- kind: ServiceAccount
+  name: kyverno-service-account
+  namespace: syn-kyverno

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_role_kyverno_leaderelection.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_role_kyverno_leaderelection.yaml
@@ -1,0 +1,33 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: kyverno
+    app.kubernetes.io/component: kyverno
+    app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/version: v1.8.1
+  name: kyverno:leaderelection
+  namespace: syn-kyverno
+rules:
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - patch
+  - update
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_rolebinding_kyverno_leaderelection.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_rolebinding_kyverno_leaderelection.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: kyverno
+    app.kubernetes.io/component: kyverno
+    app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/version: v1.8.1
+  name: kyverno:leaderelection
+  namespace: syn-kyverno
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kyverno:leaderelection
+subjects:
+- kind: ServiceAccount
+  name: kyverno-service-account
+  namespace: syn-kyverno

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/v1_configmap_kyverno-metrics.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/v1_configmap_kyverno-metrics.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+data:
+  metricsRefreshInterval: 24h
+  namespaces: '{"exclude":[],"include":[]}'
+kind: ConfigMap
+metadata:
+  labels:
+    app: kyverno
+    app.kubernetes.io/component: kyverno
+    app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/version: v1.8.1
+  name: kyverno-metrics
+  namespace: syn-kyverno

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/v1_configmap_kyverno.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/v1_configmap_kyverno.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+data:
+  excludeGroupRole: system:serviceaccounts:kube-system,system:nodes,system:kube-scheduler
+  generateSuccessEvents: "false"
+  resourceFilters: |
+    [Event,*,*] [*,kube-system,*] [*,kube-public,*] [*,kube-node-lease,*] [*,kyverno,*] [Node,*,*] [APIService,*,*] [TokenReview,*,*] [SubjectAccessReview,*,*] [SelfSubjectAccessReview,*,*] [*,kyverno,kyverno*] [Binding,*,*] [ReplicaSet,*,*] [AdmissionReport,*,*] [ClusterAdmissionReport,*,*] [BackgroundScanReport,*,*] [ClusterBackgroundScanReport,*,*] [PolicyReport,*,*] [ClusterPolicyReport,*,*]
+  webhooks: '[{"namespaceSelector": {"matchExpressions": [{"key":"kubernetes.io/metadata.name","operator":"NotIn","values":["kyverno"]}]}}]'
+kind: ConfigMap
+metadata:
+  labels:
+    app: kyverno
+    app.kubernetes.io/component: kyverno
+    app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/version: v1.8.1
+  name: kyverno
+  namespace: syn-kyverno

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/v1_namespace_syn-kyverno.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/v1_namespace_syn-kyverno.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/node-selector: node-role.kubernetes.io/master=
+  labels:
+    SYNMonitoring: main
+    app: kyverno
+    app.kubernetes.io/component: kyverno
+    app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/version: v1.8.1
+    name: syn-kyverno
+    network-policies.syn.tools/no-defaults: "true"
+    network-policies.syn.tools/purge-defaults: "true"
+  name: syn-kyverno

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/v1_service_kyverno-svc-metrics.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/v1_service_kyverno-svc-metrics.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: kyverno
+    app.kubernetes.io/component: kyverno
+    app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/version: v1.8.1
+  name: kyverno-svc-metrics
+  namespace: syn-kyverno
+spec:
+  ports:
+  - name: metrics-port
+    port: 8000
+    targetPort: metrics-port
+  selector:
+    app: kyverno
+    app.kubernetes.io/name: kyverno

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/v1_service_kyverno-svc.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/v1_service_kyverno-svc.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: kyverno
+    app.kubernetes.io/component: kyverno
+    app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/version: v1.8.1
+  name: kyverno-svc
+  namespace: syn-kyverno
+spec:
+  ports:
+  - name: https
+    port: 443
+    targetPort: https
+  selector:
+    app: kyverno
+    app.kubernetes.io/name: kyverno

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/v1_serviceaccount_kyverno-service-account.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/v1_serviceaccount_kyverno-service-account.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: kyverno
+    app.kubernetes.io/component: kyverno
+    app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/version: v1.8.1
+  name: kyverno-service-account
+  namespace: syn-kyverno

--- a/tests/golden/policies/kyverno/kyverno/10_pod-disruption-budget.yaml
+++ b/tests/golden/policies/kyverno/kyverno/10_pod-disruption-budget.yaml
@@ -1,4 +1,4 @@
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   annotations: {}

--- a/tests/openshift-4.10.yml
+++ b/tests/openshift-4.10.yml
@@ -1,0 +1,8 @@
+parameters:
+  kyverno:
+    containerSecurityContext: null
+  kapitan:
+    dependencies:
+      - type: https
+        source: https://raw.githubusercontent.com/appuio/component-openshift4-monitoring/v1.9.2/lib/prom.libsonnet
+        output_path: vendor/lib/prom.libsonnet

--- a/tests/unit/validate_test.go
+++ b/tests/unit/validate_test.go
@@ -20,6 +20,7 @@ func skipValidation(path string) bool {
 	ignore := []*regexp.Regexp{
 		regexp.MustCompile(fmt.Sprintf("%s/00_crds", testPath)),
 		regexp.MustCompile(fmt.Sprintf("%s/10_monitoring", testPath)),
+		regexp.MustCompile(fmt.Sprintf("%s/10_pod-disruption-budget", testPath)),
 		regexp.MustCompile(fmt.Sprintf("%s/80_policies.yaml", testPath)),
 		regexp.MustCompile(`.*/apiextensions.k8s.io_v1_customresourcedefinition.*\.yaml`),
 	}


### PR DESCRIPTION
On OpenShift 4.10 and older, the default container security context provided by upstream isn't compatible with the restricted SCC. This PR introduces a new parameter which allows customizing or removing the container security context from all containers of the Kyverno deployment.

The PR also adds a new test case which verifies that setting `containerSecurityContext: null` drops the security context as expected.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
