### PR TITLE
Add aggregated clusterroles for `view` and `cluster-reader`

### DIFF
--- a/class/kyverno.yml
+++ b/class/kyverno.yml
@@ -38,6 +38,7 @@ parameters:
         output_path: .
 
       - input_paths:
+          - kyverno/component/aggregated-clusterroles.jsonnet
           - kyverno/component/main.jsonnet
           - kyverno/component/rolebindings.jsonnet
           - kyverno/component/monitoring.jsonnet

--- a/component/aggregated-clusterroles.jsonnet
+++ b/component/aggregated-clusterroles.jsonnet
@@ -1,0 +1,66 @@
+local kube = import 'lib/kube.libjsonnet';
+
+local namespaced_kyverno_kinds = [
+  'policies',
+  'admissionreports',
+  'backgroundscanreports',
+  'generaterequests',
+  'updaterequests',
+];
+local cluster_kyverno_kinds = [
+  'clusterpolicies',
+  'clusteradmissionreports',
+  'clusterbackgroundscanreports',
+];
+local namespaced_wgpolicy_kinds = [
+  'policyreports',
+];
+local cluster_wgpolicy_kinds = [
+  'clusterpolicyreports',
+];
+
+
+local readonly_verbs = [ 'get', 'list', 'watch' ];
+
+{
+  rbac_aggregate_to_view:
+    kube.ClusterRole('syn-kyverno:aggregate-to-view') {
+      metadata+: {
+        labels+: {
+          'rbac.authorization.k8s.io/aggregate-to-view': 'true',
+        },
+      },
+      rules: [
+        {
+          apiGroups: [ 'kyverno.io' ],
+          resources: namespaced_kyverno_kinds,
+          verbs: readonly_verbs,
+        },
+        {
+          apiGroups: [ 'wgpolicy.k8s.io' ],
+          resources: namespaced_wgpolicy_kinds,
+          verbs: readonly_verbs,
+        },
+      ],
+    },
+  rbac_aggregate_to_cluster_reader:
+    kube.ClusterRole('syn-kyverno:aggregate-to-cluster-reader') {
+      metadata+: {
+        labels+: {
+          'rbac.authorization.k8s.io/aggregate-to-cluster-reader': 'true',
+        },
+      },
+      rules: [
+        {
+          apiGroups: [ 'kyverno.io' ],
+          resources: cluster_kyverno_kinds,
+          verbs: readonly_verbs,
+        },
+        {
+          apiGroups: [ 'wgpolicy.k8s.io' ],
+          resources: cluster_wgpolicy_kinds,
+          verbs: readonly_verbs,
+        },
+      ],
+    },
+}

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -2,4 +2,11 @@
 
 kyverno is a Commodore component to manage kyverno.
 
+== Aggregated cluster roles for the Kyverno CRDs
+
+Kyverno already brings `ClusterRole` objects to aggregate read-write permissions for its CRDs to the `admin` cluster role.
+However, upstream doesn't provide `ClusterRole` objects to aggregate read-only permissions for the Kyverno CRDs to the `view` or `cluster-reader` cluster roles.
+
+To address this shortcoming, the component creates two `ClusterRole` objects, `syn-kyverno:aggregate-to-view` and `syn-kyverno:aggregate-to-cluster-reader` which aggregate read-only permissions to the `view` and `cluster-reader` cluster roles for namespaced and cluster-scoped Kyverno CRDs respectively.
+
 See the xref:references/parameters.adoc[parameters] reference for further details.

--- a/tests/golden/defaults/kyverno/kyverno/rbac_aggregate_to_cluster_reader.yaml
+++ b/tests/golden/defaults/kyverno/kyverno/rbac_aggregate_to_cluster_reader.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: syn-kyverno-aggregate-to-cluster-reader
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: 'true'
+  name: syn-kyverno:aggregate-to-cluster-reader
+rules:
+  - apiGroups:
+      - kyverno.io
+    resources:
+      - clusterpolicies
+      - clusteradmissionreports
+      - clusterbackgroundscanreports
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - wgpolicy.k8s.io
+    resources:
+      - clusterpolicyreports
+    verbs:
+      - get
+      - list
+      - watch

--- a/tests/golden/defaults/kyverno/kyverno/rbac_aggregate_to_view.yaml
+++ b/tests/golden/defaults/kyverno/kyverno/rbac_aggregate_to_view.yaml
@@ -1,0 +1,29 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: syn-kyverno-aggregate-to-view
+    rbac.authorization.k8s.io/aggregate-to-view: 'true'
+  name: syn-kyverno:aggregate-to-view
+rules:
+  - apiGroups:
+      - kyverno.io
+    resources:
+      - policies
+      - admissionreports
+      - backgroundscanreports
+      - generaterequests
+      - updaterequests
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - wgpolicy.k8s.io
+    resources:
+      - policyreports
+    verbs:
+      - get
+      - list
+      - watch

--- a/tests/golden/openshift-4.10/kyverno/kyverno/rbac_aggregate_to_cluster_reader.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/rbac_aggregate_to_cluster_reader.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: syn-kyverno-aggregate-to-cluster-reader
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: 'true'
+  name: syn-kyverno:aggregate-to-cluster-reader
+rules:
+  - apiGroups:
+      - kyverno.io
+    resources:
+      - clusterpolicies
+      - clusteradmissionreports
+      - clusterbackgroundscanreports
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - wgpolicy.k8s.io
+    resources:
+      - clusterpolicyreports
+    verbs:
+      - get
+      - list
+      - watch

--- a/tests/golden/openshift-4.10/kyverno/kyverno/rbac_aggregate_to_view.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/rbac_aggregate_to_view.yaml
@@ -1,0 +1,29 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: syn-kyverno-aggregate-to-view
+    rbac.authorization.k8s.io/aggregate-to-view: 'true'
+  name: syn-kyverno:aggregate-to-view
+rules:
+  - apiGroups:
+      - kyverno.io
+    resources:
+      - policies
+      - admissionreports
+      - backgroundscanreports
+      - generaterequests
+      - updaterequests
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - wgpolicy.k8s.io
+    resources:
+      - policyreports
+    verbs:
+      - get
+      - list
+      - watch

--- a/tests/golden/policies/kyverno/kyverno/rbac_aggregate_to_cluster_reader.yaml
+++ b/tests/golden/policies/kyverno/kyverno/rbac_aggregate_to_cluster_reader.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: syn-kyverno-aggregate-to-cluster-reader
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: 'true'
+  name: syn-kyverno:aggregate-to-cluster-reader
+rules:
+  - apiGroups:
+      - kyverno.io
+    resources:
+      - clusterpolicies
+      - clusteradmissionreports
+      - clusterbackgroundscanreports
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - wgpolicy.k8s.io
+    resources:
+      - clusterpolicyreports
+    verbs:
+      - get
+      - list
+      - watch

--- a/tests/golden/policies/kyverno/kyverno/rbac_aggregate_to_view.yaml
+++ b/tests/golden/policies/kyverno/kyverno/rbac_aggregate_to_view.yaml
@@ -1,0 +1,29 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: syn-kyverno-aggregate-to-view
+    rbac.authorization.k8s.io/aggregate-to-view: 'true'
+  name: syn-kyverno:aggregate-to-view
+rules:
+  - apiGroups:
+      - kyverno.io
+    resources:
+      - policies
+      - admissionreports
+      - backgroundscanreports
+      - generaterequests
+      - updaterequests
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - wgpolicy.k8s.io
+    resources:
+      - policyreports
+    verbs:
+      - get
+      - list
+      - watch


### PR DESCRIPTION
Kyverno already ships with aggregated clusterroles for `admin`, but doesn't provide read-only variants for `view` and `cluster-reader`.

We possibly could extract the kinds from the upstream aggregated roles for admin, but they're not separated by cluster-scoped and namespaced resources, so we'd have to do some manual checking anyway when updating to a new minor version.




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
