### PR TITLE
Remove explicit `imagePullPolicy` configuration 

### DIFF
--- a/component/kyverno.jsonnet
+++ b/component/kyverno.jsonnet
@@ -90,6 +90,7 @@ com.Kustomization(
                 name: 'kyverno-pre',
                 resources: params.resources.pre,
                 securityContext: params.containerSecurityContext,
+                imagePullPolicy: null,
               },
             ],
             containers: [
@@ -98,6 +99,7 @@ com.Kustomization(
                 resources: params.resources.kyverno,
                 args: params.extraArgs,
                 securityContext: params.containerSecurityContext,
+                imagePullPolicy: null,
               },
             ],
           },

--- a/tests/golden/defaults/kyverno/kyverno/kyverno/apps_v1_deployment_kyverno.yaml
+++ b/tests/golden/defaults/kyverno/kyverno/kyverno/apps_v1_deployment_kyverno.yaml
@@ -63,7 +63,6 @@ spec:
         - name: TUF_ROOT
           value: /.sigstore
         image: ghcr.io/kyverno/kyverno:v1.8.2
-        imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 2
           httpGet:
@@ -132,7 +131,6 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         image: ghcr.io/kyverno/kyvernopre:v1.8.2
-        imagePullPolicy: Always
         name: kyverno-pre
         resources:
           limits:

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/apps_v1_deployment_kyverno.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/apps_v1_deployment_kyverno.yaml
@@ -63,7 +63,6 @@ spec:
         - name: TUF_ROOT
           value: /.sigstore
         image: ghcr.io/kyverno/kyverno:v1.8.2
-        imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 2
           httpGet:
@@ -122,7 +121,6 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         image: ghcr.io/kyverno/kyvernopre:v1.8.2
-        imagePullPolicy: Always
         name: kyverno-pre
         resources:
           limits:

--- a/tests/golden/policies/kyverno/kyverno/kyverno/apps_v1_deployment_kyverno.yaml
+++ b/tests/golden/policies/kyverno/kyverno/kyverno/apps_v1_deployment_kyverno.yaml
@@ -63,7 +63,6 @@ spec:
         - name: TUF_ROOT
           value: /.sigstore
         image: ghcr.io/kyverno/kyverno:v1.8.2
-        imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 2
           httpGet:
@@ -132,7 +131,6 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         image: ghcr.io/kyverno/kyvernopre:v1.8.2
-        imagePullPolicy: Always
         name: kyverno-pre
         resources:
           limits:


### PR DESCRIPTION
This should fall back to the Kubernetes default of using `imagePullPolicy: IfNotPresent` unless tag `latest` is used.

Without this change, it's possible that Kyverno ends up in `ImagePullBackoff` if the GitHub container registry has issues, even though the image is present on the cluster nodes.



## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
