### PR TITLE
Re-add common labels

### DIFF
--- a/component/kyverno.jsonnet
+++ b/component/kyverno.jsonnet
@@ -117,13 +117,15 @@ com.Kustomization(
       annotations+: nodeSelectionNamespaceAnnotations,
     },
   },
+  // Add labels to all resources
+  // This is a customized transformer to not update the selector of the deployment which would be a breaking change.
   labels: {
     apiVersion: 'builtin',
     kind: 'LabelTransformer',
     metadata: {
       name: 'labelTransformer',
     },
-    labels: {
+    labels: common.Labels {
       'app.kubernetes.io/version': params.manifest_version,
     },
     fieldSpecs: [

--- a/tests/golden/defaults/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_admissionreports.kyverno.io.yaml
+++ b/tests/golden/defaults/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_admissionreports.kyverno.io.yaml
@@ -8,8 +8,9 @@ metadata:
   labels:
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: admissionreports.kyverno.io
 spec:

--- a/tests/golden/defaults/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_backgroundscanreports.kyverno.io.yaml
+++ b/tests/golden/defaults/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_backgroundscanreports.kyverno.io.yaml
@@ -8,8 +8,9 @@ metadata:
   labels:
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: backgroundscanreports.kyverno.io
 spec:

--- a/tests/golden/defaults/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clusteradmissionreports.kyverno.io.yaml
+++ b/tests/golden/defaults/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clusteradmissionreports.kyverno.io.yaml
@@ -8,8 +8,9 @@ metadata:
   labels:
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: clusteradmissionreports.kyverno.io
 spec:

--- a/tests/golden/defaults/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clusterbackgroundscanreports.kyverno.io.yaml
+++ b/tests/golden/defaults/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clusterbackgroundscanreports.kyverno.io.yaml
@@ -8,8 +8,9 @@ metadata:
   labels:
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: clusterbackgroundscanreports.kyverno.io
 spec:

--- a/tests/golden/defaults/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clusterpolicies.kyverno.io.yaml
+++ b/tests/golden/defaults/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clusterpolicies.kyverno.io.yaml
@@ -8,8 +8,9 @@ metadata:
   labels:
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: clusterpolicies.kyverno.io
 spec:

--- a/tests/golden/defaults/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clusterpolicyreports.wgpolicyk8s.io.yaml
+++ b/tests/golden/defaults/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clusterpolicyreports.wgpolicyk8s.io.yaml
@@ -8,8 +8,9 @@ metadata:
   labels:
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: clusterpolicyreports.wgpolicyk8s.io
 spec:

--- a/tests/golden/defaults/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_generaterequests.kyverno.io.yaml
+++ b/tests/golden/defaults/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_generaterequests.kyverno.io.yaml
@@ -8,8 +8,9 @@ metadata:
   labels:
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: generaterequests.kyverno.io
 spec:

--- a/tests/golden/defaults/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_policies.kyverno.io.yaml
+++ b/tests/golden/defaults/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_policies.kyverno.io.yaml
@@ -8,8 +8,9 @@ metadata:
   labels:
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: policies.kyverno.io
 spec:

--- a/tests/golden/defaults/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_policyreports.wgpolicyk8s.io.yaml
+++ b/tests/golden/defaults/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_policyreports.wgpolicyk8s.io.yaml
@@ -8,8 +8,9 @@ metadata:
   labels:
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: policyreports.wgpolicyk8s.io
 spec:

--- a/tests/golden/defaults/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_updaterequests.kyverno.io.yaml
+++ b/tests/golden/defaults/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_updaterequests.kyverno.io.yaml
@@ -8,8 +8,9 @@ metadata:
   labels:
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: updaterequests.kyverno.io
 spec:

--- a/tests/golden/defaults/kyverno/kyverno/kyverno/apps_v1_deployment_kyverno.yaml
+++ b/tests/golden/defaults/kyverno/kyverno/kyverno/apps_v1_deployment_kyverno.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
     name: kyverno
   name: kyverno
@@ -28,8 +29,9 @@ spec:
         app: kyverno
         app.kubernetes.io/component: kyverno
         app.kubernetes.io/instance: kyverno
+        app.kubernetes.io/managed-by: commodore
         app.kubernetes.io/name: kyverno
-        app.kubernetes.io/part-of: kyverno
+        app.kubernetes.io/part-of: syn
         app.kubernetes.io/version: v1.8.4
     spec:
       affinity:

--- a/tests/golden/defaults/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno.yaml
+++ b/tests/golden/defaults/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno.yaml
@@ -9,7 +9,8 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: kyverno

--- a/tests/golden/defaults/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_admin-generaterequest.yaml
+++ b/tests/golden/defaults/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_admin-generaterequest.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
   name: kyverno:admin-generaterequest

--- a/tests/golden/defaults/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_admin-policies.yaml
+++ b/tests/golden/defaults/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_admin-policies.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
   name: kyverno:admin-policies

--- a/tests/golden/defaults/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_admin-policyreport.yaml
+++ b/tests/golden/defaults/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_admin-policyreport.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
   name: kyverno:admin-policyreport

--- a/tests/golden/defaults/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_admin-reports.yaml
+++ b/tests/golden/defaults/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_admin-reports.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
   name: kyverno:admin-reports

--- a/tests/golden/defaults/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_admin-updaterequest.yaml
+++ b/tests/golden/defaults/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_admin-updaterequest.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
   name: kyverno:admin-updaterequest

--- a/tests/golden/defaults/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_events.yaml
+++ b/tests/golden/defaults/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_events.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: kyverno:events
 rules:

--- a/tests/golden/defaults/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_generate.yaml
+++ b/tests/golden/defaults/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_generate.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: kyverno:generate
 rules:

--- a/tests/golden/defaults/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_policies.yaml
+++ b/tests/golden/defaults/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_policies.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: kyverno:policies
 rules:

--- a/tests/golden/defaults/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_userinfo.yaml
+++ b/tests/golden/defaults/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_userinfo.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: kyverno:userinfo
 rules:

--- a/tests/golden/defaults/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_view.yaml
+++ b/tests/golden/defaults/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_view.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: kyverno:view
 rules:

--- a/tests/golden/defaults/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_webhook.yaml
+++ b/tests/golden/defaults/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_webhook.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: kyverno:webhook
 rules:

--- a/tests/golden/defaults/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrolebinding_kyverno.yaml
+++ b/tests/golden/defaults/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrolebinding_kyverno.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: kyverno
 roleRef:

--- a/tests/golden/defaults/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_role_kyverno_leaderelection.yaml
+++ b/tests/golden/defaults/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_role_kyverno_leaderelection.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: kyverno:leaderelection
   namespace: syn-kyverno

--- a/tests/golden/defaults/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_rolebinding_kyverno_leaderelection.yaml
+++ b/tests/golden/defaults/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_rolebinding_kyverno_leaderelection.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: kyverno:leaderelection
   namespace: syn-kyverno

--- a/tests/golden/defaults/kyverno/kyverno/kyverno/v1_configmap_kyverno-metrics.yaml
+++ b/tests/golden/defaults/kyverno/kyverno/kyverno/v1_configmap_kyverno-metrics.yaml
@@ -8,8 +8,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: kyverno-metrics
   namespace: syn-kyverno

--- a/tests/golden/defaults/kyverno/kyverno/kyverno/v1_configmap_kyverno.yaml
+++ b/tests/golden/defaults/kyverno/kyverno/kyverno/v1_configmap_kyverno.yaml
@@ -11,8 +11,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: kyverno
   namespace: syn-kyverno

--- a/tests/golden/defaults/kyverno/kyverno/kyverno/v1_service_kyverno-svc-metrics.yaml
+++ b/tests/golden/defaults/kyverno/kyverno/kyverno/v1_service_kyverno-svc-metrics.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: kyverno-svc-metrics
   namespace: syn-kyverno

--- a/tests/golden/defaults/kyverno/kyverno/kyverno/v1_service_kyverno-svc.yaml
+++ b/tests/golden/defaults/kyverno/kyverno/kyverno/v1_service_kyverno-svc.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: kyverno-svc
   namespace: syn-kyverno

--- a/tests/golden/defaults/kyverno/kyverno/kyverno/v1_serviceaccount_kyverno-service-account.yaml
+++ b/tests/golden/defaults/kyverno/kyverno/kyverno/v1_serviceaccount_kyverno-service-account.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: kyverno-service-account
   namespace: syn-kyverno

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_admissionreports.kyverno.io.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_admissionreports.kyverno.io.yaml
@@ -8,8 +8,9 @@ metadata:
   labels:
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: admissionreports.kyverno.io
 spec:

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_backgroundscanreports.kyverno.io.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_backgroundscanreports.kyverno.io.yaml
@@ -8,8 +8,9 @@ metadata:
   labels:
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: backgroundscanreports.kyverno.io
 spec:

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clusteradmissionreports.kyverno.io.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clusteradmissionreports.kyverno.io.yaml
@@ -8,8 +8,9 @@ metadata:
   labels:
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: clusteradmissionreports.kyverno.io
 spec:

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clusterbackgroundscanreports.kyverno.io.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clusterbackgroundscanreports.kyverno.io.yaml
@@ -8,8 +8,9 @@ metadata:
   labels:
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: clusterbackgroundscanreports.kyverno.io
 spec:

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clusterpolicies.kyverno.io.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clusterpolicies.kyverno.io.yaml
@@ -8,8 +8,9 @@ metadata:
   labels:
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: clusterpolicies.kyverno.io
 spec:

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clusterpolicyreports.wgpolicyk8s.io.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clusterpolicyreports.wgpolicyk8s.io.yaml
@@ -8,8 +8,9 @@ metadata:
   labels:
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: clusterpolicyreports.wgpolicyk8s.io
 spec:

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_generaterequests.kyverno.io.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_generaterequests.kyverno.io.yaml
@@ -8,8 +8,9 @@ metadata:
   labels:
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: generaterequests.kyverno.io
 spec:

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_policies.kyverno.io.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_policies.kyverno.io.yaml
@@ -8,8 +8,9 @@ metadata:
   labels:
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: policies.kyverno.io
 spec:

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_policyreports.wgpolicyk8s.io.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_policyreports.wgpolicyk8s.io.yaml
@@ -8,8 +8,9 @@ metadata:
   labels:
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: policyreports.wgpolicyk8s.io
 spec:

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_updaterequests.kyverno.io.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_updaterequests.kyverno.io.yaml
@@ -8,8 +8,9 @@ metadata:
   labels:
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: updaterequests.kyverno.io
 spec:

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/apps_v1_deployment_kyverno.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/apps_v1_deployment_kyverno.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
     name: kyverno
   name: kyverno
@@ -28,8 +29,9 @@ spec:
         app: kyverno
         app.kubernetes.io/component: kyverno
         app.kubernetes.io/instance: kyverno
+        app.kubernetes.io/managed-by: commodore
         app.kubernetes.io/name: kyverno
-        app.kubernetes.io/part-of: kyverno
+        app.kubernetes.io/part-of: syn
         app.kubernetes.io/version: v1.8.4
     spec:
       affinity:

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno.yaml
@@ -9,7 +9,8 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: kyverno

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_admin-generaterequest.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_admin-generaterequest.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
   name: kyverno:admin-generaterequest

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_admin-policies.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_admin-policies.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
   name: kyverno:admin-policies

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_admin-policyreport.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_admin-policyreport.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
   name: kyverno:admin-policyreport

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_admin-reports.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_admin-reports.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
   name: kyverno:admin-reports

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_admin-updaterequest.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_admin-updaterequest.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
   name: kyverno:admin-updaterequest

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_events.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_events.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: kyverno:events
 rules:

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_generate.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_generate.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: kyverno:generate
 rules:

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_policies.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_policies.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: kyverno:policies
 rules:

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_userinfo.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_userinfo.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: kyverno:userinfo
 rules:

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_view.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_view.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: kyverno:view
 rules:

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_webhook.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_webhook.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: kyverno:webhook
 rules:

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrolebinding_kyverno.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrolebinding_kyverno.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: kyverno
 roleRef:

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_role_kyverno_leaderelection.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_role_kyverno_leaderelection.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: kyverno:leaderelection
   namespace: syn-kyverno

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_rolebinding_kyverno_leaderelection.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_rolebinding_kyverno_leaderelection.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: kyverno:leaderelection
   namespace: syn-kyverno

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/v1_configmap_kyverno-metrics.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/v1_configmap_kyverno-metrics.yaml
@@ -8,8 +8,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: kyverno-metrics
   namespace: syn-kyverno

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/v1_configmap_kyverno.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/v1_configmap_kyverno.yaml
@@ -11,8 +11,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: kyverno
   namespace: syn-kyverno

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/v1_service_kyverno-svc-metrics.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/v1_service_kyverno-svc-metrics.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: kyverno-svc-metrics
   namespace: syn-kyverno

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/v1_service_kyverno-svc.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/v1_service_kyverno-svc.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: kyverno-svc
   namespace: syn-kyverno

--- a/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/v1_serviceaccount_kyverno-service-account.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/kyverno/v1_serviceaccount_kyverno-service-account.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: kyverno-service-account
   namespace: syn-kyverno

--- a/tests/golden/policies/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_admissionreports.kyverno.io.yaml
+++ b/tests/golden/policies/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_admissionreports.kyverno.io.yaml
@@ -8,8 +8,9 @@ metadata:
   labels:
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: admissionreports.kyverno.io
 spec:

--- a/tests/golden/policies/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_backgroundscanreports.kyverno.io.yaml
+++ b/tests/golden/policies/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_backgroundscanreports.kyverno.io.yaml
@@ -8,8 +8,9 @@ metadata:
   labels:
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: backgroundscanreports.kyverno.io
 spec:

--- a/tests/golden/policies/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clusteradmissionreports.kyverno.io.yaml
+++ b/tests/golden/policies/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clusteradmissionreports.kyverno.io.yaml
@@ -8,8 +8,9 @@ metadata:
   labels:
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: clusteradmissionreports.kyverno.io
 spec:

--- a/tests/golden/policies/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clusterbackgroundscanreports.kyverno.io.yaml
+++ b/tests/golden/policies/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clusterbackgroundscanreports.kyverno.io.yaml
@@ -8,8 +8,9 @@ metadata:
   labels:
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: clusterbackgroundscanreports.kyverno.io
 spec:

--- a/tests/golden/policies/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clusterpolicies.kyverno.io.yaml
+++ b/tests/golden/policies/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clusterpolicies.kyverno.io.yaml
@@ -8,8 +8,9 @@ metadata:
   labels:
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: clusterpolicies.kyverno.io
 spec:

--- a/tests/golden/policies/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clusterpolicyreports.wgpolicyk8s.io.yaml
+++ b/tests/golden/policies/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clusterpolicyreports.wgpolicyk8s.io.yaml
@@ -8,8 +8,9 @@ metadata:
   labels:
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: clusterpolicyreports.wgpolicyk8s.io
 spec:

--- a/tests/golden/policies/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_generaterequests.kyverno.io.yaml
+++ b/tests/golden/policies/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_generaterequests.kyverno.io.yaml
@@ -8,8 +8,9 @@ metadata:
   labels:
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: generaterequests.kyverno.io
 spec:

--- a/tests/golden/policies/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_policies.kyverno.io.yaml
+++ b/tests/golden/policies/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_policies.kyverno.io.yaml
@@ -8,8 +8,9 @@ metadata:
   labels:
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: policies.kyverno.io
 spec:

--- a/tests/golden/policies/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_policyreports.wgpolicyk8s.io.yaml
+++ b/tests/golden/policies/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_policyreports.wgpolicyk8s.io.yaml
@@ -8,8 +8,9 @@ metadata:
   labels:
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: policyreports.wgpolicyk8s.io
 spec:

--- a/tests/golden/policies/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_updaterequests.kyverno.io.yaml
+++ b/tests/golden/policies/kyverno/kyverno/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_updaterequests.kyverno.io.yaml
@@ -8,8 +8,9 @@ metadata:
   labels:
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: updaterequests.kyverno.io
 spec:

--- a/tests/golden/policies/kyverno/kyverno/kyverno/apps_v1_deployment_kyverno.yaml
+++ b/tests/golden/policies/kyverno/kyverno/kyverno/apps_v1_deployment_kyverno.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
     name: kyverno
   name: kyverno
@@ -28,8 +29,9 @@ spec:
         app: kyverno
         app.kubernetes.io/component: kyverno
         app.kubernetes.io/instance: kyverno
+        app.kubernetes.io/managed-by: commodore
         app.kubernetes.io/name: kyverno
-        app.kubernetes.io/part-of: kyverno
+        app.kubernetes.io/part-of: syn
         app.kubernetes.io/version: v1.8.4
     spec:
       affinity:

--- a/tests/golden/policies/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno.yaml
+++ b/tests/golden/policies/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno.yaml
@@ -9,7 +9,8 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: kyverno

--- a/tests/golden/policies/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_admin-generaterequest.yaml
+++ b/tests/golden/policies/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_admin-generaterequest.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
   name: kyverno:admin-generaterequest

--- a/tests/golden/policies/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_admin-policies.yaml
+++ b/tests/golden/policies/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_admin-policies.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
   name: kyverno:admin-policies

--- a/tests/golden/policies/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_admin-policyreport.yaml
+++ b/tests/golden/policies/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_admin-policyreport.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
   name: kyverno:admin-policyreport

--- a/tests/golden/policies/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_admin-reports.yaml
+++ b/tests/golden/policies/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_admin-reports.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
   name: kyverno:admin-reports

--- a/tests/golden/policies/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_admin-updaterequest.yaml
+++ b/tests/golden/policies/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_admin-updaterequest.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
   name: kyverno:admin-updaterequest

--- a/tests/golden/policies/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_events.yaml
+++ b/tests/golden/policies/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_events.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: kyverno:events
 rules:

--- a/tests/golden/policies/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_generate.yaml
+++ b/tests/golden/policies/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_generate.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: kyverno:generate
 rules:

--- a/tests/golden/policies/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_policies.yaml
+++ b/tests/golden/policies/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_policies.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: kyverno:policies
 rules:

--- a/tests/golden/policies/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_userinfo.yaml
+++ b/tests/golden/policies/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_userinfo.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: kyverno:userinfo
 rules:

--- a/tests/golden/policies/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_view.yaml
+++ b/tests/golden/policies/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_view.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: kyverno:view
 rules:

--- a/tests/golden/policies/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_webhook.yaml
+++ b/tests/golden/policies/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno_webhook.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: kyverno:webhook
 rules:

--- a/tests/golden/policies/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrolebinding_kyverno.yaml
+++ b/tests/golden/policies/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_clusterrolebinding_kyverno.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: kyverno
 roleRef:

--- a/tests/golden/policies/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_role_kyverno_leaderelection.yaml
+++ b/tests/golden/policies/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_role_kyverno_leaderelection.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: kyverno:leaderelection
   namespace: syn-kyverno

--- a/tests/golden/policies/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_rolebinding_kyverno_leaderelection.yaml
+++ b/tests/golden/policies/kyverno/kyverno/kyverno/rbac.authorization.k8s.io_v1_rolebinding_kyverno_leaderelection.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: kyverno:leaderelection
   namespace: syn-kyverno

--- a/tests/golden/policies/kyverno/kyverno/kyverno/v1_configmap_kyverno-metrics.yaml
+++ b/tests/golden/policies/kyverno/kyverno/kyverno/v1_configmap_kyverno-metrics.yaml
@@ -8,8 +8,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: kyverno-metrics
   namespace: syn-kyverno

--- a/tests/golden/policies/kyverno/kyverno/kyverno/v1_configmap_kyverno.yaml
+++ b/tests/golden/policies/kyverno/kyverno/kyverno/v1_configmap_kyverno.yaml
@@ -11,8 +11,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: kyverno
   namespace: syn-kyverno

--- a/tests/golden/policies/kyverno/kyverno/kyverno/v1_service_kyverno-svc-metrics.yaml
+++ b/tests/golden/policies/kyverno/kyverno/kyverno/v1_service_kyverno-svc-metrics.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: kyverno-svc-metrics
   namespace: syn-kyverno

--- a/tests/golden/policies/kyverno/kyverno/kyverno/v1_service_kyverno-svc.yaml
+++ b/tests/golden/policies/kyverno/kyverno/kyverno/v1_service_kyverno-svc.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: kyverno-svc
   namespace: syn-kyverno

--- a/tests/golden/policies/kyverno/kyverno/kyverno/v1_serviceaccount_kyverno-service-account.yaml
+++ b/tests/golden/policies/kyverno/kyverno/kyverno/v1_serviceaccount_kyverno-service-account.yaml
@@ -5,8 +5,9 @@ metadata:
     app: kyverno
     app.kubernetes.io/component: kyverno
     app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/part-of: kyverno
+    app.kubernetes.io/part-of: syn
     app.kubernetes.io/version: v1.8.4
   name: kyverno-service-account
   namespace: syn-kyverno


### PR DESCRIPTION
I saw missing Kyverno metrics on LPG2. The selector of the ServiceMonitor still had the common labels.

I double checked that the selector of the deployment is not updated so should not be a breaking change.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
