### PR TITLE
Fix alert query for Prometheus v3 `le` label values parsing

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -54,7 +54,7 @@ parameters:
               (
                 sum by(resource_kind, resource_namespace) (increase(kyverno_admission_review_duration_seconds_bucket{le="+Inf"}[10m]))
               -
-                sum by(resource_kind, resource_namespace) (increase(kyverno_admission_review_duration_seconds_bucket{le="10"}[10m]))
+                sum by(resource_kind, resource_namespace) (increase(kyverno_admission_review_duration_seconds_bucket{le=~"10(\\.0)?"}[10m]))
               ) > 0
             for: 5m
             labels:

--- a/tests/golden/defaults/kyverno/kyverno/10_monitoring/10_prometheusrule_kyverno-alerts.yaml
+++ b/tests/golden/defaults/kyverno/kyverno/10_monitoring/10_prometheusrule_kyverno-alerts.yaml
@@ -25,7 +25,7 @@ spec:
             (
               sum by(resource_kind, resource_namespace) (increase(kyverno_admission_review_duration_seconds_bucket{le="+Inf"}[10m]))
             -
-              sum by(resource_kind, resource_namespace) (increase(kyverno_admission_review_duration_seconds_bucket{le="10"}[10m]))
+              sum by(resource_kind, resource_namespace) (increase(kyverno_admission_review_duration_seconds_bucket{le=~"10(\\.0)?"}[10m]))
             ) > 0
           for: 5m
           labels:

--- a/tests/golden/openshift-4.10/kyverno/kyverno/10_monitoring/10_prometheusrule_kyverno-alerts.yaml
+++ b/tests/golden/openshift-4.10/kyverno/kyverno/10_monitoring/10_prometheusrule_kyverno-alerts.yaml
@@ -25,7 +25,7 @@ spec:
             (
               sum by(resource_kind, resource_namespace) (increase(kyverno_admission_review_duration_seconds_bucket{le="+Inf"}[10m]))
             -
-              sum by(resource_kind, resource_namespace) (increase(kyverno_admission_review_duration_seconds_bucket{le="10"}[10m]))
+              sum by(resource_kind, resource_namespace) (increase(kyverno_admission_review_duration_seconds_bucket{le=~"10(\\.0)?"}[10m]))
             ) > 0
           for: 5m
           labels:

--- a/tests/golden/policies/kyverno/kyverno/10_monitoring/10_prometheusrule_kyverno-alerts.yaml
+++ b/tests/golden/policies/kyverno/kyverno/10_monitoring/10_prometheusrule_kyverno-alerts.yaml
@@ -25,7 +25,7 @@ spec:
             (
               sum by(resource_kind, resource_namespace) (increase(kyverno_admission_review_duration_seconds_bucket{le="+Inf"}[10m]))
             -
-              sum by(resource_kind, resource_namespace) (increase(kyverno_admission_review_duration_seconds_bucket{le="10"}[10m]))
+              sum by(resource_kind, resource_namespace) (increase(kyverno_admission_review_duration_seconds_bucket{le=~"10(\\.0)?"}[10m]))
             ) > 0
           for: 5m
           labels:


### PR DESCRIPTION
This should address the `SYN_PrometheusPossibleNarrowSelectors` alert that's started popping up on some OpenShift 4.19 clusters.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
